### PR TITLE
Properly handle simulation rates

### DIFF
--- a/gym_ignition/__init__.py
+++ b/gym_ignition/__init__.py
@@ -32,6 +32,9 @@ from gym_ignition.tasks import cartpole_continuous
 # GYMPP C++ ENVIRONMENTS
 # ======================
 
+import numpy as np
+max_float = float(np.finfo(np.float32).max)
+
 register(
     id='CartPoleGympp-Discrete-v0',
     max_episode_steps=5000,
@@ -49,7 +52,7 @@ register(
             'robot': sim.cartpole.CartPoleRobot,
             'sdf': "CartPole/CartPole.sdf",
             'world': "DefaultEmptyWorld.world",
-            'rtf': 1E9,
+            'rtf': max_float,
             'agent_rate': 1000,
             'physics_rate': 1000,
             })
@@ -62,7 +65,7 @@ register(
             'robot': sim.cartpole.CartPoleRobot,
             'sdf': "CartPole/CartPole.sdf",
             'world': "DefaultEmptyWorld.world",
-            'rtf': 1E9,
+            'rtf': max_float,
             'agent_rate': 1000,
             'physics_rate': 1000,
             })

--- a/gym_ignition/__init__.py
+++ b/gym_ignition/__init__.py
@@ -49,9 +49,9 @@ register(
             'robot': sim.cartpole.CartPoleRobot,
             'sdf': "CartPole/CartPole.sdf",
             'world': "DefaultEmptyWorld.world",
+            'rtf': 1E9,
             'agent_rate': 1000,
             'physics_rate': 1000,
-            'simulation_rate': 1e9,
             })
 
 register(
@@ -62,7 +62,7 @@ register(
             'robot': sim.cartpole.CartPoleRobot,
             'sdf': "CartPole/CartPole.sdf",
             'world': "DefaultEmptyWorld.world",
+            'rtf': 1E9,
             'agent_rate': 1000,
             'physics_rate': 1000,
-            'simulation_rate': 1e9,
             })

--- a/gym_ignition/__init__.py
+++ b/gym_ignition/__init__.py
@@ -34,6 +34,7 @@ from gym_ignition.tasks import cartpole_continuous
 
 register(
     id='CartPoleGympp-Discrete-v0',
+    max_episode_steps=5000,
     entry_point='gym_ignition.gympp.cartpole:CartPoleDiscrete')
 
 # ==========================
@@ -43,21 +44,25 @@ register(
 register(
     id='CartPoleGymppy-Discrete-v0',
     entry_point='gym_ignition.base.gazebo_env:GazeboEnv',
+    max_episode_steps=5000,
     kwargs={'task': cartpole_discrete.CartPoleDiscrete,
             'robot': sim.cartpole.CartPoleRobot,
             'sdf': "CartPole/CartPole.sdf",
             'world': "DefaultEmptyWorld.world",
             'agent_rate': 1000,
             'physics_rate': 1000,
+            'simulation_rate': 1e9,
             })
 
 register(
     id='CartPoleGymppy-Continuous-v0',
     entry_point='gym_ignition.base.gazebo_env:GazeboEnv',
+    max_episode_steps=5000,
     kwargs={'task': cartpole_continuous.CartPoleContinuous,
             'robot': sim.cartpole.CartPoleRobot,
             'sdf': "CartPole/CartPole.sdf",
             'world': "DefaultEmptyWorld.world",
             'agent_rate': 1000,
             'physics_rate': 1000,
+            'simulation_rate': 1e9,
             })

--- a/gym_ignition/base/gazebo_env.py
+++ b/gym_ignition/base/gazebo_env.py
@@ -190,7 +190,11 @@ class GazeboEnv(gym.Wrapper):
 
     def render(self, mode: str = 'human', **kwargs) -> None:
         if mode == 'human':
-            gui_ok = self.gazebo.gui()
+            # Initialize gazebo if not yet done
+            gazebo = self.gazebo
+            assert gazebo, "Gazebo object not valid"
+
+            gui_ok = gazebo.gui()
             assert gui_ok, "Failed to render the environment"
             return
 

--- a/gym_ignition/base/gazebo_env.py
+++ b/gym_ignition/base/gazebo_env.py
@@ -15,8 +15,9 @@ class GazeboEnv(gym.Wrapper):
                  robot : type,
                  sdf: str,
                  world: str,
-                 physics_rate: float,
+                 rtf: float,
                  agent_rate: float,
+                 physics_rate: float,
                  **kwargs):
 
         # Save the keyworded arguments.
@@ -27,9 +28,12 @@ class GazeboEnv(gym.Wrapper):
         # Store the type of the class that provides gymppy.Robot interface
         self._robot_cls = robot
 
-        # Gazebo private attributes
+        # SDF files
         self._sdf = sdf
         self._world = world
+
+        # Gazebo simulation attributes
+        self._rtf = rtf
         self._agent_rate = agent_rate
         self._physics_rate = physics_rate
         self._gazebo_wrapper = None
@@ -59,34 +63,12 @@ class GazeboEnv(gym.Wrapper):
     # ==========
 
     @property
-    def physics_rate(self) -> float:
-        return self._physics_rate
-
-    @property
-    def agent_rate(self) -> float:
-        return self._agent_rate
-
-    @physics_rate.setter
-    def physics_rate(self, physics_rate: float) -> None:
-        if self._gazebo_wrapper:
-            raise Exception("Gazebo server has been already created. You should set "
-                            "the update rate before its initialization.")
-
-        self._physics_rate = float(physics_rate)
-
-    @agent_rate.setter
-    def agent_rate(self, agent_rate: float) -> None:
-        if self._gazebo_wrapper:
-            raise Exception("Gazebo server has been already created. You should set "
-                            "the update rate before its initialization.")
-
-        self._agent_rate = float(agent_rate)
-
-    @property
     def gazebo(self) -> bindings.GazeboWrapper:
         if self._gazebo_wrapper:
-            assert self._gazebo_wrapper.getUpdateRate() == self.physics_rate, \
-                "Update rate modified after gazebo started"
+            assert self._gazebo_wrapper.getPhysicsData().rtf == self._rtf, \
+                "The RTF of gazebo does not match the configuration"
+            assert 1 / self._gazebo_wrapper.getPhysicsData().maxStepSize == self._physics_rate, \
+                "The physics rate of gazebo does not match the configuration"
 
             return self._gazebo_wrapper
 
@@ -94,14 +76,31 @@ class GazeboEnv(gym.Wrapper):
         # INITIALIZE GAZEBO
         # =================
 
-        assert self.agent_rate, "Agent rate was not set"
-        assert self.physics_rate, "Physics rate was not set"
+        assert self._rtf, "Real Time Factor was not set"
+        assert self._agent_rate, "Agent rate was not set"
+        assert self._physics_rate, "Physics rate was not set"
 
-        logger.debug("Starting gazebo with physics at {} Hz and agent at {} Hz ".format(
-            self.physics_rate, self.agent_rate))
+        logger.debug("Starting gazebo")
+        logger.debug("Agent rate: {} Hz".format(self._agent_rate))
+        logger.debug("Physics rate: {} Hz".format(self._physics_rate))
+        logger.debug("Simulation RTF: {}".format(self._rtf))
+
+        # Compute the number of physics iteration to execute at every environment step
+        num_of_iterations_per_gazebo_step = self._physics_rate / self._agent_rate
+
+        if num_of_iterations_per_gazebo_step != int(num_of_iterations_per_gazebo_step):
+            logger.warn("Rounding the number of iterations to {} from the nominal {}"
+                        .format(int(num_of_iterations_per_gazebo_step),
+                                num_of_iterations_per_gazebo_step))
+        else:
+            logger.debug("Setting {} iteration per simulator step"
+                         .format(int(num_of_iterations_per_gazebo_step)))
 
         # Create the GazeboWrapper object
-        self._gazebo_wrapper = bindings.GazeboWrapper(self.physics_rate)
+        self._gazebo_wrapper = bindings.GazeboWrapper(
+            int(num_of_iterations_per_gazebo_step),
+            self._rtf,
+            self._physics_rate)
 
         # Set the verbosity
         logger.set_level(gym.logger.MIN_LEVEL)
@@ -117,8 +116,7 @@ class GazeboEnv(gym.Wrapper):
         # Initialize the robot controller plugin
         lib_name = "RobotController"
         class_name = "gympp::plugins::RobotController"
-        wrapper_ok = self._gazebo_wrapper.setupIgnitionPlugin(lib_name, class_name,
-                                                              self.agent_rate)
+        wrapper_ok = self._gazebo_wrapper.setupIgnitionPlugin(lib_name, class_name)
         assert wrapper_ok, "Failed to setup the ignition plugin"
 
         # Initialize the ignition gazebo wrapper

--- a/gym_ignition/gympp/cartpole.py
+++ b/gym_ignition/gympp/cartpole.py
@@ -22,8 +22,12 @@ class CartPoleDiscrete(gympp_env.GymppEnv):
         md.setClassName("gympp::plugins::CartPole")
         md.setWorldFileName("DefaultEmptyWorld.world")
         md.setModelFileName("CartPole/CartPole.sdf")
-        md.setGazeboUpdateRate(1000)      # Rate of physics
-        md.setEnvironmentUpdateRate(1000) # Rate of environment and joint controller
+
+        md.setAgentRate(1000)
+
+        real_time_factor = 1E9
+        max_physics_step_size = 0.001
+        md.setPhysicsData(bindings.PhysicsData(real_time_factor, max_physics_step_size))
 
         # Configure the action space
         action_space_md = bindings.SpaceMetadata()

--- a/gym_ignition/robots/base/factory_robot.py
+++ b/gym_ignition/robots/base/factory_robot.py
@@ -3,8 +3,9 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 from typing import List
-from gym_ignition import gympp_bindings as bindings
 from gym_ignition.base import robot
+from gym_ignition.utils import logger
+from gym_ignition import gympp_bindings as bindings
 
 
 class FactoryRobot(robot.Robot):
@@ -31,6 +32,7 @@ class FactoryRobot(robot.Robot):
         assert self._gympp_robot.valid(), "The Robot object is not valid"
 
         if self._controller_rate:
+            logger.debug("Robot controller rate: {} Hz".format(self._controller_rate))
             ok_dt = self._gympp_robot.setdt(1 / self._controller_rate)
             assert ok_dt, "Failed to set the robot controller period"
 

--- a/gym_ignition/tasks/cartpole_continuous.py
+++ b/gym_ignition/tasks/cartpole_continuous.py
@@ -108,9 +108,9 @@ class CartPoleContinuous(gym_ignition.Task):
             x_dot = observation[1]
 
             reward = reward \
-                     - 0.10 * np.abs(x) \
-                     - 0.10 * np.abs(x_dot) \
-                     - 10.0 * (x == self._x_threshold_reset)
+                - 0.10 * np.abs(x) \
+                - 0.10 * np.abs(x_dot) \
+                - 10.0 * (x >= self._x_threshold_reset)
 
         return reward
 

--- a/gym_ignition/tasks/cartpole_discrete.py
+++ b/gym_ignition/tasks/cartpole_discrete.py
@@ -106,7 +106,10 @@ class CartPoleDiscrete(gym_ignition.Task):
             x_dot = observation[1]
 
             # Update the reward
-            reward = reward - np.abs(x) - np.abs(x_dot) - 10 * (x == self._x_threshold)
+            reward = reward \
+                - np.abs(x) \
+                - np.abs(x_dot) \
+                - 10 * (x >= self._x_threshold)
 
         return reward
 

--- a/ignition/include/gympp/gazebo/GazeboWrapper.h
+++ b/ignition/include/gympp/gazebo/GazeboWrapper.h
@@ -24,6 +24,7 @@
 
 namespace gympp {
     namespace gazebo {
+        struct PhysicsData;
         class GazeboWrapper;
     } // namespace gazebo
 } // namespace gympp
@@ -35,10 +36,12 @@ private:
     std::unique_ptr<Impl, std::function<void(Impl*)>> pImpl;
 
 public:
+    // TODO
     using SdfModelName = std::string;
 
-    GazeboWrapper() = delete;
-    GazeboWrapper(double updateRate);
+    GazeboWrapper(const size_t numOfIterations = 1,
+                  const double desiredRTF = std::numeric_limits<double>::max(),
+                  const double physicsUpdateRate = 1000);
     virtual ~GazeboWrapper();
 
     bool initialize();
@@ -46,17 +49,45 @@ public:
     bool gui();
     bool close();
 
-    double getUpdateRate() const;
-    uint64_t getNumberOfIterations() const;
+    PhysicsData getPhysicsData() const;
 
     static void setVerbosity(int level = DEFAULT_VERBOSITY);
     std::vector<SdfModelName> getModelNames() const;
     bool setupGazeboModel(const std::string& modelFile,
                           std::array<double, 6> pose = {0, 0, 0, 0, 0, 0});
     bool setupGazeboWorld(const std::string& worldFile);
-    bool setupIgnitionPlugin(const std::string& libName,
-                             const std::string& className,
-                             double agentUpdateRate = 0);
+    bool setupIgnitionPlugin(const std::string& libName, const std::string& className);
+};
+
+struct gympp::gazebo::PhysicsData
+{
+    double rtf;
+    double maxStepSize;
+    const double realTimeUpdateRate = -1;
+
+    PhysicsData(double _rtf = 1, double _maxStepSize = 0.001)
+        : rtf(_rtf)
+        , maxStepSize(_maxStepSize)
+    {}
+
+    PhysicsData(const PhysicsData& other)
+        : rtf(other.rtf)
+        , maxStepSize(other.maxStepSize)
+        , realTimeUpdateRate(other.realTimeUpdateRate)
+    {}
+
+    PhysicsData& operator=(const PhysicsData& other)
+    {
+        rtf = other.rtf;
+        maxStepSize = other.maxStepSize;
+        return *this;
+    }
+
+    bool operator==(const PhysicsData& other)
+    {
+        return other.rtf == rtf && other.maxStepSize == maxStepSize
+               && other.realTimeUpdateRate == realTimeUpdateRate;
+    }
 };
 
 #endif // GYMPP_GAZEBO_GAZEBOWRAPPER

--- a/ignition/include/gympp/gazebo/IgnitionEnvironment.h
+++ b/ignition/include/gympp/gazebo/IgnitionEnvironment.h
@@ -46,7 +46,9 @@ public:
     IgnitionEnvironment() = delete;
     IgnitionEnvironment(const ActionSpacePtr aSpace,
                         const ObservationSpacePtr oSpace,
-                        double physicsUpdateRate);
+                        const double agentUpdateRate,
+                        const double realTimeFactor = 1,
+                        const double physicsUpdateRate = 1000);
     ~IgnitionEnvironment() override = default;
 
     bool render(RenderMode mode) override;

--- a/ignition/src/IgnitionRobot.cpp
+++ b/ignition/src/IgnitionRobot.cpp
@@ -442,6 +442,12 @@ bool IgnitionRobot::setJointForce(const gympp::Robot::JointName& jointName, cons
 bool IgnitionRobot::setJointPositionTarget(const gympp::Robot::JointName& jointName,
                                            const double jointPositionReference)
 {
+    // The controller period must have been set in order to set references
+    if (pImpl->dt == std::chrono::duration<double>(0.0)) {
+        gymppError << "The update time of the controlled was not set" << std::endl;
+        return false;
+    }
+
     JointEntity jointEntity = pImpl->getJointEntity(jointName);
     if (jointEntity == ignition::gazebo::kNullEntity) {
         return false;
@@ -470,6 +476,12 @@ bool IgnitionRobot::setJointPositionTarget(const gympp::Robot::JointName& jointN
 bool IgnitionRobot::setJointVelocityTarget(const gympp::Robot::JointName& jointName,
                                            const double jointVelocityReference)
 {
+    // The controller period must have been set in order to set references
+    if (pImpl->dt == std::chrono::duration<double>(0.0)) {
+        gymppError << "The update time of the controlled was not set" << std::endl;
+        return false;
+    }
+
     JointEntity jointEntity = pImpl->getJointEntity(jointName);
     if (jointEntity == ignition::gazebo::kNullEntity) {
         return false;

--- a/plugins/CartPole/CartPolePlugin.cpp
+++ b/plugins/CartPole/CartPolePlugin.cpp
@@ -40,7 +40,6 @@ enum ObservationIndex
     PoleVelocity = 3,
 };
 
-const double DefaultControllerRate = 1000;
 const size_t MaxEpisodeLength = 20000;
 const double XThreshold = 2.4;
 const double ThetaThresholdDeg = 12;
@@ -105,17 +104,6 @@ void CartPole::Configure(const ignition::gazebo::Entity& entity,
     if (!ignRobot->configureECM(entity, sdf, ecm)) {
         gymppError << "Failed to configure the Robot interface" << std::endl;
         return;
-    }
-
-    // Read the optional update_rate option from the sdf
-    if (sdf->HasElement("update_rate")) {
-        double rate = sdf->Get<double>("update_rate");
-        ignRobot->setdt(std::chrono::duration<double>(1 / rate));
-        gymppDebug << "Setting plugin rate " << rate << " Hz" << std::endl;
-    }
-    else {
-        ignRobot->setdt(std::chrono::duration<double>(1 / DefaultControllerRate));
-        gymppDebug << "Setting plugin rate " << DefaultControllerRate << " Hz" << std::endl;
     }
 
     if (!ignRobot->valid()) {

--- a/plugins/GymFactory/CMakeLists.txt
+++ b/plugins/GymFactory/CMakeLists.txt
@@ -12,8 +12,8 @@ add_library(GymFactory
     src/GymFactory.cpp)
 
 target_link_libraries(GymFactory
-    PUBLIC gympp
-    PRIVATE IgnitionEnvironment ignition-gazebo2::core)
+    PUBLIC gympp IgnitionEnvironment
+    PRIVATE ignition-gazebo2::core)
 
 set_target_properties(GymFactory PROPERTIES
     PUBLIC_HEADER

--- a/plugins/GymFactory/include/gympp/Metadata.h
+++ b/plugins/GymFactory/include/gympp/Metadata.h
@@ -11,6 +11,7 @@
 
 #include "gympp/Log.h"
 #include "gympp/Space.h"
+#include "gympp/gazebo/IgnitionEnvironment.h"
 
 #include <string>
 #include <vector>
@@ -105,8 +106,8 @@ private:
     std::string modelFileName;
     std::string worldFileName;
 
-    double gazeboUpdateRate;
-    double environmentUpdateRate;
+    double agentRate;
+    gazebo::PhysicsData physicsData;
 
     SpaceMetadata actionSpace;
     SpaceMetadata observationSpace;
@@ -117,8 +118,8 @@ public:
     inline std::string getClassName() const { return className; }
     inline std::string getModelFileName() const { return modelFileName; }
     inline std::string getWorldFileName() const { return worldFileName; }
-    inline double getGazeboUpdateRate() const { return gazeboUpdateRate; }
-    inline double getEnvironmentUpdateRate() const { return environmentUpdateRate; }
+    inline double getAgentRate() const { return agentRate; }
+    inline gazebo::PhysicsData getPhysicsData() const { return physicsData; }
     inline SpaceMetadata getActionSpaceMetadata() const { return actionSpace; }
     inline SpaceMetadata getObservationSpaceMetadata() const { return observationSpace; }
 
@@ -148,14 +149,11 @@ public:
         this->worldFileName = worldFileName;
     }
 
-    inline void setGazeboUpdateRate(const double gazeboUpdateRate)
-    {
-        this->gazeboUpdateRate = gazeboUpdateRate;
-    }
+    inline void setAgentRate(const double agentRate) { this->agentRate = agentRate; }
 
-    inline void setEnvironmentUpdateRate(const double environmentUpdateRate)
+    inline void setPhysicsData(const gazebo::PhysicsData& physicsData)
     {
-        this->environmentUpdateRate = environmentUpdateRate;
+        this->physicsData = physicsData;
     }
 
     bool isValid() const
@@ -168,8 +166,9 @@ public:
         ok = ok && !worldFileName.empty();
         ok = ok && actionSpace.isValid();
         ok = ok && observationSpace.isValid();
-        ok = ok && (gazeboUpdateRate != 0.0);
-        ok = ok && (environmentUpdateRate != 0.0);
+        ok = ok && physicsData.rtf > 0;
+        ok = ok && physicsData.maxStepSize > 0;
+        ok = ok && agentRate > 0;
         return ok;
     }
 };

--- a/plugins/GymFactory/include/gympp/PluginDatabase.h
+++ b/plugins/GymFactory/include/gympp/PluginDatabase.h
@@ -13,6 +13,7 @@
 #include "gympp/Log.h"
 #include "gympp/Metadata.h"
 #include "gympp/Space.h"
+#include "gympp/gazebo/GazeboWrapper.h"
 
 class GymppPluginRegistrator_CartPole
 {
@@ -47,8 +48,12 @@ public:
         cartPoleMetadata.setActionSpaceMetadata(actionSpaceMetadata);
         cartPoleMetadata.setObservationSpaceMetadata(observationSpaceMetadata);
 
-        cartPoleMetadata.setGazeboUpdateRate(1000);
-        cartPoleMetadata.setEnvironmentUpdateRate(100);
+        gympp::gazebo::PhysicsData physicsData;
+        physicsData.rtf = 1E9;
+        physicsData.maxStepSize = 0.001;
+        cartPoleMetadata.setPhysicsData(physicsData);
+
+        cartPoleMetadata.setAgentRate(1000);
 
         factory->registerPlugin(cartPoleMetadata);
     }

--- a/plugins/GymFactory/src/GymFactory.cpp
+++ b/plugins/GymFactory/src/GymFactory.cpp
@@ -76,8 +76,12 @@ gympp::EnvironmentPtr gympp::GymFactory::make(const std::string& envName)
     }
 
     // Create the environment
-    auto ignGym = std::make_shared<gazebo::IgnitionEnvironment>(
-        actionSpace, observationSpace, md.gazeboUpdateRate);
+    auto ignGym =
+        std::make_shared<gazebo::IgnitionEnvironment>(actionSpace,
+                                                      observationSpace,
+                                                      md.agentRate,
+                                                      md.getPhysicsData().rtf,
+                                                      1 / md.getPhysicsData().maxStepSize);
 
     // Setup the world
     if (!ignGym->setupGazeboWorld(md.worldFileName)) {
@@ -92,7 +96,7 @@ gympp::EnvironmentPtr gympp::GymFactory::make(const std::string& envName)
     }
 
     // Setup the plugin
-    if (!ignGym->setupIgnitionPlugin(md.libraryName, md.className, md.environmentUpdateRate)) {
+    if (!ignGym->setupIgnitionPlugin(md.libraryName, md.className)) {
         gymppError << "Failed to setup the ignition plugin" << std::endl;
         return nullptr;
     }

--- a/plugins/RobotController/RobotController.cpp
+++ b/plugins/RobotController/RobotController.cpp
@@ -25,8 +25,6 @@ using namespace gympp::plugins;
 using ObservationDataType = int;
 using ObservationSample = gympp::BufferContainer<ObservationDataType>::type;
 
-const double DefaultControllerRate = 1000;
-
 class RobotController::Impl
 {
 public:
@@ -58,17 +56,6 @@ void RobotController::Configure(const ignition::gazebo::Entity& entity,
     if (!ignRobot->configureECM(entity, sdf, ecm)) {
         gymppError << "Failed to configure the Robot interface" << std::endl;
         return;
-    }
-
-    // Read the optional update_rate option from the sdf
-    if (sdf->HasElement("update_rate")) {
-        double rate = sdf->Get<double>("update_rate");
-        ignRobot->setdt(std::chrono::duration<double>(1 / rate));
-        gymppDebug << "Setting plugin rate " << rate << " Hz" << std::endl;
-    }
-    else {
-        ignRobot->setdt(std::chrono::duration<double>(1 / DefaultControllerRate));
-        gymppDebug << "Setting plugin rate " << DefaultControllerRate << " Hz" << std::endl;
     }
 
     if (!ignRobot->valid()) {

--- a/tests/python/test_bindings.py
+++ b/tests/python/test_bindings.py
@@ -5,11 +5,17 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 import os
+import gym
 import pytest
 import numpy as np
 from numpy import pi
 from pathlib import Path
+from gym_ignition.utils import logger
 from gym_ignition import gympp_bindings as bindings
+
+# Set verbosity
+logger.set_level(gym.logger.DEBUG)
+
 
 @pytest.fixture
 def create_std_vector():
@@ -130,14 +136,17 @@ def test_metadata():
     md.setWorldFileName(world_name)
     assert md.getWorldFileName() == world_name, "Failed to store the world file name"
 
-    gazebo_rate = 1000.0
-    md.setGazeboUpdateRate(gazebo_rate)
-    assert md.getGazeboUpdateRate() == gazebo_rate, "Failed to store the gazebo update " \
-                                                    "rate"
-    environment_rate = 100.0
-    md.setEnvironmentUpdateRate(environment_rate)
-    assert md.getEnvironmentUpdateRate() == environment_rate, "Failed to store the " \
-                                                              "environment update rate"
+    agent_rate = 1000
+    md.setAgentRate(agent_rate)
+    assert md.getAgentRate() == agent_rate, "Failed to store the agent rate"
+
+    real_time_factor = 1E9
+    max_physics_step_size = 0.001
+    md.setPhysicsData(bindings.PhysicsData(real_time_factor, max_physics_step_size))
+    physics_data = md.getPhysicsData()
+    assert physics_data.rtf == real_time_factor, "Failed to store RTF"
+    assert physics_data.maxStepSize == max_physics_step_size, "Failed to store the " \
+                                                              "max physics step size"
 
 
 def test_gymfactory():
@@ -169,8 +178,8 @@ def test_gymfactory():
     md.setClassName("gympp::plugins::CartPole")
     md.setWorldFileName("DefaultEmptyWorld.world")
     md.setModelFileName("CartPole/CartPole.sdf")
-    md.setGazeboUpdateRate(1000000000)
-    md.setEnvironmentUpdateRate(md.getGazeboUpdateRate() / 10)
+    md.setAgentRate(1000)
+    md.setPhysicsData(bindings.PhysicsData(1.0, 0.001))
     action_space_md = bindings.SpaceMetadata()
     action_space_md.setType(bindings.SpaceType_Discrete)
     action_space_md.setDimensions([2])

--- a/tests/python/test_environments.py
+++ b/tests/python/test_environments.py
@@ -10,8 +10,8 @@ from numpy import pi, sin
 from gym_ignition.utils import logger
 from gym_ignition import gympp_bindings as bindings
 
-# Set gym verbosity
-logger.set_level(gym.logger.WARN)
+# Set verbosity
+logger.set_level(gym.logger.DEBUG)
 
 
 def test_create_cpp_environment():
@@ -60,11 +60,14 @@ def test_joint_controller():
     controller_rate = 500.0
 
     # Create the gazebo wrapper
-    gazebo = bindings.GazeboWrapper(physics_rate)
+    numOfIterations = 10
+    desiredRTF = float(np.finfo(np.float32).max)
+    physicsUpdateRate = 1000.0
+    gazebo = bindings.GazeboWrapper(numOfIterations, desiredRTF, physicsUpdateRate)
     assert gazebo, "Failed to get the gazebo wrapper"
 
-    # Set verbosity
-    logger.set_level(gym.logger.WARN)
+    # Set the verbosity
+    logger.set_level(gym.logger.MIN_LEVEL)
 
     # Initialize the world
     world_ok = gazebo.setupGazeboWorld(world_sdf)
@@ -75,7 +78,7 @@ def test_joint_controller():
     assert model_ok, "Failed to initialize the gazebo model"
 
     # Initialize the plugin
-    wrapper_ok = gazebo.setupIgnitionPlugin(lib_name, class_name, agent_rate)
+    wrapper_ok = gazebo.setupIgnitionPlugin(lib_name, class_name)
     assert wrapper_ok, "Failed to setup the ignition plugin"
 
     # Initialize the ignition gazebo wrapper

--- a/tests/python/test_rates.py
+++ b/tests/python/test_rates.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import gym
+import time
+import pytest
+import itertools
+import numpy as np
+import gym_ignition
+from typing import Tuple
+from gym_ignition.utils import logger
+from gym_ignition import gympp_bindings as bindings
+
+# Set verbosity
+logger.set_level(gym.logger.ERROR)
+
+
+def get_gazebo_and_robot(rtf: float,
+                         physics_rate: float,
+                         agent_rate: float,
+                         controller_rate: float = None,
+                         ) \
+        -> Tuple[bindings.GazeboWrapper, bindings.Robot]:
+
+    lib_name = "RobotController"
+    class_name = "gympp::plugins::RobotController"
+
+    model_sdf = "CartPole/CartPole.sdf"
+    world_sdf = "CartPole.world"
+
+    num_of_iterations_per_gazebo_step = physics_rate / agent_rate
+    assert num_of_iterations_per_gazebo_step == int(num_of_iterations_per_gazebo_step)
+
+    # Create the gazebo wrapper
+    gazebo = bindings.GazeboWrapper(int(num_of_iterations_per_gazebo_step),
+                                    rtf,
+                                    physics_rate)
+    assert gazebo, "Failed to get the gazebo wrapper"
+
+    # Set verbosity
+    logger.set_level(gym.logger.MIN_LEVEL)
+
+    # Initialize the world
+    world_ok = gazebo.setupGazeboWorld(world_sdf)
+    assert world_ok, "Failed to initialize the gazebo world"
+
+    # Initialize the model
+    model_ok = gazebo.setupGazeboModel(model_sdf)
+    assert model_ok, "Failed to initialize the gazebo model"
+
+    # Initialize the plugin
+    wrapper_ok = gazebo.setupIgnitionPlugin(lib_name, class_name)
+    assert wrapper_ok, "Failed to setup the ignition plugin"
+
+    # Initialize the ignition gazebo wrapper
+    gazebo_initialized = gazebo.initialize()
+    assert gazebo_initialized, "Failed to initialize ignition gazebo"
+
+    # Get the robot name
+    model_names = gazebo.getModelNames()
+    assert len(model_names) == 1, "The environment has more than one model"
+    model_name = model_names[0]
+
+    # Get the robot object
+    robot = bindings.RobotSingleton_get().getRobot(model_name)
+    assert robot, "Failed to get the Robot object"
+    assert robot.valid(), "The Robot object is not valid"
+
+    # Set the joint controller period
+    robot.setdt(0.001)
+
+    # Return the simulator and the robot object
+    return gazebo, robot
+
+
+def almost_equal(first, second, epsilon=None) -> bool:
+    if not epsilon:
+        epsilon = first * 0.05
+
+    res = np.abs(first - second) <= epsilon
+
+    if not res:
+        print("----------------")
+        print("ASSERTION FAILED")
+        print("----------------")
+        print("#1={}".format(first))
+        print("#2={}".format(second))
+        print("Error={}".format(np.abs(first-second)))
+        print("Tolerance={}".format(epsilon))
+        print("----------------")
+
+    return res
+
+
+def template_test(rtf: float,
+                  physics_rate: float,
+                  agent_rate: float,
+                  controller_rate: float = None,
+                  ) -> None:
+
+    # Get the simulator and the robot objects
+    gazebo, robot = get_gazebo_and_robot(rtf=rtf,
+                                         physics_rate=physics_rate,
+                                         agent_rate=agent_rate,
+                                         controller_rate=None,  # Does not matter
+                                         )
+
+    # Trajectory specifications
+    trajectory_dt = 1 / agent_rate
+    tot_simulated_seconds = 2
+
+    # Generate the cart trajectory. This is analogous of setting an action containing
+    # the cart references, hence it is related to the agent rate.
+    cart_ref = np.fromiter(
+        (0.2 * np.sin(2 * np.pi * 0.5 * t) for t in np.arange(0, tot_simulated_seconds,
+                                                              trajectory_dt)),
+        dtype=np.float)
+
+    avg_time_per_step = 0.0
+    start = time.time()
+
+    for (i, ref) in enumerate(cart_ref):
+        # Set the references
+        ok_ref = robot.setJointPositionTarget("linear", ref)
+        assert ok_ref, "Failed to set joint references"
+
+        # Step the simulator
+        now = time.time()
+        gazebo.run()
+        this_step = time.time() - now
+        avg_time_per_step = avg_time_per_step + 0.1 * (this_step - avg_time_per_step)
+
+    stop = time.time()
+    elapsed_time = stop - start
+
+    # Compute useful quantities
+    # simulation_dt = 1 / simulation_rate
+    number_of_actions = tot_simulated_seconds / trajectory_dt
+    physics_iterations_per_run = physics_rate / agent_rate
+    simulation_dt = 1 / (physics_rate * rtf)
+
+    assert number_of_actions == cart_ref.size
+
+    print()
+    print("Elapsed time = {}".format(elapsed_time))
+    print("Average step time = {}".format(avg_time_per_step))
+    print("Number of actions: = {}".format(tot_simulated_seconds / trajectory_dt))
+    print("Physics iteration per simulator step = {}".format(physics_iterations_per_run))
+    print()
+
+    # Check if the average time per step matches what expected
+    assert almost_equal(first=avg_time_per_step,
+                        second=simulation_dt * physics_iterations_per_run,
+                        epsilon=avg_time_per_step * 0.5)
+
+    # Check if the total time of the simulation matched what expected
+    assert almost_equal(first=elapsed_time,
+                        second=number_of_actions * simulation_dt * physics_iterations_per_run,
+                        epsilon=elapsed_time * 0.5)
+
+
+def test_rates():
+    # Test matrix
+    rtf_list = [1, 2, 5, 10]
+    agent_rate_list = [100, 1000, 5000]
+    physics_rate_list = [100, 500, 1000, 2000]
+
+    for agent_rate in agent_rate_list:
+
+        # Compute all the combinations of simulation rate and physics rate
+        combinations = list(itertools.product(rtf_list, physics_rate_list))
+
+        for rtf, physics_rate in combinations:
+
+            # This case is not allowed
+            if agent_rate > physics_rate:
+                continue
+
+            print("========")
+            print("Testing:")
+            print("========")
+            print("RTF = {}".format(rtf))
+            print("Agent rate = {}".format(agent_rate))
+            print("Physics rate = {}".format(physics_rate))
+
+            # Test this combination
+            template_test(rtf=rtf,
+                          physics_rate=physics_rate,
+                          controller_rate=None,
+                          agent_rate=agent_rate)


### PR DESCRIPTION
This PR hopefully fixes all the misunderstanding we had about simulation rates in Ignition Gazebo. So far, we wrongly confused the rate of the simulation (how quick gazebo is stepped) and how much the simulated time (physics) advances.

Here below a brief recap about all the rates we currently support.

- **Physics rate:** Its inverse provides the maximum physics step length. E.g. if the rate is set to 1000 Hz (btw, the default):
    - The physics is integrated for 1 millisecond of simulated time
    - All the ignition plugins are stepped only once providing them a physics step of 1 millisecond
- **Joint controller rate:** if the `Task` is controlling the robot sending position / velocity references, low level PID controllers are used. Since the physics might run very fast depending on the wanted simulation accuracy, we need to separate the physics rate wrt the controller rate. The joint controller rate is the rate of change of actuated forces. Forces are kept constant in all the physics steps within a controller period.
- **Agent rate:** This is the rate of execution of the Task, i.e. when the actions are sent and observation are gathered and returned to the agent.
- **Simulator rate:** It is the rate that a single physics step is called. It is unrelated to the simulated time, and if set very high it makes the simulation to run as fast as possible (accelerated). It does not affect the simulation itself, it just accelerates its execution.

![diagram-20190530](https://user-images.githubusercontent.com/469199/58627800-5f9a3800-82d8-11e9-9b43-8b292efd7bc1.png)

From the agent point of view, it might want to set an action, e.g. a joint position reference, at a low rate, let's assume 100 Hz. This is the rate of the agent training loop in python. Then, this reference needs to be actuated. Let's assume the joint controller is running al 500 Hz. This means that the same reference is kept constant for 5 steps of the PID. The PID produces 5 different force outputs which are forwarded to the physic engine (references do not change, but the physics run faster and the position changes). If the physics is running at 1000 Hz, these forces are applied 2 times, i.e. for two iterations.

In this example the ratio `physics rate / agent rate = 10`. This is the number of physics steps executed on each agent new action. Following the example above, within these 10 iterations the real actuated force is kept constant for 2 iterations, after which a new joint position is read and passed to the PID. The PID reference is constant for 10 iterations, but every 2 its state changes because it receives this new position. 

cc @traversaro can you please check if all of this makes sense? I still have to polish the code, please wait some more time before reviewing it.