### PR TITLE
Simplify gympp by removing unused templates

### DIFF
--- a/bindings/gympp.i
+++ b/bindings/gympp.i
@@ -41,8 +41,6 @@
 %template(getBuffer_u) gympp::data::Sample::getBuffer<size_t>;
 %template(getBuffer_f) gympp::data::Sample::getBuffer<float>;
 %template(getBuffer_d) gympp::data::Sample::getBuffer<double>;
-%template(RangeFloat) gympp::Range<float>;
-%template(RangeDouble) gympp::Range<double>;
 
 %include "optional.i"
 %template(Optional_i) std::optional<int>;

--- a/bindings/gympp.i
+++ b/bindings/gympp.i
@@ -54,11 +54,9 @@
 
 %include <std_shared_ptr.i>
 %shared_ptr(gympp::spaces::Space)
-%shared_ptr(gympp::spaces::details::TBox<double>)
+%shared_ptr(gympp::spaces::Box)
 %shared_ptr(gympp::spaces::Discrete)
-
 %include "gympp/Space.h"
-%template(Box) gympp::spaces::details::TBox<double>;
 
 %shared_ptr(gympp::Environment)
 %shared_ptr(gympp::gazebo::GazeboWrapper)
@@ -66,6 +64,7 @@
 %include "ignition/common/SingletonT.hh"
 %ignore ignition::common::SingletonT<gympp::GymFactory>::myself;
 %template(GymFactorySingleton) ignition::common::SingletonT<gympp::GymFactory>;
+
 %include "gympp/Environment.h"
 %include "gympp/gazebo/GazeboWrapper.h"
 %include "gympp/gazebo/IgnitionEnvironment.h"

--- a/gympp/include/gympp/Common.h
+++ b/gympp/include/gympp/Common.h
@@ -19,8 +19,6 @@
 namespace gympp {
 
     using DataSupport = double;
-
-    template <typename DataSupport>
     struct Range;
 
     template <typename Type>
@@ -90,7 +88,6 @@ struct gympp::data::Sample
     }
 };
 
-template <typename DataSupport>
 struct gympp::Range
 {
     Range(DataSupport minValue = std::numeric_limits<DataSupport>::lowest(),

--- a/gympp/include/gympp/Environment.h
+++ b/gympp/include/gympp/Environment.h
@@ -59,7 +59,7 @@ public:
     using ObservationSpace = gympp::spaces::Space;
     using ActionSpacePtr = std::shared_ptr<ActionSpace>;
     using ObservationSpacePtr = std::shared_ptr<ObservationSpace>;
-    using RewardRange = gympp::Range<DataSupport>;
+    using RewardRange = gympp::Range;
 
 public:
     ActionSpacePtr action_space;

--- a/gympp/include/gympp/Space.h
+++ b/gympp/include/gympp/Space.h
@@ -16,16 +16,10 @@
 
 namespace gympp {
     namespace spaces {
-
-        namespace details {
-            template <typename DataType>
-            class TBox;
-        }
-
+        class Box;
         class Space;
         class Discrete;
         using SpacePtr = std::shared_ptr<Space>;
-        using Box = gympp::spaces::details::TBox<double>;
     } // namespace spaces
 } // namespace gympp
 
@@ -48,19 +42,18 @@ public:
     // from_jsonable
 };
 
-template <typename DataType>
-class gympp::spaces::details::TBox : public gympp::spaces::Space
+class gympp::spaces::Box : public gympp::spaces::Space
 {
 public:
     using Shape = gympp::data::Shape;
-    using Buffer = typename gympp::BufferContainer<DataType>::type;
+    using Buffer = typename gympp::BufferContainer<DataSupport>::type;
     using Limit = Buffer;
     using Sample = gympp::data::Sample;
 
-    TBox() = delete;
-    TBox(const DataType low, const DataType high, const Shape& shape);
-    TBox(const Limit& low, const Limit& high);
-    ~TBox() override = default;
+    Box() = delete;
+    Box(const DataSupport low, const DataSupport high, const Shape& shape);
+    Box(const Limit& low, const Limit& high);
+    ~Box() override = default;
 
     Sample sample() override;
     bool contains(const Sample& data) const override;
@@ -73,9 +66,6 @@ private:
     class Impl;
     std::unique_ptr<Impl, std::function<void(Impl*)>> pImpl;
 };
-
-// TODO: export the symbol and instantiate in the cpp
-extern template class gympp::spaces::details::TBox<double>;
 
 class gympp::spaces::Discrete : public gympp::spaces::Space
 {

--- a/gympp/src/Space.cpp
+++ b/gympp/src/Space.cpp
@@ -16,56 +16,45 @@
 #include <utility>
 #include <vector>
 
-template class gympp::spaces::details::TBox<double>;
-
 using namespace gympp::spaces;
-using namespace gympp::spaces::details;
 
 // ===
 // BOX
 // ===
 
-template <typename DataType>
-class TBox<DataType>::Impl
+class Box::Impl
 {
 public:
-    TBox<DataType>::Limit low;
-    TBox<DataType>::Limit high;
+    Box::Limit low;
+    Box::Limit high;
     Shape shape;
 };
 
-template <typename DataType>
-TBox<DataType>::TBox(const DataType low, const DataType high, const Shape& shape)
+Box::Box(const DataSupport low, const DataSupport high, const Shape& shape)
     : pImpl{new Impl(), [](Impl* impl) { delete impl; }}
 {
     // TODO
-    size_t size = shape.size();
-    assert(size == 1);
+    assert(shape.size() == 1);
 
     pImpl->shape = shape;
     pImpl->low = Limit(shape[0], low);
     pImpl->high = Limit(shape[0], high);
 }
 
-template <typename DataType>
-TBox<DataType>::TBox(const Limit& low, const Limit& high)
+Box::Box(const Limit& low, const Limit& high)
     : pImpl{new Impl(), [](Impl* impl) { delete impl; }}
 {
     assert(low.size() == high.size());
     pImpl->shape = {low.size()};
 
     // TODO
-    size_t size = pImpl->shape.size();
-    assert(size == 1);
+    assert(pImpl->shape.size() == 1);
 
     pImpl->low = low;
     pImpl->high = high;
 }
 
-// Box::~Box() = default;
-
-template <typename DataType>
-typename TBox<DataType>::Sample TBox<DataType>::TBox::sample()
+Box::Sample Box::Box::sample()
 {
     Space::Sample randomSample;
 
@@ -73,7 +62,7 @@ typename TBox<DataType>::Sample TBox<DataType>::TBox::sample()
     // TODO: 1D
     assert(pImpl->shape.size() == 1);
     assert(pImpl->shape[0] != 0);
-    auto data = Buffer(pImpl->shape[0], DataType{});
+    auto data = Buffer(pImpl->shape[0], DataSupport{});
 
     // Fill it with random data within the bounds
     for (unsigned i = 0; i < data.size(); ++i) {
@@ -90,10 +79,9 @@ typename TBox<DataType>::Sample TBox<DataType>::TBox::sample()
     return randomSample;
 }
 
-template <typename DataType>
-bool TBox<DataType>::contains(const Space::Sample& data) const
+bool Box::contains(const Space::Sample& data) const
 {
-    auto* bufferPtr = data.getBuffer<DataType>();
+    auto* bufferPtr = data.getBuffer<DataSupport>();
 
     // Check the type
     if (!bufferPtr) {
@@ -121,20 +109,17 @@ bool TBox<DataType>::contains(const Space::Sample& data) const
     return true;
 }
 
-template <typename DataType>
-typename TBox<DataType>::Limit TBox<DataType>::high()
+typename Box::Limit Box::high()
 {
     return pImpl->high;
 }
 
-template <typename DataType>
-typename TBox<DataType>::Limit TBox<DataType>::low()
+typename Box::Limit Box::low()
 {
     return pImpl->low;
 }
 
-template <typename DataType>
-Box::Shape TBox<DataType>::shape()
+Box::Shape Box::shape()
 {
     return pImpl->shape;
 }

--- a/tests/python/test_bindings.py
+++ b/tests/python/test_bindings.py
@@ -57,7 +57,7 @@ def test_sample(create_std_vector):
 
 
 def test_range():
-    gympp_range = gympp.RangeDouble(-5.0, 10.0)
+    gympp_range = gympp.Range(-5.0, 10.0)
     assert gympp_range.contains(0), "Range object failed to verify if it containes a value"
     assert gympp_range.contains(-5), "Range object failed to verify if it containes a value"
     assert gympp_range.contains(10), "Range object failed to verify if it containes a value"


### PR DESCRIPTION
In the beginning the templates were added to provide the support of changing the base support data type used throughout the code. Since handling this from the bindings is not straightforward and is error prone, `double` is now used by default.

Furthermore, the implementation that was using explicit template declaration was not working with clang (both 7 and 8).