### PR TITLE
Remove unused unistd.h header

### DIFF
--- a/ignition/src/IgnitionEnvironment.cpp
+++ b/ignition/src/IgnitionEnvironment.cpp
@@ -25,7 +25,6 @@
 #include <functional>
 #include <mutex>
 #include <thread>
-#include <unistd.h>
 #include <vector>
 
 using namespace gympp::gazebo;


### PR DESCRIPTION
I guess the include was added in https://github.com/robotology/gym-ignition/commit/4a13ebab3a7e2b7d5014b964de4e88b3a12c6fed to use `fork`, but as now the project is using tiny-process-lib I think we can remove it.