### PR TITLE
Multithread support

### DIFF
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -4,3 +4,6 @@
 
 add_executable(LaunchCartPole LaunchCartPole.cpp)
 target_link_libraries(LaunchCartPole PRIVATE GymFactory Clara)
+
+add_executable(LaunchParallelCartPole LaunchParallelCartPole.cpp)
+target_link_libraries(LaunchParallelCartPole PRIVATE GymFactory Clara)

--- a/examples/cpp/LaunchParallelCartPole.cpp
+++ b/examples/cpp/LaunchParallelCartPole.cpp
@@ -1,0 +1,265 @@
+/*
+ * Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include "gympp/Common.h"
+#include "gympp/Environment.h"
+#include "gympp/GymFactory.h"
+#include "gympp/Log.h"
+#include "gympp/PluginDatabase.h"
+#include "gympp/Random.h"
+#include "gympp/Space.h"
+
+#include "clara.hpp"
+
+#include <ignition/common/SignalHandler.hh>
+
+#include <atomic>
+#include <cassert>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+
+using namespace gympp;
+using namespace clara;
+
+class Worker
+{
+private:
+    size_t m_id;
+    size_t m_maxEpisodes;
+    std::string m_environmentName;
+    EnvironmentPtr m_env;
+    static std::mutex m_mutex;
+
+public:
+    // Global variable shared by worker threads
+    static std::atomic<size_t> BestScore;
+    static std::atomic<size_t> InstanceCounter;
+    static std::atomic<size_t> NumberOfEpisodes;
+    static std::atomic<double> MovingAverageReward;
+
+    using EnvironmentName = std::string;
+
+    Worker(const EnvironmentName& name, size_t maxEpisodes)
+        : m_id(Worker::InstanceCounter++)
+        , m_maxEpisodes(maxEpisodes)
+        , m_environmentName(name)
+    {
+        gymppDebug << "Constructing worker #" << m_id;
+    }
+
+    bool initialize()
+    {
+        m_env = GymFactory::Instance()->make(m_environmentName);
+
+        if (!m_env) {
+            gymppError << "Failed to create environment '" << m_environmentName << "'" << std::endl;
+            return false;
+        }
+
+        return true;
+    }
+
+    void run()
+    {
+        // This check the number of episodes of all workers
+        while (Worker::NumberOfEpisodes <= (m_maxEpisodes - std::thread::hardware_concurrency())) {
+            // Reset the environment
+            assert(m_env);
+            auto reward = Environment::Reward(0);
+            auto observation = m_env->reset();
+            assert(observation);
+
+            // Create the initial state object
+            Environment::State oldState;
+            oldState.done = false;
+            oldState.observation = observation.value();
+
+            size_t episodeStep = 0;
+
+            while (!oldState.done) {
+                // Process oldState to obtain the action.
+                // Here we use a random action to bypass it.
+                auto actionSample = m_env->action_space->sample();
+
+                // Simulate the system with the given action
+                auto state = m_env->step(actionSample);
+                assert(state && state->observation.getBuffer<double>());
+
+                // Cumulate the reward
+                reward += state->reward;
+
+                // Save the old state
+                oldState = std::move(state.value());
+
+                // Increase the episode steps counter
+                episodeStep++;
+
+                // Handle termination
+                if (state->done) {
+                    std::unique_lock lock(Worker::m_mutex);
+
+                    // Increase the episodes counter
+                    Worker::NumberOfEpisodes++;
+                    record(NumberOfEpisodes, reward, m_id, episodeStep);
+
+                    // Handle this episode if it is the best achieved until now
+                    if (reward > Worker::BestScore) {
+                        // CartPole rewards are integers
+                        Worker::BestScore = static_cast<size_t>(reward);
+                        gymppMessage << "New best score: " << reward << std::endl;
+                    }
+                }
+            }
+        }
+    }
+
+    static void record(const size_t episode,
+                       const Reward reward,
+                       const size_t worker_id,
+                       const size_t numOfSteps)
+    {
+        if (Worker::MovingAverageReward == 0.0) {
+            Worker::MovingAverageReward = reward;
+        }
+        else {
+            Worker::MovingAverageReward = Worker::MovingAverageReward * 0.99 + reward * 0.01;
+        }
+
+        std::cout << "Episode: " << episode
+                  << " | Moving Average Reward: " << Worker::MovingAverageReward
+                  << " | Episode reward: " << reward << " | Steps: " << numOfSteps
+                  << " | Worker: " << worker_id << std::endl;
+    }
+};
+
+// Define static attributes
+std::mutex Worker::m_mutex;
+std::atomic<size_t> Worker::BestScore = 0;
+std::atomic<size_t> Worker::InstanceCounter = 0;
+std::atomic<size_t> Worker::NumberOfEpisodes = 0;
+std::atomic<double> Worker::MovingAverageReward = 0;
+
+class MasterAgent
+{
+private:
+    size_t m_maxEpisodes;
+    std::vector<std::unique_ptr<Worker>> m_workers;
+    std::vector<std::thread> m_pool;
+    const gympp::EnvironmentName EnvName = "CartPole";
+
+public:
+    MasterAgent(const size_t maxEpisodes)
+        : m_maxEpisodes(maxEpisodes)
+    {}
+
+    bool train()
+    {
+        unsigned threadAffinity = std::thread::hardware_concurrency();
+        gymppMessage << "Machine supports " << threadAffinity << " concurrent threads" << std::endl;
+
+        for (size_t i = 0; i < threadAffinity; ++i) {
+            // Create the worker
+            m_workers.emplace_back(std::make_unique<Worker>(EnvName, m_maxEpisodes));
+
+            auto& worker = m_workers.back();
+
+            if (!worker->initialize()) {
+                return false;
+            }
+
+            // Add its run method in the thread pool
+            m_pool.emplace_back(&Worker::run, &*m_workers.back());
+        }
+
+        for (auto& thread : m_pool) {
+            thread.join();
+        }
+
+        return true;
+    }
+
+    void reset()
+    {
+        for (auto& worker : m_workers) {
+            worker.reset();
+        }
+    }
+};
+
+struct Config
+{
+    bool help = false;
+    bool train = false;
+    size_t maxEpisodes = 100;
+    std::optional<size_t> seed;
+};
+
+int main(int argc, char* argv[])
+{
+    // ==================
+    // PARSE COMMAND LINE
+    // ==================
+
+    Config config;
+
+    // Create the command line parser
+    auto cli =
+        Help(config.help) //
+        | Opt(config.maxEpisodes, "n")["-m"]["--max-episodes"]("Maximum number of episodes to run")
+        | Opt(config.train)["-t"]["--train"]("Train the model")
+        | Opt([&](unsigned value) { config.seed = value; },
+              "seed")["-s"]["--seed"]("use a specific seed for randomness");
+
+    // Parse the command line
+    if (auto result = cli.parse(Args(argc, argv)); !result) {
+        gymppError << "Error in command line: " << result.errorMessage() << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    if (config.help) {
+        std::cout << cli;
+        exit(EXIT_SUCCESS);
+    }
+
+    // ====================
+    // INITIALIZE THE AGENT
+    // ====================
+
+    if (config.seed) {
+        Random::setSeed(config.seed.value());
+    }
+
+    // Create the master agent
+    MasterAgent agent(config.maxEpisodes);
+
+    // Terminate the agent gracefully
+    ignition::common::SignalHandler sigHandler;
+    assert(sigHandler.Initialized());
+    sigHandler.AddCallback([&](const int /*_sig*/) {
+        gymppDebug << "Shutting down gracefully" << std::endl;
+        agent.reset();
+        exit(EXIT_FAILURE);
+    });
+
+    // =====
+    // TRAIN
+    // =====
+
+    bool ok = agent.train();
+
+    if (!ok) {
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/gym_ignition/envs/cartpole/CartPole.py
+++ b/gym_ignition/envs/cartpole/CartPole.py
@@ -17,7 +17,7 @@ class CartPoleEnv(IgnitionEnv):
         md.setLibraryName("CartPolePlugin")
         md.setClassName("gympp::plugins::CartPole")
         md.setWorldFileName("CartPole.world")
-        md.setModelNames(["cartpole_xacro"])
+        md.setModelFileName("CartPole/CartPole.sdf")
 
         action_space_md = SpaceMetadata()
         action_space_md.setType(SpaceType_Discrete)

--- a/ignition/CMakeLists.txt
+++ b/ignition/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries(IgnitionEnvironment
     PUBLIC
     gympp
     PRIVATE
+    EnvironmentCallbacksSingleton
     ignition-gazebo1::core
     tiny-process-library)
 

--- a/ignition/CMakeLists.txt
+++ b/ignition/CMakeLists.txt
@@ -84,6 +84,27 @@ target_include_directories(RobotSingleton PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
+# ==============
+# IGNITION ROBOT
+# ==============
+
+add_library(IgnitionRobot SHARED
+    include/gympp/gazebo/IgnitionRobot.h
+    src/IgnitionRobot.cpp)
+
+target_link_libraries(IgnitionRobot
+    PUBLIC
+    gympp
+    RobotSingleton
+    ignition-gazebo1::core)
+
+set_target_properties(IgnitionRobot PROPERTIES
+    PUBLIC_HEADER include/gympp/gazebo/IgnitionRobot.h)
+
+target_include_directories(IgnitionRobot PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
 # ===================
 # INSTALL THE TARGETS
 # ===================
@@ -94,34 +115,9 @@ install(
     RobotSingleton
     EnvironmentCallbacks
     EnvironmentCallbacksSingleton
+    IgnitionRobot
     EXPORT gympp
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gympp/gazebo)
-
-# ====================
-# IgnitionRobot PLUGIN
-# ====================
-
-add_library(IgnitionRobot SHARED
-    include/gympp/gazebo/IgnitionRobot.h
-    src/IgnitionRobot.cpp)
-
-target_link_libraries(IgnitionRobot
-    PUBLIC
-    gympp
-    IgnitionEnvironment
-    RobotSingleton
-    ignition-gazebo1::core)
-
-target_include_directories(IgnitionRobot PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-
-install(
-    TARGETS IgnitionRobot
-    EXPORT gympp
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/gympp/plugins
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/gympp/plugins
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/gympp/plugins)

--- a/ignition/CMakeLists.txt
+++ b/ignition/CMakeLists.txt
@@ -2,6 +2,25 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
+# =============================
+# EnvironmentCallbacksSingleton
+# =============================
+
+add_library(EnvironmentCallbacksSingleton SHARED
+    include/gympp/gazebo/EnvironmentCallbacksSingleton.h
+    src/EnvironmentCallbacksSingleton.cpp)
+
+target_include_directories(EnvironmentCallbacksSingleton PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+target_link_libraries(EnvironmentCallbacksSingleton PUBLIC
+    gympp
+    ignition-gazebo1::core)
+
+set_target_properties(EnvironmentCallbacksSingleton PROPERTIES
+    PUBLIC_HEADER include/gympp/gazebo/EnvironmentCallbacksSingleton.h)
+
 # ====================
 # IGNITION ENVIRONMENT
 # ====================
@@ -70,7 +89,11 @@ target_include_directories(RobotSingleton PUBLIC
 # ===================
 
 install(
-    TARGETS IgnitionEnvironment RobotSingleton EnvironmentCallbacks
+    TARGETS
+    IgnitionEnvironment
+    RobotSingleton
+    EnvironmentCallbacks
+    EnvironmentCallbacksSingleton
     EXPORT gympp
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/ignition/include/gympp/gazebo/EnvironmentCallbacksSingleton.h
+++ b/ignition/include/gympp/gazebo/EnvironmentCallbacksSingleton.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef GYMPP_ROBOT_ENVIRONMENTCALLBACKSSINGLETON_H
+#define GYMPP_ROBOT_ENVIRONMENTCALLBACKSSINGLETON_H
+
+#include <ignition/common/SingletonT.hh>
+
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "gympp/gazebo/EnvironmentCallbacks.h"
+namespace gympp {
+    namespace gazebo {
+        class EnvironmentCallbacksSingleton;
+    } // namespace gazebo
+} // namespace gympp
+
+class gympp::gazebo::EnvironmentCallbacksSingleton
+    : public ignition::common::SingletonT<EnvironmentCallbacksSingleton>
+{
+private:
+    class Impl;
+    std::unique_ptr<Impl, std::function<void(Impl*)>> pImpl;
+
+public:
+    EnvironmentCallbacksSingleton();
+
+    gympp::gazebo::EnvironmentCallbacks* get(const std::string& label);
+    bool storeEnvironmentCallback(const std::string& label,
+                                  gympp::gazebo::EnvironmentCallbacks* cb);
+};
+
+#endif // GYMPP_ROBOT_ENVIRONMENTCALLBACKSSINGLETON_H

--- a/ignition/include/gympp/gazebo/IgnitionEnvironment.h
+++ b/ignition/include/gympp/gazebo/IgnitionEnvironment.h
@@ -42,6 +42,8 @@ public:
     using Environment::Reward;
     using Environment::State;
 
+    static size_t EnvironmentId;
+
     IgnitionEnvironment() = delete;
     IgnitionEnvironment(const ActionSpacePtr aSpace,
                         const ObservationSpacePtr oSpace,
@@ -57,7 +59,11 @@ public:
     // Public APIs
     EnvironmentPtr env();
     static void setVerbosity(int level = DEFAULT_VERBOSITY);
-    bool setupGazeboWorld(const std::string& worldFile, const std::vector<std::string>& modelNames);
+
+    bool setupGazeboModel(const std::string& modelFile,
+                          std::array<double, 6> pose = {0, 0, 0, 0, 0, 0});
+    bool setupGazeboWorld(const std::string& worldFile);
+
     bool setupIgnitionPlugin(const std::string& libName, const std::string& className);
 };
 

--- a/ignition/include/gympp/gazebo/IgnitionEnvironment.h
+++ b/ignition/include/gympp/gazebo/IgnitionEnvironment.h
@@ -58,7 +58,7 @@ public:
     EnvironmentPtr env();
     static void setVerbosity(int level = DEFAULT_VERBOSITY);
     bool setupGazeboWorld(const std::string& worldFile, const std::vector<std::string>& modelNames);
-    bool setupIgnitionPlugin(const std::string& libName, const std::string& pluginName);
+    bool setupIgnitionPlugin(const std::string& libName, const std::string& className);
 };
 
 #endif // GYMPP_GYMS_IGNITION

--- a/ignition/include/gympp/gazebo/IgnitionRobot.h
+++ b/ignition/include/gympp/gazebo/IgnitionRobot.h
@@ -11,8 +11,11 @@
 
 #include "gympp/Robot.h"
 
-#include <ignition/gazebo/System.hh>
+#include <ignition/gazebo/Entity.hh>
+#include <ignition/gazebo/EntityComponentManager.hh>
+#include <sdf/Element.hh>
 
+#include <functional>
 #include <memory>
 
 namespace gympp {
@@ -21,10 +24,7 @@ namespace gympp {
     } // namespace gazebo
 } // namespace gympp
 
-class gympp::gazebo::IgnitionRobot final
-    : public gympp::Robot
-    , public ignition::gazebo::System
-    , public ignition::gazebo::ISystemConfigure
+class gympp::gazebo::IgnitionRobot : public gympp::Robot
 {
 private:
     class Impl;
@@ -34,11 +34,9 @@ public:
     IgnitionRobot();
     ~IgnitionRobot() override;
 
-    void Configure(const ignition::gazebo::Entity& entity,
-                   const std::shared_ptr<const sdf::Element>& sdf,
-                   ignition::gazebo::EntityComponentManager& ecm,
-                   ignition::gazebo::EventManager& eventMgr) override;
-
+    bool configureECM(const ignition::gazebo::Entity& entity,
+                      const std::shared_ptr<const sdf::Element>& sdf,
+                      ignition::gazebo::EntityComponentManager& ecm);
     bool valid() const override;
 
     // ===========

--- a/ignition/src/EnvironmentCallbacksSingleton.cpp
+++ b/ignition/src/EnvironmentCallbacksSingleton.cpp
@@ -1,0 +1,45 @@
+#include "gympp/gazebo/EnvironmentCallbacksSingleton.h"
+#include "gympp/Log.h"
+
+#include <unordered_map>
+
+using namespace gympp::gazebo;
+
+class EnvironmentCallbacksSingleton::Impl
+{
+public:
+    std::unordered_map<std::string, EnvironmentCallbacks*> callbacks;
+};
+
+EnvironmentCallbacksSingleton::EnvironmentCallbacksSingleton()
+    : pImpl{new Impl(), [](Impl* impl) { delete impl; }}
+{}
+
+EnvironmentCallbacks* EnvironmentCallbacksSingleton::get(const std::string& label)
+{
+    if (pImpl->callbacks.find(label) == pImpl->callbacks.end()) {
+        gymppError << "Failed to find environment callbacks labelled as '" << label << "'"
+                   << std::endl;
+        return nullptr;
+    }
+
+    assert(pImpl->callbacks.at(label));
+    return pImpl->callbacks.at(label);
+}
+
+bool EnvironmentCallbacksSingleton::storeEnvironmentCallback(const std::string& label,
+                                                             EnvironmentCallbacks* cb)
+{
+    if (!cb || label.empty()) {
+        gymppError << "Trying to store invalid environment callbacks" << std::endl;
+        return false;
+    }
+
+    if (pImpl->callbacks.find(label) != pImpl->callbacks.end()) {
+        gymppError << "Environment callbacks with label '" << label
+                   << "' have been already registered" << std::endl;
+    }
+
+    pImpl->callbacks.insert({label, cb});
+    return true;
+}

--- a/ignition/src/IgnitionEnvironment.cpp
+++ b/ignition/src/IgnitionEnvironment.cpp
@@ -19,7 +19,9 @@
 #include <ignition/gazebo/SystemLoader.hh>
 #include <ignition/plugin/SpecializedPluginPtr.hh>
 #include <sdf/Element.hh>
-//#include <sdf/Root.hh>
+#include <sdf/Model.hh>
+#include <sdf/Root.hh>
+#include <sdf/World.hh>
 
 #include <chrono>
 #include <condition_variable>
@@ -30,37 +32,56 @@
 
 using namespace gympp::gazebo;
 
+size_t IgnitionEnvironment::EnvironmentId = 0;
+
 class IgnitionEnvironment::Impl
 {
+private:
+    gympp::gazebo::EnvironmentCallbacks* cb = nullptr;
+
 public:
+    size_t id;
+
     std::unique_ptr<TinyProcessLib::Process> ignitionGui;
 
     uint64_t numOfIterations = 0;
     ignition::gazebo::ServerConfig serverConfig;
     std::shared_ptr<ignition::gazebo::Server> server;
+
+    gympp::gazebo::EnvironmentCallbacks* envCallbacks();
     std::shared_ptr<ignition::gazebo::Server> getServer();
 
-    gympp::gazebo::EnvironmentCallbacks* envCallbacks()
-    {
-        auto ecSingleton = EnvironmentCallbacksSingleton::Instance();
-        auto* callbacks = ecSingleton->get(scopedModelName);
-        assert(callbacks);
-        return callbacks;
-    }
+    sdf::Root sdf;
+    bool findAndLoadSdf(const std::string& sdfFileName, sdf::Root& sdfRoot);
+
+    ignition::common::SystemPaths systemPaths;
 
     std::string scopedModelName;
-    std::vector<std::string> modelsNamesInSdf;
 };
+
+gympp::gazebo::EnvironmentCallbacks* IgnitionEnvironment::Impl::envCallbacks()
+{
+    if (!cb) {
+        auto ecSingleton = EnvironmentCallbacksSingleton::Instance();
+        cb = ecSingleton->get(scopedModelName);
+        assert(cb);
+    }
+
+    return cb;
+}
 
 std::shared_ptr<ignition::gazebo::Server> IgnitionEnvironment::Impl::getServer()
 {
     // Lazy initialization of the server
     if (!server) {
 
-        if (serverConfig.SdfFile().empty() && serverConfig.SdfString().empty()) {
-            gymppError << "The sdf file was not configured" << std::endl;
-            return nullptr;
-        }
+        assert(sdf.Element());
+        assert(!sdf.Element()->ToString("").empty());
+        serverConfig.SetSdfString(sdf.Element()->ToString(""));
+
+        sdf::Root root;
+        auto errors = root.LoadSdfString(sdf.Element()->ToString(""));
+        assert(errors.empty()); // This should be already ok
 
         // Create the server
         gymppDebug << "Creating the server" << std::endl << std::flush;
@@ -80,6 +101,38 @@ std::shared_ptr<ignition::gazebo::Server> IgnitionEnvironment::Impl::getServer()
     return server;
 }
 
+// TODO: there's a bug in the destructor of sdf::Physics that prevents returning std::optional
+bool IgnitionEnvironment::Impl::findAndLoadSdf(const std::string& sdfFileName, sdf::Root& root)
+{
+    if (sdfFileName.empty()) {
+        gymppError << "The SDF file name of the gazebo model is empty" << std::endl;
+        return {};
+    }
+
+    // Find the file
+    // TODO: add install directory of our world and model files
+    std::string sdfFilePath = systemPaths.FindFile(sdfFileName);
+
+    if (sdfFilePath.empty()) {
+        gymppError << "Failed to find '" << sdfFileName << "'. "
+                   << "Check that it's contained in the paths defined in IGN_GAZEBO_RESOURCE_PATH."
+                   << std::endl;
+        return {};
+    }
+
+    // Load the sdf
+    auto errors = root.Load(sdfFilePath);
+
+    if (!errors.empty()) {
+        gymppError << "Failed to load sdf file '" << sdfFilePath << "." << std::endl;
+        for (const auto& error : errors) {
+            gymppError << error << std::endl;
+        }
+        return {};
+    }
+    return true;
+}
+
 // ===============
 // IGNITION GAZEBO
 // ===============
@@ -91,18 +144,34 @@ IgnitionEnvironment::IgnitionEnvironment(const ActionSpacePtr aSpace,
     : Environment(aSpace, oSpace)
     , pImpl{new IgnitionEnvironment::Impl, [](Impl* impl) { delete impl; }}
 {
-    setVerbosity(4);
-    //    pImpl->sdfFile = sdfFile;
+    // Assign an unique id to the object
+    pImpl->id = EnvironmentId++;
+
     pImpl->numOfIterations = iterations;
     pImpl->serverConfig.SetUpdateRate(updateRate);
+
+    pImpl->systemPaths.SetFilePathEnv("IGN_GAZEBO_RESOURCE_PATH");
+    pImpl->systemPaths.AddFilePaths(IGN_GAZEBO_WORLD_INSTALL_DIR);
+    // TODO: add install world / models path
+
+    // Set default verbosity which is dependent on the compilation flags
+    setVerbosity();
 }
 
-static size_t counter = 0;
 bool IgnitionEnvironment::setupIgnitionPlugin(const std::string& libName,
                                               const std::string& className)
 {
-    auto uniqueID = counter++;
-    pImpl->scopedModelName = pImpl->modelsNamesInSdf.front() + std::to_string(uniqueID);
+    assert(!pImpl->scopedModelName.empty());
+
+    sdf::ElementPtr sdf(new sdf::Element);
+    sdf->SetName("plugin");
+    sdf->AddAttribute("name", "string", className, true);
+    sdf->AddAttribute("filename", "string", libName, true);
+
+    ignition::gazebo::ServerConfig::PluginInfo pluginInfo{
+        pImpl->scopedModelName, "model", libName, className, sdf};
+
+    pImpl->serverConfig.AddPlugin(pluginInfo);
 
     return true;
 }
@@ -213,47 +282,77 @@ void IgnitionEnvironment::setVerbosity(int level)
     ignition::common::Console::SetVerbosity(level);
 }
 
-bool IgnitionEnvironment::setupGazeboWorld(const std::string& worldFile,
-                                           const std::vector<std::string>& modelNames)
+bool IgnitionEnvironment::setupGazeboModel(const std::string& modelFile,
+                                           std::array<double, 6> /*pose*/)
 {
-    // =================
-    // LOAD THE SDF FILE
-    // =================
-
-    if (worldFile.empty()) {
-        gymppError << "Passed SDF file argument is an empty string" << std::endl;
+    if (!pImpl->scopedModelName.empty()) {
+        gymppError << "The model has been already configured previously" << std::endl;
         return false;
     }
 
-    // Find the file
-    // TODO: add install directory of our world files
-    ignition::common::SystemPaths systemPaths;
-    systemPaths.SetFilePathEnv("IGN_GAZEBO_RESOURCE_PATH");
-    systemPaths.AddFilePaths(IGN_GAZEBO_WORLD_INSTALL_DIR);
-    std::string filePath = systemPaths.FindFile(worldFile);
-
-    if (filePath.empty()) {
-        gymppError << "Failed to find '" << worldFile << "'. "
-                   << "Check that it's contained in the paths defined in IGN_GAZEBO_RESOURCE_PATH."
-                   << std::endl;
-        gymppError << "If you use the <include> element, make sure to add the parent folder of the "
-                   << "<uri> in the SDF_PATH variable." << std::endl;
+    if (pImpl->sdf.WorldCount() <= 0) {
+        gymppError << "The gazebo world was not properly configured" << std::endl;
         return false;
     }
 
-    if (!pImpl->serverConfig.SetSdfFile(filePath)) {
-        gymppError << "Failed to set the SDF file " << worldFile << std::endl;
+    // Find and load the sdf file that contains the model
+    sdf::Root sdfRoot;
+    if (!pImpl->findAndLoadSdf(modelFile, sdfRoot)) {
+        gymppError << "Failed to find and load sdf file '" << modelFile << "'" << std::endl;
         return false;
     }
 
-    // ======================================
-    // LOAD A ROBOT PLUGIN FOR EACH SDF MODEL
-    // ======================================
+    if (sdfRoot.ModelCount() == 0) {
+        gymppError << "Failed to find any model in '" << modelFile << "' sdf file" << std::endl;
+        return false;
+    }
 
-    // Store the model names
-    // TODO: We should separate robot and environment. In this way we would have an sdf file for
-    //       the robot that we can parse to get automatically the model names.
-    pImpl->modelsNamesInSdf = modelNames;
+    // Get the models names included in the sdf file.
+    // In order to allow multithreading, the name of the model contained in the sdf must be scoped.
+    // We use the id of the IgnitionEnvironment object as scope.
+    for (unsigned i = 0; i < sdfRoot.ModelCount(); ++i) {
+        // Get the model name
+        std::string modelName = sdfRoot.ModelByIndex(i)->Name();
+        gymppDebug << "Found model '" << modelName << "' in the sdf file" << std::endl;
+
+        // Create a scoped name
+        std::string scopedModelName = std::to_string(pImpl->id) + "::" + modelName;
+        gymppDebug << "Registering scoped '" << scopedModelName << "' model" << std::endl;
+
+        // Copy the content of the model in another sdf element.
+        // This has to be done because it is not possible to change in-place the name of the model,
+        // so we create a new element and we copy all the children.
+        sdf::ElementPtr renamedModel(new sdf::Element);
+        renamedModel->SetName("model");
+        renamedModel->AddAttribute("name", "string", scopedModelName, true);
+
+        sdf::ElementPtr child = sdfRoot.ModelByIndex(i)->Element()->GetFirstElement();
+
+        while (child) {
+            renamedModel->InsertElement(child);
+            child = child->GetNextElement();
+        }
+
+        // TODO: Temporarily support only one model, and it must be the one to which the gympp
+        //       plugin will be attached to.
+        assert(sdfRoot.ModelCount() == 1);
+        pImpl->scopedModelName = scopedModelName;
+
+        // Attach the model to the sdf world
+        assert(pImpl->sdf.WorldCount() == 1);
+        pImpl->sdf.WorldByIndex(0)->Element()->InsertElement(renamedModel);
+    }
+
+    return true;
+}
+
+bool IgnitionEnvironment::setupGazeboWorld(const std::string& worldFile)
+{
+    // Find and load the sdf file that contains the world
+    if (!pImpl->findAndLoadSdf(worldFile, pImpl->sdf)) {
+        gymppError << "Failed to find and load sdf file '" << worldFile << "'" << std::endl;
+        return false;
+    }
 
     return true;
 }
@@ -265,7 +364,7 @@ gympp::EnvironmentPtr IgnitionEnvironment::env()
 
 std::optional<IgnitionEnvironment::Observation> IgnitionEnvironment::reset()
 {
-    gymppMessage << "Resetting the environment" << std::endl;
+    gymppDebug << "Resetting the environment" << std::endl;
 
     // The plugin must be loaded in order to call its reset() method
     if (!pImpl->getServer()) {

--- a/models/CartPole/CartPole.sdf
+++ b/models/CartPole/CartPole.sdf
@@ -1,5 +1,8 @@
 <sdf version='1.6'>
   <model name='cartpole_xacro'>
+    <plugin name="gympp::plugins::CartPole" filename="CartPolePlugin">
+      <scoped_name>cartpole_xacro0</scoped_name>
+    </plugin>
     <link name='rail'>
       <pose frame=''>0 0 0.5 0 -0 0</pose>
       <inertial>

--- a/models/CartPole/CartPole.sdf
+++ b/models/CartPole/CartPole.sdf
@@ -1,8 +1,5 @@
 <sdf version='1.6'>
   <model name='cartpole_xacro'>
-    <plugin name="gympp::plugins::CartPole" filename="CartPolePlugin">
-      <scoped_name>cartpole_xacro0</scoped_name>
-    </plugin>
     <link name='rail'>
       <pose frame=''>0 0 0.5 0 -0 0</pose>
       <inertial>

--- a/models/worlds/CartPole.world
+++ b/models/worlds/CartPole.world
@@ -46,6 +46,7 @@
         <service>/world/default/control</service>
         <stats_topic>/world/default/stats</stats_topic>
       </plugin>
+
       <!-- Grid 3D -->
 <!--      <plugin filename='Grid3D' name='3D Grid'>
         <ignition-gui>
@@ -91,11 +92,6 @@
         </visual>
       </link>
     </model>
-
-    <include>
-      <pose>0 0 0 0 0 0</pose>
-      <uri>CartPole</uri>
-    </include>
 
   </world>
 </sdf>

--- a/plugins/CartPole/CMakeLists.txt
+++ b/plugins/CartPole/CMakeLists.txt
@@ -13,12 +13,14 @@ add_library(CartPolePlugin SHARED
 target_link_libraries(CartPolePlugin
     PUBLIC
     EnvironmentCallbacks
-    RobotSingleton
+    ignition-gazebo1::core
     PRIVATE
-    ignition-gazebo1::core)
+    IgnitionRobot
+    EnvironmentCallbacksSingleton
+    RobotSingleton)
 
 target_include_directories(CartPolePlugin PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR})
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 if(MSVC)
     # Import math symbols from standard cmath

--- a/plugins/CartPole/CartPolePlugin.cpp
+++ b/plugins/CartPole/CartPolePlugin.cpp
@@ -11,6 +11,8 @@
 #include "gympp/Log.h"
 #include "gympp/Random.h"
 #include "gympp/Robot.h"
+#include "gympp/gazebo/EnvironmentCallbacksSingleton.h"
+#include "gympp/gazebo/IgnitionRobot.h"
 #include "gympp/gazebo/RobotSingleton.h"
 
 #include <ignition/plugin/Register.hh>
@@ -18,6 +20,7 @@
 #include <cmath>
 #include <mutex>
 
+using namespace gympp::gazebo;
 using namespace gympp::plugins;
 
 using ActionDataType = int;
@@ -46,9 +49,6 @@ enum CartPoleAction
 
 class CartPole::Impl
 {
-private:
-    gympp::RobotPtr robot = nullptr;
-
 public:
     unsigned seed;
     bool firstRun = true;
@@ -59,22 +59,12 @@ public:
     ObservationSample observationBuffer;
     std::optional<CartPoleAction> action;
 
+    std::shared_ptr<gympp::Robot> robot = nullptr;
+
     double getRandomThetaInRad()
     {
         std::uniform_real_distribution<> distr(-MaxTheta0Rad, MaxTheta0Rad);
         return distr(gympp::Random::engine());
-    }
-
-    gympp::RobotPtr getRobot()
-    {
-        if (!robot) {
-            auto& robotSingleton = gympp::gazebo::RobotSingleton::get();
-            robot = robotSingleton.getRobot("cartpole_xacro");
-        }
-
-        assert(robot);
-        assert(robot->valid());
-        return robot;
     }
 };
 
@@ -89,6 +79,51 @@ CartPole::CartPole()
     pImpl->observationBuffer.resize(4);
 }
 
+void CartPole::Configure(const ignition::gazebo::Entity& entity,
+                         const std::shared_ptr<const sdf::Element>& sdf,
+                         ignition::gazebo::EntityComponentManager& ecm,
+                         ignition::gazebo::EventManager& eventMgr)
+{
+    // Get the sdf element that contains the scoped name of the model.
+    // It is used only for multiple environments running in seraparated threads.
+    std::string scopedModelName;
+    auto sdfClone = sdf->Clone();
+    sdf::ElementPtr element = sdfClone->GetElement("scoped_name");
+
+    if (!element) {
+        gymppError << "Failed to find 'scoped_name' sdf plugin element" << std::endl;
+        return;
+    }
+
+    // Get the scoped name of the model
+    scopedModelName = element->Get<std::string>();
+
+    // Auto-register the environment callbacks
+    auto ecSingleton = EnvironmentCallbacksSingleton::Instance();
+    bool registered = ecSingleton->storeEnvironmentCallback(scopedModelName, this);
+    assert(registered);
+
+    // Create a gympp::IgnitionRobot object from the ecm
+    auto ignRobot = std::make_shared<gympp::gazebo::IgnitionRobot>();
+    if (!ignRobot->configureECM(entity, sdf, ecm)) {
+        gymppError << "Failed to configure the Robot interface" << std::endl;
+        return;
+    }
+
+    if (!ignRobot->valid()) {
+        gymppError << "The Robot interface is not valid" << std::endl;
+        return;
+    }
+
+    // Store a pointer to gympp::Robot
+    pImpl->robot = ignRobot;
+
+    // TODO: Right now the gympp::Robot interface is only used inside this plugin.
+    //       Since we want to expose the robot also to python (in order to read and
+    //       modify the state) it can be registered in the RobotSingleton using the
+    //       scoped name.
+}
+
 void CartPole::PreUpdate(const ignition::gazebo::UpdateInfo& info,
                          ignition::gazebo::EntityComponentManager& /*manager*/)
 {
@@ -96,15 +131,13 @@ void CartPole::PreUpdate(const ignition::gazebo::UpdateInfo& info,
         return;
     }
 
-    // Get the pointer to the Robot interface
-    gympp::RobotPtr robot = pImpl->getRobot();
-    assert(robot);
+    assert(pImpl->robot);
 
     if (pImpl->firstRun) {
         pImpl->firstRun = false;
 
         // Initialize the PID
-        if (!robot->setJointPID("linear", {10000, 50, 200})) {
+        if (!pImpl->robot->setJointPID("linear", {10000, 50, 200})) {
             gymppError << "Failed to set the PID of joint 'linear'" << std::endl;
             return;
         }
@@ -114,7 +147,7 @@ void CartPole::PreUpdate(const ignition::gazebo::UpdateInfo& info,
     }
 
     // Set the step size
-    if (!robot->setdt(info.dt)) {
+    if (!pImpl->robot->setdt(info.dt)) {
         gymppError << "Failed to set the step size" << std::endl;
         return;
     }
@@ -143,7 +176,7 @@ void CartPole::PreUpdate(const ignition::gazebo::UpdateInfo& info,
             pImpl->action.reset();
         }
 
-        if (!robot->setJointForce("linear", appliedForce)) {
+        if (!pImpl->robot->setJointForce("linear", appliedForce)) {
             gymppError << "Failed to set the force to joint 'linear'" << std::endl;
             return;
         }
@@ -157,15 +190,13 @@ void CartPole::PostUpdate(const ignition::gazebo::UpdateInfo& info,
         return;
     }
 
-    // Get the pointer to the Robot interface
-    gympp::RobotPtr robot = pImpl->getRobot();
-    assert(robot);
+    assert(pImpl->robot);
 
-    double cartJointPosition = robot->jointPosition("linear");
-    double poleJointPosition = robot->jointPosition("pivot");
+    double cartJointPosition = pImpl->robot->jointPosition("linear");
+    double poleJointPosition = pImpl->robot->jointPosition("pivot");
 
-    double cartJointVelocity = robot->jointVelocity("linear");
-    double poleJointVelocity = robot->jointVelocity("pivot");
+    double cartJointVelocity = pImpl->robot->jointVelocity("linear");
+    double poleJointVelocity = pImpl->robot->jointVelocity("pivot");
 
     {
         std::lock_guard lock(pImpl->mutex);
@@ -191,14 +222,7 @@ bool CartPole::isDone()
 
 bool CartPole::reset()
 {
-    // Get the pointer to the Robot interface
-    gympp::RobotPtr robot = pImpl->getRobot();
-    assert(robot);
-
-    if (!robot) {
-        gymppError << "Failed to get pointer to the robot interface" << std::endl;
-        return false;
-    }
+    assert(pImpl->robot);
 
     // Reset the number of iterations
     pImpl->iterations = 0;
@@ -209,13 +233,13 @@ bool CartPole::reset()
     auto theta0 = pImpl->getRandomThetaInRad();
 
     // Set the random pole angle
-    if (!robot->resetJoint("pivot", theta0, v0)) {
+    if (!pImpl->robot->resetJoint("pivot", theta0, v0)) {
         gymppError << "Failed to reset the position of joint 'pivot'" << std::endl;
         return false;
     }
 
     // Reset the cart position
-    if (!robot->resetJoint("linear", x0, v0)) {
+    if (!pImpl->robot->resetJoint("linear", x0, v0)) {
         gymppError << "Failed to reset the position of joint 'linear'" << std::endl;
         return false;
     }
@@ -278,6 +302,7 @@ std::optional<gympp::gazebo::EnvironmentCallbacks::Observation> CartPole::getObs
 
 IGNITION_ADD_PLUGIN(gympp::plugins::CartPole,
                     gympp::plugins::CartPole::System,
+                    gympp::plugins::CartPole::ISystemConfigure,
                     gympp::plugins::CartPole::ISystemPreUpdate,
                     gympp::plugins::CartPole::ISystemPostUpdate,
                     gympp::gazebo::EnvironmentCallbacks)

--- a/plugins/CartPole/CartPolePlugin.cpp
+++ b/plugins/CartPole/CartPolePlugin.cpp
@@ -82,27 +82,8 @@ CartPole::CartPole()
 void CartPole::Configure(const ignition::gazebo::Entity& entity,
                          const std::shared_ptr<const sdf::Element>& sdf,
                          ignition::gazebo::EntityComponentManager& ecm,
-                         ignition::gazebo::EventManager& eventMgr)
+                         ignition::gazebo::EventManager& /*eventMgr*/)
 {
-    // Get the sdf element that contains the scoped name of the model.
-    // It is used only for multiple environments running in seraparated threads.
-    std::string scopedModelName;
-    auto sdfClone = sdf->Clone();
-    sdf::ElementPtr element = sdfClone->GetElement("scoped_name");
-
-    if (!element) {
-        gymppError << "Failed to find 'scoped_name' sdf plugin element" << std::endl;
-        return;
-    }
-
-    // Get the scoped name of the model
-    scopedModelName = element->Get<std::string>();
-
-    // Auto-register the environment callbacks
-    auto ecSingleton = EnvironmentCallbacksSingleton::Instance();
-    bool registered = ecSingleton->storeEnvironmentCallback(scopedModelName, this);
-    assert(registered);
-
     // Create a gympp::IgnitionRobot object from the ecm
     auto ignRobot = std::make_shared<gympp::gazebo::IgnitionRobot>();
     if (!ignRobot->configureECM(entity, sdf, ecm)) {
@@ -122,6 +103,13 @@ void CartPole::Configure(const ignition::gazebo::Entity& entity,
     //       Since we want to expose the robot also to python (in order to read and
     //       modify the state) it can be registered in the RobotSingleton using the
     //       scoped name.
+
+    // Auto-register the environment callbacks
+    gymppDebug << "Registering environment callbacks for robot '" << ignRobot->name() << "'"
+               << std::endl;
+    auto ecSingleton = EnvironmentCallbacksSingleton::Instance();
+    bool registered = ecSingleton->storeEnvironmentCallback(ignRobot->name(), this);
+    assert(registered);
 }
 
 void CartPole::PreUpdate(const ignition::gazebo::UpdateInfo& info,

--- a/plugins/CartPole/CartPolePlugin.h
+++ b/plugins/CartPole/CartPolePlugin.h
@@ -24,6 +24,7 @@ namespace gympp {
 
 class gympp::plugins::CartPole final
     : public ignition::gazebo::System
+    , public ignition::gazebo::ISystemConfigure
     , public ignition::gazebo::ISystemPreUpdate
     , public ignition::gazebo::ISystemPostUpdate
     , public gympp::gazebo::EnvironmentCallbacks
@@ -35,6 +36,11 @@ private:
 public:
     CartPole();
     ~CartPole() override = default;
+
+    void Configure(const ignition::gazebo::Entity& entity,
+                   const std::shared_ptr<const sdf::Element>& sdf,
+                   ignition::gazebo::EntityComponentManager& ecm,
+                   ignition::gazebo::EventManager& eventMgr) override;
 
     void PreUpdate(const ignition::gazebo::UpdateInfo& info,
                    ignition::gazebo::EntityComponentManager& manager) override;

--- a/plugins/GymFactory/include/gympp/Metadata.h
+++ b/plugins/GymFactory/include/gympp/Metadata.h
@@ -101,8 +101,9 @@ private:
     std::string environmentName;
     std::string libraryName;
     std::string className;
+
+    std::string modelFileName;
     std::string worldFileName;
-    std::vector<std::string> modelNames;
 
     SpaceMetadata actionSpace;
     SpaceMetadata observationSpace;
@@ -111,19 +112,14 @@ public:
     inline std::string getEnvironmentName() const { return environmentName; }
     inline std::string getLibraryName() const { return libraryName; }
     inline std::string getClassName() const { return className; }
+    inline std::string getModelFileName() const { return modelFileName; }
     inline std::string getWorldFileName() const { return worldFileName; }
-    inline std::vector<std::string> getModelNames() const { return modelNames; }
     inline SpaceMetadata getActionSpaceMetadata() const { return actionSpace; }
     inline SpaceMetadata getObservationSpaceMetadata() const { return observationSpace; }
 
     inline void setEnvironmentName(const std::string& environmentName)
     {
         this->environmentName = environmentName;
-    }
-
-    inline void setModelNames(const std::vector<std::string>& modelNames)
-    {
-        this->modelNames = modelNames;
     }
 
     inline void setActionSpaceMetadata(const SpaceMetadata& actionSpaceMetadata)
@@ -138,6 +134,10 @@ public:
 
     inline void setLibraryName(const std::string& libraryName) { this->libraryName = libraryName; }
     inline void setClassName(const std::string& className) { this->className = className; }
+    inline void setModelFileName(const std::string& modelFileName)
+    {
+        this->modelFileName = modelFileName;
+    }
     inline void setWorldFileName(const std::string& worldFileName)
     {
         this->worldFileName = worldFileName;
@@ -149,8 +149,8 @@ public:
         ok = ok && !environmentName.empty();
         ok = ok && !libraryName.empty();
         ok = ok && !className.empty();
+        ok = ok && !modelFileName.empty();
         ok = ok && !worldFileName.empty();
-        ok = ok && !modelNames.empty();
         ok = ok && actionSpace.isValid();
         ok = ok && observationSpace.isValid();
         return ok;

--- a/plugins/GymFactory/include/gympp/PluginDatabase.h
+++ b/plugins/GymFactory/include/gympp/PluginDatabase.h
@@ -25,8 +25,8 @@ public:
         cartPoleMetadata.setEnvironmentName("CartPole");
         cartPoleMetadata.setLibraryName("CartPolePlugin");
         cartPoleMetadata.setClassName("gympp::plugins::CartPole");
+        cartPoleMetadata.setModelFileName("CartPole/CartPole.sdf");
         cartPoleMetadata.setWorldFileName("CartPole.world");
-        cartPoleMetadata.setModelNames({"cartpole_xacro"});
 
         gympp::SpaceMetadata actionSpaceMetadata;
         actionSpaceMetadata.setDimensions({3});

--- a/plugins/GymFactory/src/GymFactory.cpp
+++ b/plugins/GymFactory/src/GymFactory.cpp
@@ -76,16 +76,15 @@ gympp::EnvironmentPtr gympp::GymFactory::make(const std::__cxx11::string& envNam
                                                                 observationSpace,
                                                                 /*updateRate=*/50,
                                                                 /*iterations=*/10);
+    // Setup the world
+    if (!ignGym->setupGazeboWorld(md.worldFileName, md.modelNames)) {
+        gymppError << "Failed to setup SDF file";
+        return nullptr;
+    }
 
     // Setup the CartPolePlugin
     if (!ignGym->setupIgnitionPlugin(md.libraryName, md.className)) {
         gymppError << "Failed to setup the ignition plugin" << std::endl;
-        return nullptr;
-    }
-
-    // Setup the world
-    if (!ignGym->setupGazeboWorld(md.worldFileName, md.modelNames)) {
-        gymppError << "Failed to setup SDF file";
         return nullptr;
     }
 

--- a/plugins/GymFactory/src/GymFactory.cpp
+++ b/plugins/GymFactory/src/GymFactory.cpp
@@ -77,12 +77,18 @@ gympp::EnvironmentPtr gympp::GymFactory::make(const std::__cxx11::string& envNam
                                                                 /*updateRate=*/50,
                                                                 /*iterations=*/10);
     // Setup the world
-    if (!ignGym->setupGazeboWorld(md.worldFileName, md.modelNames)) {
-        gymppError << "Failed to setup SDF file";
+    if (!ignGym->setupGazeboWorld(md.worldFileName)) {
+        gymppError << "Failed to setup gazebo world";
         return nullptr;
     }
 
-    // Setup the CartPolePlugin
+    // Setup the model
+    if (!ignGym->setupGazeboModel(md.modelFileName)) {
+        gymppError << "Failed to setup the gazebo model" << std::endl;
+        return nullptr;
+    }
+
+    // Setup the plugin
     if (!ignGym->setupIgnitionPlugin(md.libraryName, md.className)) {
         gymppError << "Failed to setup the ignition plugin" << std::endl;
         return nullptr;

--- a/plugins/GymFactory/src/GymFactory.cpp
+++ b/plugins/GymFactory/src/GymFactory.cpp
@@ -74,8 +74,9 @@ gympp::EnvironmentPtr gympp::GymFactory::make(const std::__cxx11::string& envNam
     // Create the environment
     auto ignGym = std::make_shared<gazebo::IgnitionEnvironment>(actionSpace,
                                                                 observationSpace,
-                                                                /*updateRate=*/50,
-                                                                /*iterations=*/10);
+                                                                /*updateRate=*/10000000,
+                                                                /*iterations=*/1);
+
     // Setup the world
     if (!ignGym->setupGazeboWorld(md.worldFileName)) {
         gymppError << "Failed to setup gazebo world";


### PR DESCRIPTION
This PR adds multithread support to gym-ignition. It required few changes in the architecture, mainly related on how singletons were holding objects related to simulated models.

1. If more simulations are running in parallel (by creating multiple `IgnitionEnvironmenet` objects), it means that there are in parallel multiple worlds containing the same sdf model. Before objects in the singleton were stored using the plain model name, instead, now, the names are scoped as `<counter>::<modelname>`.
1. Previously, considering a single simulation, two plugins were running in a single world: the one that provides data to the agent (e.g. CartPole), and the one to exposes the robot state wrapping the ECM. This has been simplified. The class that implemented the second (robot state) is not anymore a plugin, it is a regular class. Gympp plugins (e.g. CartPole) that need to access the state of a robot will allocate in their `Configure` step such object. Therefore, the `RobotSingleton` is not anymore used to get `gympp::Robot` pointers, though it will be useful to expose the robot state to other entities (e.g. the python interpreter). This will be implemented in another PR.
1. As a partial consequence of the previous points, robot and world have been separated. Both are sdf files, but the latter does not include anymore the former. `IgnitionEnvironment` reads both files and merges the two. This process has few advantages:
    - The world sdf file can be the same for all models (if there are no particular need of a structured world)
    - The model sdf file is generic, and has no information about the gympp plugin that operates on it. This means that also multiple plugins can act on the same model (`<plugin>` elements are added directly in C++). Therefore, experiments can share the same sdf file.
    - It removes the need to specify the models contained in the sdf file. This was required to give ign-gazebo the information to attach the gympp plugin to the right element. Now, since the model sdf is parsed, the model name is automatically retrieved.

In order to test the multiprocess simulation I created a C++ example [`LaunchParallelCartPole.cpp`](https://github.com/robotology/gym-ignition/blob/157fbef2551bd75b803bc01e13d08a0d28258ddf/examples/cpp/LaunchParallelCartPole.cpp). Here below a teaser:

![Screenshot_20190417_090140](https://user-images.githubusercontent.com/469199/56267551-6a658880-60ef-11e9-97b3-d6e29176df89.png)

Partially fixes #12, because this works well in C++ but unfortunately not from Python. In fact, python has this (horrible) "feature" called [Global Interpreter Lock](https://en.wikipedia.org/wiki/Global_interpreter_lock) that prevents real multithreading (or well, MT is non effective for non-I/O intensive tasks as this one). For the time being this PR only targets C++, I'm going to experiment solutions in python that exploit multiprocess and IPC rather that multithreading.