### PR TITLE
New Runtime abstract base class

### DIFF
--- a/gym_ignition/__init__.py
+++ b/gym_ignition/__init__.py
@@ -42,7 +42,7 @@ register(
 
 register(
     id='CartPoleGymppy-Discrete-v0',
-    entry_point='gym_ignition.base.gazebo_env:GazeboEnv',
+    entry_point='gym_ignition.runtimes.gazebo_runtime:GazeboRuntime',
     max_episode_steps=5000,
     kwargs={'task_cls': cartpole_discrete.CartPoleDiscrete,
             'robot_cls': sim.cartpole.CartPoleRobot,
@@ -55,7 +55,7 @@ register(
 
 register(
     id='CartPoleGymppy-Continuous-v0',
-    entry_point='gym_ignition.base.gazebo_env:GazeboEnv',
+    entry_point='gym_ignition.runtimes.gazebo_runtime:GazeboRuntime',
     max_episode_steps=5000,
     kwargs={'task_cls': cartpole_continuous.CartPoleContinuous,
             'robot_cls': sim.cartpole.CartPoleRobot,

--- a/gym_ignition/base/__init__.py
+++ b/gym_ignition/base/__init__.py
@@ -9,7 +9,6 @@ from gym_ignition.base import runtime
 
 # Base Python environments
 from gym_ignition.base import rt_env
-from gym_ignition.base import gazebo_env
 
 # Base C++ environment
 from gym_ignition.base import gympp_env

--- a/gym_ignition/base/__init__.py
+++ b/gym_ignition/base/__init__.py
@@ -7,8 +7,5 @@ from gym_ignition.base import task
 from gym_ignition.base import robot
 from gym_ignition.base import runtime
 
-# Base Python environments
-from gym_ignition.base import rt_env
-
 # Base C++ environment
 from gym_ignition.base import gympp_env

--- a/gym_ignition/base/__init__.py
+++ b/gym_ignition/base/__init__.py
@@ -5,6 +5,7 @@
 # Abstract classes
 from gym_ignition.base import task
 from gym_ignition.base import robot
+from gym_ignition.base import runtime
 
 # Base Python environments
 from gym_ignition.base import rt_env

--- a/gym_ignition/base/runtime.py
+++ b/gym_ignition/base/runtime.py
@@ -1,0 +1,68 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import abc
+import gym
+from gym_ignition.base.task import Task
+
+
+class Runtime(gym.Wrapper, abc.ABC):
+    """
+    Base class for defining Task runtimes.
+
+    The runtime is the executor of a Task. Tasks are supposed to be generic and are not
+    tied to any specific Runtime. Implementations of the Runtime class contain all the
+    logic to define how to execute the Task, allowing to reuse the same Task class
+    e.g. on different simulators or in a real-time setting.
+
+    Runtime objects are the real environments returned to the users when they use the
+    gym.make factory method. Despite they inherit from gym.Wrapper, they are exposed to
+    the user as gym.Env objects.
+    """
+
+    # Add a spec class variable to make the wrapper look like an environment.
+    # This class variable overrides the gym.Wrapper.spec property and enables registering
+    # runtime objects in the environment factory, despite they inherit from Wrapper.
+    spec = None
+
+    def __init__(self, task: Task, agent_rate: float):
+        # Initialize the gym.Wrapper class
+        super().__init__(env=task)
+
+        # All runtimes provide to the user the nominal rate of their execution
+        self.agent_rate = agent_rate
+        # TODO: should agent rate be the real one with rtf taken into account? Call it
+        #  env_update_rate?
+
+    # Redefine this magic method since the Wrapper.__getattr__ is not compatible with
+    # the usage we want to achieve with Runtime objects. In fact, we want to resolve
+    # attributes in the following order:
+    #
+    # 1. All non-private attributes of the runtime implementation (example: get the
+    #    simulator object).
+    # 2. Get all the non-private attributes of the environment calling the Wrapper's
+    #    getattr implementation.
+    #
+    def __getattr__(self, name):
+        if name in self.__dict__:
+            # Hide private attributes
+            if not name.startswith('_'):
+                return __dict__[name]
+        else:
+            # Call the Wrapper getattr
+            return super().__getattr__(name)
+
+    @property
+    def unwrapped(self):
+        """
+        Expose Runtime objects as real gym.Env objects.
+
+        This method disables the gym.Wrapper logic to returned the wrapped environment.
+        In fact, the wrapped environment is a Task which contains not a implemented
+        gym.Env interface.
+
+        Returns:
+            The gym.Env environment of the Runtime.
+        """
+        return self

--- a/gym_ignition/runtimes/__init__.py
+++ b/gym_ignition/runtimes/__init__.py
@@ -3,3 +3,4 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 from . import gazebo_runtime
+from . import realtime_runtime

--- a/gym_ignition/runtimes/__init__.py
+++ b/gym_ignition/runtimes/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+from . import gazebo_runtime

--- a/gym_ignition/runtimes/gazebo_runtime.py
+++ b/gym_ignition/runtimes/gazebo_runtime.py
@@ -9,7 +9,7 @@ from gym_ignition.base.robot import robot_abc
 from gym_ignition import gympp_bindings as bindings
 
 
-class GazeboEnv(runtime.Runtime):
+class GazeboRuntime(runtime.Runtime):
     metadata = {'render.modes': ['human']}
 
     def __init__(self,

--- a/gym_ignition/runtimes/realtime_runtime.py
+++ b/gym_ignition/runtimes/realtime_runtime.py
@@ -3,14 +3,13 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 import gym
-# from gym_ignition.utils import logger
 from gym_ignition.utils.typing import *
 
 
-class RTEnv(gym.Wrapper):
+class RealTimeRuntime(gym.Wrapper):
     def __init__(self,
                  task: type,
-                 robot : type,
+                 robot: type,
                  agent_rate: float,
                  **kwargs):
         super().__init__(task)


### PR DESCRIPTION
Right now the classes like `GazeboEnv`, that provide the simulator-specific logic, inherit directly from `gym.Wrapper`. Since there are few shared attributes and methods, it makes sense to create a new class `Runtime` which can be inherited.

This PR adds the new `Runtime` class and renames the old `*Env` obtaining the following:

- `GazeboRuntime`
- `RealTimeRuntime` (still dummy)