### PR TITLE
Google colab example

### DIFF
--- a/examples/colab/Demo.ipynb
+++ b/examples/colab/Demo.ipynb
@@ -1,0 +1,220 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "GymIgnition.ipynb",
+      "version": "0.3.2",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "eM1VjwzYj6ty",
+        "colab_type": "text"
+      },
+      "source": [
+        "# Gym Ignition Example"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "OmfdKqSnkBiw",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Installation"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Qzte7pe6jzGF",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Disable stdout (use output.show() to print it)\n",
+        "%%capture --no-stderr output\n",
+        "\n",
+        "# UPDATE CMAKE\n",
+        "!\\\n",
+        "    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add - &&\\\n",
+        "    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' &&\\\n",
+        "    apt-get -qq update &&\\\n",
+        "    apt-get -qq install cmake\n",
+        "\n",
+        "# INSTALL SWIG\n",
+        "!\\\n",
+        "    apt-get -qq install -y --no-install-recommends \\\n",
+        "        autotools-dev \\\n",
+        "        automake \\\n",
+        "        bison \\\n",
+        "        libpcre3-dev &&\\\n",
+        "    cd /tmp/ &&\\\n",
+        "    rm -rf swig &&\\\n",
+        "    git clone --depth 1 -b rel-4.0.0 https://github.com/swig/swig.git &&\\\n",
+        "    cd swig &&\\\n",
+        "    sh autogen.sh &&\\\n",
+        "    ./configure &&\\\n",
+        "    make -j8 &&\\\n",
+        "    make install\n",
+        "\n",
+        "# INSTALL IGNITION LIBRARIES\n",
+        "!\\\n",
+        "    apt-get -qq update &&\\\n",
+        "    echo \"deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main\" > /etc/apt/sources.list.d/gazebo-stable.list &&\\\n",
+        "    echo \"deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease `lsb_release -cs` main\" > /etc/apt/sources.list.d/gazebo-prerelease.list &&\\\n",
+        "    echo \"deb http://packages.osrfoundation.org/gazebo/ubuntu-nightly `lsb_release -cs` main\" > /etc/apt/sources.list.d/gazebo-prerelease.list &&\\\n",
+        "    wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add - &&\\\n",
+        "    apt-get -qq update &&\\\n",
+        "    apt-get -qq install -y --no-install-recommends \\\n",
+        "        libgflags-dev \\\n",
+        "        libignition-cmake2-dev \\\n",
+        "        libignition-plugin-dev \\\n",
+        "        libignition-math6-dev \\\n",
+        "        libignition-common3-dev \\\n",
+        "        libignition-transport7-dev \\\n",
+        "        libignition-msgs4-dev \\\n",
+        "        libignition-tools-dev \\\n",
+        "        libignition-fuel-tools3-dev \\\n",
+        "        libsdformat8-dev \\\n",
+        "        libignition-physics-dev \\\n",
+        "        libignition-rendering-dev \\\n",
+        "        libignition-sensors2-dev \\\n",
+        "        libignition-gui2-dev\n",
+        "\n",
+        "# INSTALL IGNITION GAZEBO\n",
+        "!cd /tmp &&\\\n",
+        "    rm -rf ign-gazebo &&\\\n",
+        "    git clone --depth 1 https://github.com/diegoferigo/ign-gazebo &&\\\n",
+        "    cd ign-gazebo && mkdir -p build && cd build &&\\\n",
+        "    cmake -DCMAKE_BUILD_TYPE=\"Release\" -DBUILD_TESTING:BOOL=OFF .. &&\\\n",
+        "    cmake --build . --target install -- -j8 &&\\\n",
+        "    rm -r /tmp/ign-gazebo\n",
+        "\n",
+        "# INSTALL GYM IGNITION\n",
+        "!export PATH=/usr/bin:$PATH &&\\\n",
+        "    cd /tmp &&\\\n",
+        "    rm -rf gym-ignition &&\\\n",
+        "    git clone https://github.com/robotology/gym-ignition &&\\\n",
+        "    cd gym-ignition && mkdir -p build && cd build &&\\\n",
+        "    cmake .. &&\\\n",
+        "    cmake --build . --target install -- -j8 &&\\\n",
+        "    cd .. &&\\\n",
+        "    pip3 install ."
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "RsGVAqwz2eJ7",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# CONFIGURE PYTHON PATH\n",
+        "import sys\n",
+        "sys.path.append('/usr/local/lib/gympp/bindings')\n",
+        "\n",
+        "# CONFIGURE ENV\n",
+        "import os\n",
+        "os.environ['IGN_GAZEBO_SYSTEM_PLUGIN_PATH'] = \"/usr/local/lib/gympp/plugins\"\n",
+        "os.environ['IGN_GAZEBO_RESOURCE_PATH'] = \"/usr/local/share/gympp/gazebo/worlds:/usr/local/share/gympp/gazebo/models\""
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "38A4Q2Rmd29V",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 208
+        },
+        "outputId": "ca6b195e-5884-4c8c-d7c9-7cc3f71b8908"
+      },
+      "source": [
+        "%%capture --no-stderr --no-stdout output\n",
+        "\n",
+        "import gym\n",
+        "import gym_ignition\n",
+        "import gym_ignition.utils.logger as logger\n",
+        "\n",
+        "# Set gym verbosity\n",
+        "logger.set_level(gym.logger.INFO)\n",
+        "\n",
+        "logger.debug(\"Initializing the environment\")\n",
+        "\n",
+        "# Create the environment\n",
+        "# env = gym.make(\"CartPole-v1\")\n",
+        "# env = gym.make(\"CartPoleIgnition-v0\")\n",
+        "env = gym.make(\"CartPoleIgnitionPython-v0\")\n",
+        "\n",
+        "# Initialize the seed\n",
+        "env.seed(42)\n",
+        "\n",
+        "for epoch in range(10):\n",
+        "    # Reset the environment\n",
+        "    observation = env.reset()\n",
+        "\n",
+        "    # Initialize returned values\n",
+        "    done = False\n",
+        "    totalReward = 0\n",
+        "\n",
+        "    while not done:\n",
+        "        # Execute a random action\n",
+        "        action = env.action_space.sample()\n",
+        "        observation, reward, done, _ = env.step(action)\n",
+        "\n",
+        "        # Render the environment\n",
+        "        # env.render('human')\n",
+        "\n",
+        "        # Accumulate the reward\n",
+        "        totalReward += reward\n",
+        "\n",
+        "        # Print the observation\n",
+        "        msg = \"\"\n",
+        "        for value in observation:\n",
+        "            msg += \"\\t%.6f\" % value\n",
+        "        logger.debug(msg)\n",
+        "\n",
+        "    logger.info(\"Total reward for episode #{}: {}\".format(epoch, totalReward))\n",
+        "\n",
+        "env.close()\n"
+      ],
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "INFO: Making new env: CartPoleIgnitionPython-v0\n",
+            "INFO: Total reward for episode #0: 39.0\n",
+            "INFO: Total reward for episode #1: 27.0\n",
+            "INFO: Total reward for episode #2: 32.0\n",
+            "INFO: Total reward for episode #3: 32.0\n",
+            "INFO: Total reward for episode #4: 28.0\n",
+            "INFO: Total reward for episode #5: 30.0\n",
+            "INFO: Total reward for episode #6: 25.0\n",
+            "INFO: Total reward for episode #7: 53.0\n",
+            "INFO: Total reward for episode #8: 20.0\n",
+            "INFO: Total reward for episode #9: 45.0\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I added a google colaboratory example to run the environments remotely.

- There is no display support, the simulations must be headless
- It takes some while (couple of minutes) to download and compile everything. As soon as we can use upstream `ign-gazebo` and find a swig 4 deb package time will become reasonable.

Edit: probably github cannot execute it on their server (probably due to all the dependencies of the first cell) and the preview is not working. You can render the notebook here:

https://nbviewer.jupyter.org/github/robotology/gym-ignition/blob/2dcdc66cfa814eec887878168bca0446d237b2cc/examples/colab/Demo.ipynb