### PR TITLE
Small improvements of the gym_ignition python package

### DIFF
--- a/gym_ignition/envs/cartpole/CartPole.py
+++ b/gym_ignition/envs/cartpole/CartPole.py
@@ -26,8 +26,8 @@ class CartPoleEnv(IgnitionEnv):
         observation_space_md = SpaceMetadata()
         observation_space_md.setType(SpaceType_Box)
         max_float = float(np.finfo(np.float32).max)
-        observation_space_md.setLowLimit([-2.4, -max_float, -24, -max_float])
-        observation_space_md.setHighLimit([2.4, max_float, 24, max_float])
+        observation_space_md.setLowLimit([-2.5, -max_float, -24, -max_float])
+        observation_space_md.setHighLimit([2.5, max_float, 24, max_float])
 
         md.setActionSpaceMetadata(action_space_md)
         md.setObservationSpaceMetadata(observation_space_md)

--- a/gym_ignition/envs/cartpole/CartPole.py
+++ b/gym_ignition/envs/cartpole/CartPole.py
@@ -11,7 +11,7 @@ class CartPoleEnv(IgnitionEnv):
     def __init__(self):
         IgnitionEnv.__init__(self)
 
-    def _plugin_metadata(self):
+    def _plugin_metadata(self) -> PluginMetadata:
         md = PluginMetadata()
         md.setEnvironmentName("CartPole")
         md.setLibraryName("CartPolePlugin")

--- a/gym_ignition/envs/ignition_env.py
+++ b/gym_ignition/envs/ignition_env.py
@@ -37,8 +37,10 @@ class IgnitionEnv(gym.Env):
         self.md = self._plugin_metadata()
 
         # Create the spaces
-        self.action_space, self.act_dt = self._create_space(self.md.getActionSpaceMetadata())
-        self.observation_space, self.obs_dt = self._create_space(self.md.getObservationSpaceMetadata())
+        self.action_space, self.act_dt = IgnitionEnv._create_space(
+            self.md.getActionSpaceMetadata())
+        self.observation_space, self.obs_dt = IgnitionEnv._create_space(
+            self.md.getObservationSpaceMetadata())
 
         # Register the environment
         factory = gympp.GymFactory.Instance()
@@ -138,7 +140,8 @@ class IgnitionEnv(gym.Env):
         raise NotImplementedError
         return gympp.PluginMetadata()
 
-    def _create_space(self, md: gympp.SpaceMetadata = None) \
+    @classmethod
+    def _create_space(cls, md: gympp.SpaceMetadata = None) \
             -> Union[Tuple[gympp.Box, str], Tuple[gympp.Discrete, str]]:
         """Create an object of the gym.space package from gympp space metadata
 

--- a/gym_ignition/envs/ignition_env.py
+++ b/gym_ignition/envs/ignition_env.py
@@ -143,11 +143,14 @@ class IgnitionEnv(gym.Env):
 
         # Seed the environment
         vector_seeds = self.ignenv.seed(seed)
-        
+
+        # Seed numpy
+        np.random.seed(seed)
+
         # Seed the spaces
         self.action_space.seed(seed)
         self.observation_space.seed(seed)
-        
+
         return list(vector_seeds)
 
     def _plugin_metadata(self) -> gympp.PluginMetadata:

--- a/gym_ignition/envs/ignition_env.py
+++ b/gym_ignition/envs/ignition_env.py
@@ -76,7 +76,7 @@ class IgnitionEnv(gym.Env):
         assert self.observation_space.contains(observation), "The returned observation does not belong to the space"
 
         # Return the tuple
-        return (observation, state.reward, state.done, state.info)
+        return observation, state.reward, state.done, state.info
 
     def reset(self) -> Observation:
         # Get std::optional<gympp::Observation>

--- a/setup.py
+++ b/setup.py
@@ -6,5 +6,13 @@ from setuptools import setup
 
 setup(name='gym_ignition',
       version='0.1',
+      author="Diego Ferigo",
+      author_email="diego.ferigo@iit.it",
+      description="Gym Ignition: A toolkit for developing OpenAI Gym environments "
+                  "running in Ignition Gazebo.",
+      url='https://github.com/robotology/gym-ignition',
+      keywords="openai gym reinforcement learning environment gazebo robotics ignition",
+      license="LGPL",
+      platforms='any',
       python_requires='>=3.6',
       install_requires=['gym'])

--- a/setup.py
+++ b/setup.py
@@ -6,4 +6,5 @@ from setuptools import setup
 
 setup(name='gym_ignition',
       version='0.1',
+      python_requires='>=3.6',
       install_requires=['gym'])


### PR DESCRIPTION
This PR introduces type hinting to the python classes. This will not likely affect the end users since environments are returned by the `gym.make()`, that does not have ootb type hinting support nor stub files. However, especially for developers with C++ background, this information can improve the code readability.

Some class and method documentation was also added, and the metadata of the python package was filled. 