### PR TITLE
Add PyBullet Runtime

### DIFF
--- a/examples/python/launch_cartpole.py
+++ b/examples/python/launch_cartpole.py
@@ -10,13 +10,17 @@ from gym_ignition.utils import logger
 
 # Set gym verbosity
 logger.set_level(gym.logger.INFO)
-assert(logger.set_level(gym.logger.DEBUG) or True)
+assert logger.set_level(gym.logger.DEBUG) or True
 
 # Create the environment
 # env = gym.make("CartPole-v1")
 # env = gym.make("CartPoleGympp-Discrete-v0")
-# env = gym.make("CartPoleGymppy-Discrete-v0")
-env = gym.make("CartPoleGymppy-Continuous-v0")
+env = gym.make("CartPoleGymppy-Discrete-v0")
+# env = gym.make("CartPoleGymppy-Continuous-v0")
+# env = gym.make("CartPole-PyBullet-Discrete-v0")
+
+# Enable the rendering
+env.render('human')
 
 # Initialize the seed
 env.seed(42)
@@ -35,7 +39,8 @@ for epoch in range(10):
         observation, reward, done, _ = env.step(action)
 
         # Render the environment
-        env.render('human')
+        # It is not required to call this in the loop
+        # env.render('human')
 
         # Accumulate the reward
         totalReward += reward

--- a/gym_ignition/__init__.py
+++ b/gym_ignition/__init__.py
@@ -15,6 +15,7 @@ import gympp_bindings
 # =========================
 
 from gym.envs.registration import register
+from gym_ignition.utils import resource_finder
 
 # Import the robots
 from gym_ignition.robots import rt
@@ -64,4 +65,26 @@ register(
             'rtf': max_float,
             'agent_rate': 1000,
             'physics_rate': 1000,
+            })
+
+# =====================
+# PYBULLET ENVIRONMENTS
+# =====================
+
+# Add the folders specified in IGN_GAZEBO_RESOURCE_PATH to the search path
+resource_finder.add_path_from_env_var("IGN_GAZEBO_RESOURCE_PATH")
+
+register(
+    id='CartPole-PyBullet-Discrete-v0',
+    entry_point='gym_ignition.runtimes.pybullet_runtime:PyBulletRuntime',
+    max_episode_steps=5000,
+    kwargs={
+            # PyBulletRuntime
+            'task_cls': cartpole_discrete.CartPoleDiscrete,
+            'robot_cls': sim.pybullet.cartpole.CartPolePyBulletRobot,
+            'model': "CartPole/CartPole.urdf",
+            'world': "plane_implicit.urdf",
+            'rtf': 1.0,
+            'agent_rate': 250,
+            'physics_rate': 250,
             })

--- a/gym_ignition/base/runtime.py
+++ b/gym_ignition/base/runtime.py
@@ -54,6 +54,10 @@ class Runtime(gym.Wrapper, abc.ABC):
             return super().__getattr__(name)
 
     @property
+    def task(self):
+        return self.env
+
+    @property
     def unwrapped(self):
         """
         Expose Runtime objects as real gym.Env objects.

--- a/gym_ignition/robots/__init__.py
+++ b/gym_ignition/robots/__init__.py
@@ -4,6 +4,7 @@
 
 # Robot implementations
 from gym_ignition.robots.base import factory_robot
+from gym_ignition.robots.base import pybullet_robot
 # from gym_ignition.robots.base import ros_robot
 # from gym_ignition.robots.base import yarp_robot
 # from gym_ignition.robots.base import ignition_transport_robot

--- a/gym_ignition/robots/base/pybullet_robot.py
+++ b/gym_ignition/robots/base/pybullet_robot.py
@@ -1,0 +1,585 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import pybullet
+import numpy as np
+from gym_ignition.base import robot
+from gym_ignition.utils import logger
+from typing import List, Tuple, Dict, Union, NamedTuple
+from gym_ignition.base.robot.robot_joints import JointControlMode
+
+
+class JointControlInfo(NamedTuple):
+    mode: JointControlMode
+    PID: robot.PID = None
+
+
+JointControlMode2PyBullet = {
+    JointControlMode.POSITION: pybullet.PD_CONTROL,
+    JointControlMode.POSITION_INTERPOLATED: None,
+    JointControlMode.VELOCITY: pybullet.PD_CONTROL,
+    JointControlMode.TORQUE: pybullet.TORQUE_CONTROL,
+}
+
+
+class ContactPyBullet(NamedTuple):
+    contactFlag: int
+    bodyUniqueIdA: int
+    bodyUniqueIdB: int
+    linkIndexA: int
+    linkIndexB: int
+    positionOnA: List[float]
+    positionOnB: List[float]
+    contactNormalOnB: List[float]
+    contactDistance: float
+    normalForce: float
+    lateralFriction1: float
+    lateralFrictionDir1: List[float]
+    lateralFriction2: float
+    lateralFrictionDir2: List[float]
+
+
+class JointInfoPyBullet(NamedTuple):
+    jointIndex: int
+    jointName: bytes
+    jointType: int
+    qIndex: int
+    uIndex: int
+    flags: int
+    jointDamping: float
+    jointFriction: float
+    jointLowerLimit: float
+    jointUpperLimit: float
+    jointMaxForce: float
+    jointMaxVelocity: float
+    linkName: bytes
+    jointAxis: List
+    parentFramePos: List
+    parentFrameOrn: List
+    parentIndex: int
+
+
+class PyBulletRobot(robot.robot_abc.RobotABC,
+                    robot.robot_joints.RobotJoints,
+                    robot.robot_contacts.RobotContacts,
+                    robot.robot_baseframe.RobotBaseFrame):
+    """
+    A "class"`Robot` implementation for the PyBullet simulator.
+
+    Args:
+        robot_id: The pybullet ID associated with the robot model
+        p: An instance of the pybullet simulator
+        plane_id: the pybullet ID associated with the plane model. It is used to
+            compute contacts between the robot and the plane.
+    """
+
+    def __init__(self,
+                 robot_id: int,
+                 p: pybullet,
+                 plane_id: int = None,
+                 keep_fixed_joints: bool = False) -> None:
+
+        super().__init__()
+
+        self._pybullet = p
+        self._robot_id = robot_id
+        self._plane_id = plane_id
+        self._keep_fixed_joints = keep_fixed_joints
+
+        # Other private attributes
+        self._links_name2index_dict = None
+        self._joints_name2index_dict = None
+
+        # TODO
+        self._base_frame = None
+        self._base_constraint = None
+        self._initial_joint_positions = None
+
+        # Initialize all joints in position control
+        self._pybullet.setJointMotorControlArray(
+            bodyUniqueId=self._robot_id,
+            jointIndices=range(self.dofs()),
+            controlMode=pybullet.POSITION_CONTROL,
+            targetPositions=self.initial_positions())
+
+        # Create a map from the joint name to its control info
+        self._jointname2jointcontrolinfo = dict()
+
+        # Initialize all the joints in POSITION mode
+        for name in self.joint_names():
+            self._jointname2jointcontrolinfo[name] = JointControlInfo(
+                mode=JointControlMode.POSITION)
+            ok_mode = self.set_joint_control_mode(name, JointControlMode.POSITION)
+            assert ok_mode, \
+                "Failed to initialize the control mode of joint '{}'".format(name)
+
+    # ==============================
+    # PRIVATE METHODS AND PROPERTIES
+    # ==============================
+
+    @property
+    def _joints_name2index(self) -> Dict[str, int]:
+        if self._joints_name2index_dict is not None:
+            return self._joints_name2index_dict
+
+        self._joints_name2index_dict = dict()
+        joints_info = self._get_joints_info()
+
+        for _, info in joints_info.items():
+            joint_idx = info.jointIndex
+            joint_name = info.jointName.decode()
+            self._joints_name2index_dict[joint_name] = joint_idx
+
+        return self._joints_name2index_dict
+
+    @property
+    def _links_name2index(self) -> Dict[str, int]:
+        if self._links_name2index_dict is not None:
+            return self._links_name2index_dict
+
+        self._links_name2index_dict = dict()
+
+        for _, info in self._get_joints_info().items():
+            self._links_name2index_dict[info.linkName.decode()] = info.jointIndex
+
+        return self._links_name2index_dict
+
+    def _get_joints_info(self) -> Dict[str, JointInfoPyBullet]:
+        joints_info = {}
+
+        for j in range(self._pybullet.getNumJoints(self._robot_id)):
+            # Get the joint info from pybullet
+            joint_info_pybullet = self._pybullet.getJointInfo(self._robot_id, j)
+
+            # Store it in a namedtuple
+            joint_info = JointInfoPyBullet._make(joint_info_pybullet)
+
+            # Add the dict entry
+            joints_info[joint_info.jointName.decode()] = joint_info
+
+        return joints_info
+
+    def _get_contact_info(self) -> List[ContactPyBullet]:
+        # Get the all contact points in the simulation
+        pybullet_contacts = self._pybullet.getContactPoints()
+
+        # List containing only the contacts that involve the robot model
+        contacts = []
+
+        # Extract only the robot contacts
+        for pybullet_contact in pybullet_contacts:
+            contact = ContactPyBullet._make(pybullet_contact)
+            contacts.append(contact)
+
+        return contacts
+
+    # =====================
+    # robot.Robot INTERFACE
+    # =====================
+
+    def valid(self) -> bool:
+        # TODO
+        return True
+
+    # ==================================
+    # robot_joints.RobotJoints INTERFACE
+    # ==================================
+
+    def dofs(self) -> int:
+        dofs = len(self.joint_names())
+
+        if self._keep_fixed_joints:
+            assert dofs == self._pybullet.getNumJoints(self._robot_id), \
+                "Number of DoFs does not match with the simulated model"
+
+        return dofs
+
+    def joint_names(self) -> List[str]:
+        joints_names = []
+
+        # Get Joint names
+        for _, info in self._get_joints_info().items():
+            if not self._keep_fixed_joints and info.jointType == pybullet.JOINT_FIXED:
+                continue
+
+            # Strings are byte-encoded. They have to be decoded with UTF-8 (default).
+            joints_names.append(info.jointName.decode())
+
+        return joints_names
+
+    def joint_type(self, joint_name: str) -> robot.robot_joints.JointType:
+        joint_info = self._get_joints_info()[joint_name]
+        joint_type_pybullet = joint_info.jointType
+
+        if joint_type_pybullet == pybullet.JOINT_FIXED:
+            return robot.robot_joints.JointType.FIXED
+        elif joint_type_pybullet == pybullet.JOINT_REVOLUTE:
+            return robot.robot_joints.JointType.REVOLUTE
+        else:
+            raise Exception(
+                "Joint type '{}' not yet supported".format(joint_type_pybullet))
+
+    def joint_control_mode(self, joint_name: str) -> JointControlMode:
+        return self._jointname2jointcontrolinfo[joint_name].mode
+
+    def set_joint_control_mode(self, joint_name: str, mode: JointControlMode) -> bool:
+        # Store the control mode and initialize the PID
+        if mode in {JointControlMode.TORQUE}:
+            pid = None
+            self._jointname2jointcontrolinfo[joint_name] = JointControlInfo(mode=mode)
+        elif mode in {JointControlMode.POSITION, JointControlMode.VELOCITY}:
+            # Initialize a default PID
+            pid = robot.PID(p=1, i=0, d=0)
+            self._jointname2jointcontrolinfo[joint_name] = JointControlInfo(
+                mode=mode, PID=pid)
+        elif mode == JointControlMode.POSITION_INTERPOLATED:
+            raise Exception("Control mode POSITION_INTERPOLATED is not supported")
+        else:
+            raise Exception("Control mode '{}' not recognized".format(mode))
+
+        mode_pybullet = JointControlMode2PyBullet[mode]
+        joint_idx_pybullet = self._joints_name2index[joint_name]
+
+        # Disable the default joint motorization setting a 0 maximum force
+        if mode == JointControlMode.TORQUE:
+            self._pybullet.setJointMotorControl2(
+                bodyIndex=self._robot_id,
+                jointIndex=joint_idx_pybullet,
+                controlMode=pybullet.VELOCITY_CONTROL,
+                force=0)
+
+        # Change the control mode of the joint
+        if mode == JointControlMode.POSITION:
+            self._pybullet.setJointMotorControl2(
+                bodyIndex=self._robot_id,
+                jointIndex=joint_idx_pybullet,
+                controlMode=mode_pybullet,
+                positionGain=pid.p,
+                velocityGain=pid.d)
+        elif mode == JointControlMode.VELOCITY:
+            # TODO: verify that setting the gains in this way processes the reference
+            #  correctly.
+            self._pybullet.setJointMotorControl2(
+                bodyIndex=self._robot_id,
+                jointIndex=joint_idx_pybullet,
+                controlMode=mode_pybullet,
+                positionGain=pid.i,
+                velocityGain=pid.p)
+
+        return True
+
+    def initial_positions(self) -> np.ndarray:
+        return np.zeros(self.dofs())
+
+    def set_initial_positions(self, positions: np.ndarray) -> bool:
+        if positions.size != self.dofs():
+            return False
+
+        self._initial_joint_positions = positions
+        return True
+
+    def joint_position(self, joint_name: str) -> float:
+        joint_idx = self._joints_name2index[joint_name]
+        return self._pybullet.getJointState(self._robot_id, joint_idx)[0]
+
+    def joint_velocity(self, joint_name: str) -> float:
+        joint_idx = self._joints_name2index[joint_name]
+        return self._pybullet.getJointState(self._robot_id, joint_idx)[1]
+
+    def joint_positions(self) -> List[float]:
+        joint_states = self._pybullet.getJointStates(self._robot_id, range(self.dofs()))
+        joint_positions = [state[0] for state in joint_states]
+        return joint_positions
+
+    def joint_velocities(self) -> List[float]:
+        joint_states = self._pybullet.getJointStates(self._robot_id, range(self.dofs()))
+        joint_velocities = [state[1] for state in joint_states]
+        return joint_velocities
+
+    def joint_pid(self, joint_name: str) -> Union[robot.PID, None]:
+        return self._jointname2jointcontrolinfo[joint_name].PID
+
+    def dt(self) -> float:
+        raise NotImplementedError
+
+    def set_dt(self, step_size: float) -> bool:
+        raise NotImplementedError
+
+    def set_joint_force(self, joint_name: str, force: float, clip: bool = False) -> bool:
+
+        if self._jointname2jointcontrolinfo[joint_name].mode != JointControlMode.TORQUE:
+            raise Exception("Joint '{}' is not controlled in TORQUE".format(joint_name))
+
+        joint_idx_pybullet = self._joints_name2index[joint_name]
+        mode_pybullet = JointControlMode2PyBullet[JointControlMode.TORQUE]
+
+        # Clip the force if specified
+        if clip:
+            fmin, fmax = self.joint_force_limit(joint_name)
+            force = fmin if force < fmin else fmax if force > fmax else force
+
+        # Set the joint force
+        self._pybullet.setJointMotorControl2(bodyUniqueId=self._robot_id,
+                                             jointIndex=joint_idx_pybullet,
+                                             controlMode=mode_pybullet,
+                                             force=force)
+
+        return True
+
+    def set_joint_position(self, joint_name: str, position: float) -> bool:
+
+        if self._jointname2jointcontrolinfo[joint_name].mode != JointControlMode.POSITION:
+            raise Exception("Joint '{}' is not controlled in POSITION".format(joint_name))
+
+        pid = self._jointname2jointcontrolinfo[joint_name].PID
+
+        joint_idx_pybullet = self._joints_name2index[joint_name]
+        mode_pybullet = JointControlMode2PyBullet[JointControlMode.POSITION]
+
+        # Change the control mode of the joint
+        self._pybullet.setJointMotorControl2(
+            bodyUniqueId=self._robot_id,
+            jointIndex=joint_idx_pybullet,
+            controlMode=mode_pybullet,
+            targetVelocity=position,
+            positionGain=pid.p,
+            velocityGain=pid.d)
+
+        return True
+
+    def set_joint_velocity(self, joint_name: str, velocity: float) -> bool:
+
+        if self._jointname2jointcontrolinfo[joint_name].mode not in \
+                {JointControlMode.POSITION, JointControlMode.VELOCITY}:
+            raise Exception("Joint '{}' is not controlled in VELOCITY".format(joint_name))
+
+        pid = self._jointname2jointcontrolinfo[joint_name].PID
+
+        joint_idx_pybullet = self._joints_name2index[joint_name]
+        mode_pybullet = JointControlMode2PyBullet[JointControlMode.POSITION]
+
+        # Change the control mode of the joint
+        self._pybullet.setJointMotorControl2(
+            bodyUniqueId=self._robot_id,
+            jointIndex=joint_idx_pybullet,
+            controlMode=mode_pybullet,
+            targetVelocity=velocity,
+            positionGain=pid.p,
+            velocityGain=pid.d)
+
+        return True
+
+    def set_joint_interpolated_position(self, joint_name: str, position: float):
+        return NotImplementedError
+
+    def set_joint_pid(self, joint_name: str, pid: robot.PID) -> bool:
+
+        mode = self._jointname2jointcontrolinfo[joint_name].mode
+        assert mode != JointControlMode.POSITION_INTERPOLATED
+
+        if mode == JointControlMode.TORQUE:
+            logger.warn("Joint '{}' is torque controlled. Setting the PID has no effect"
+                    .format(joint_name))
+            return False
+
+        if mode == JointControlMode.POSITION and pid.i != 0.0:
+            raise Exception("Integral term not supported for POSITION mode")
+        elif mode == JointControlMode.VELOCITY and pid.d != 0.0:
+            raise Exception("Derivative term not supported for VELOCITY mode")
+
+        # Store the new PID
+        self._jointname2jointcontrolinfo[joint_name]._replace(PID=pid)
+
+        # Update the PIDs setting again the control mode
+        ok_mode = self.set_joint_control_mode(joint_name, mode)
+        assert ok_mode, "Failed to set the control mode"
+
+        return True
+
+    def reset_joint(self,
+                    joint_name: str,
+                    position: float = None,
+                    velocity: float = None) -> bool:
+
+        joint_idx_pybullet = self._joints_name2index[joint_name]
+        self._pybullet.resetJointState(bodyUniqueId=self._robot_id,
+                                       jointIndex=joint_idx_pybullet,
+                                       targetValue=position,
+                                       targetVelocity=velocity)
+
+        return True
+
+    def update(self, current_time: float) -> bool:
+        raise NotImplementedError
+
+    def joint_position_limits(self, joint_name: str) -> Tuple[float, float]:
+        # Get Joint info
+        joint_info = self._get_joints_info()[joint_name]
+
+        return joint_info.jointLowerLimit, joint_info.jointUpperLimit
+
+    def joint_force_limit(self, joint_name: str) -> float:
+        # Get Joint info
+        joint_info = self._get_joints_info()[joint_name]
+
+        return joint_info.jointMaxForce
+
+    # =====================================
+    # robot_joints.RobotBaseFrame INTERFACE
+    # =====================================
+
+    def set_base_frame(self, frame_name: str) -> bool:
+        # TODO: check that it exists
+        self._base_frame = frame_name
+        return True
+
+    def base_frame(self) -> str:
+        return self._base_frame
+
+    def base_pose(self) -> Tuple[np.ndarray, np.ndarray]:
+        # Get the values
+        pos, quat = self._pybullet.getBasePositionAndOrientation(self._robot_id)
+
+        # Convert tuples into lists
+        pos = np.array(pos)
+        quat = np.array(quat)
+
+        # PyBullet returns xyzw, the interface instead returns wxyz
+        quat = np.roll(quat, 1)
+
+        return pos, quat
+
+    def base_velocity(self) -> Tuple[np.ndarray, np.ndarray]:
+        # TODO: double check
+        # Get the values
+        lin, ang = self._pybullet.getBaseVelocity(self._robot_id)
+
+        # Convert tuples into lists
+        lin = np.array(lin)
+        ang = np.array(ang)
+
+        return lin, ang
+
+    def reset_base_pose(self,
+                        position: np.ndarray,
+                        orientation: np.ndarray,
+                        floating: bool = False) -> bool:
+
+        assert position.size == 3, "Position should be a list with 3 elements"
+        assert orientation.size == 4, "Orientation should be a list with 4 elements"
+
+        # PyBullet wants xyzw, but the function argument quaternion is wxyz
+        orientation = np.roll(orientation, -1)
+
+        if not floating:
+            # Set a constraint between base_link and world
+            self._base_constraint = self._pybullet.createConstraint(
+                self._robot_id, -1, -1, -1, self._pybullet.JOINT_FIXED,
+                [0, 0, 0], [0, 0, 0], position, orientation)
+        else:
+            self._pybullet.resetBasePositionAndOrientation(
+                self._robot_id, position, orientation)
+
+        return True
+
+    def reset_base_velocity(self,
+                            linear_velocity: np.ndarray,
+                            angular_velocity: np.ndarray) -> bool:
+        raise NotImplementedError
+
+    def base_wrench(self) -> np.ndarray:
+        assert self._base_constraint is not None, "The robot is not fixed base"
+        constraint_wrench = self._pybullet.getConstraintState(self._base_constraint)
+        # print("Constraint State =", constraint_wrench)
+        return np.array(constraint_wrench)
+
+    # =============
+    # RobotContacts
+    # =============
+
+    def links_in_contact(self) -> List[str]:
+        # Get the all contact points in the simulation
+        all_contacts = self._get_contact_info()
+
+        # List containing only the contacts that involve the robot model
+        contacts_robot = []
+
+        # Extract only the robot contacts
+        for contact in all_contacts:
+            if contact.bodyUniqueIdA == self._robot_id or \
+                    contact.bodyUniqueIdB == self._robot_id:
+                contacts_robot.append(contact)
+
+        # List containing the names of the link with active contacts
+        links_in_contact = []
+
+        for contact in contacts_robot:
+            # Link of the link in contact
+            link_idx_in_contact = None
+
+            # Get the index of the link in contact.
+            # The robot body could be either body A or body B.
+            if contact.bodyUniqueIdA == self._robot_id:
+                link_idx_in_contact = contact.linkIndexA
+            elif contact.bodyUniqueIdB == self._robot_id:
+                link_idx_in_contact = contact.linkIndexB
+
+            # Get the link name from the index and add it to the returned list
+            for link_name, link_idx in self._links_name2index.items():
+                if link_idx == link_idx_in_contact:
+                    if link_name not in links_in_contact:
+
+                        # Do not consider the contact if the wrench is (almost) zero
+                        wrench = self.total_contact_wrench_on_link(link_name)
+
+                        if np.linalg.norm(wrench) < 1e-6:
+                            continue
+
+                        # Append the link name to the list of link in contact
+                        links_in_contact.append(link_name)
+
+        return links_in_contact
+
+    def contact_data(self, contact_link_name: str):  # TODO
+        raise NotImplementedError
+
+    def total_contact_wrench_on_link(self, contact_link_name: str) -> np.ndarray:
+        # TODO: finish the implementation of this method
+
+        # Get the all contact points in the simulation
+        all_contacts = self._get_contact_info()
+
+        # List containing only the contacts that involve the robot model
+        contacts_robot = []
+
+        # Extract only the robot contacts
+        for contact in all_contacts:
+            if contact.bodyUniqueIdA == self._robot_id or contact.bodyUniqueIdB == \
+                    self._robot_id:
+                contacts_robot.append(contact)
+
+        contact_link_idx = self._links_name2index[contact_link_name]
+
+        # List containing only the contacts that involve the link
+        contacts_link = []
+
+        for contact in contacts_robot:
+            if contact.bodyUniqueIdA == self._robot_id and \
+                    contact.linkIndexA == contact_link_idx or \
+               contact.bodyUniqueIdB == self._robot_id and \
+                    contact.linkIndexB == contact_link_idx:
+                contacts_link.append(contact)
+
+        total_force = np.zeros(3)
+
+        for contact in contacts_link:
+            # TODO: handle that id could be either body a or b
+            force_1 = contact.normalForce * np.array(contact.contactNormalOnB)
+            force_2 = contact.lateralFriction1 * np.array(contact.lateralFrictionDir1)
+            force_3 = contact.lateralFriction2 * np.array(contact.lateralFrictionDir2)
+
+            # TODO: compose the force transforming it in wrench applied to the link frame
+            total_force += force_1 + force_2 + force_3
+
+        return total_force

--- a/gym_ignition/robots/sim/pybullet/__init__.py
+++ b/gym_ignition/robots/sim/pybullet/__init__.py
@@ -2,10 +2,4 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
-# from gym_ignition.robots.sim import icub
-from gym_ignition.robots.sim import cartpole
-
-# Import the robots
-# TODO: move the other robots in their folder
-# from . import ignition
-from . import pybullet
+from . import cartpole

--- a/gym_ignition/robots/sim/pybullet/__init__.py
+++ b/gym_ignition/robots/sim/pybullet/__init__.py
@@ -2,4 +2,5 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
+from . import icub
 from . import cartpole

--- a/gym_ignition/robots/sim/pybullet/cartpole.py
+++ b/gym_ignition/robots/sim/pybullet/cartpole.py
@@ -1,0 +1,12 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+from gym_ignition.robots import pybullet_robot
+
+
+class CartPolePyBulletRobot(pybullet_robot.PyBulletRobot):
+    def __init__(self, **kwargs):
+        # Initialize base class
+        super().__init__(robot_id=kwargs["robot_id"],
+                         p=kwargs["pybullet"])

--- a/gym_ignition/robots/sim/pybullet/icub.py
+++ b/gym_ignition/robots/sim/pybullet/icub.py
@@ -1,0 +1,17 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+from gym_ignition.robots import pybullet_robot
+
+
+class ICubPyBulletRobot(pybullet_robot.PyBulletRobot):
+    def __init__(self, **kwargs):
+        # Initialize base class
+        super().__init__(robot_id=kwargs["robot_id"],
+                         plane_id=kwargs["plane_id"],
+                         p=kwargs["pybullet"])
+
+        # Set the base frame
+        ok_base_frame = self.set_base_frame("root_link")
+        assert ok_base_frame, "Failed to set base frame"

--- a/gym_ignition/runtimes/__init__.py
+++ b/gym_ignition/runtimes/__init__.py
@@ -4,3 +4,4 @@
 
 from . import gazebo_runtime
 from . import realtime_runtime
+from . import pybullet_runtime

--- a/gym_ignition/runtimes/pybullet_runtime.py
+++ b/gym_ignition/runtimes/pybullet_runtime.py
@@ -1,0 +1,292 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import os
+import time
+import pybullet
+import pybullet_data
+from pybullet_utils import bullet_client
+
+from gym_ignition import base, robots
+from gym_ignition.base import robot
+from gym_ignition.utils import logger, resource_finder
+from gym_ignition.utils.typing import *
+
+
+class PyBulletRuntime(base.runtime.Runtime):
+    metadata = {'render.modes': ['human']}
+
+    def __init__(self,
+                 task_cls: type,
+                 robot_cls: type,
+                 model: str,
+                 rtf: float,
+                 agent_rate: float,
+                 physics_rate: float,
+                 world: str = "plane_implicit.urdf",
+                 **kwargs):
+
+        # Save the keyworded arguments.
+        # We use them to build the task and the robot objects, and allow custom class
+        # to accept user-defined parameters.
+        self._kwargs = kwargs
+
+        # Store the type of the class that provides Robot interface
+        self._robot_cls = robot_cls
+
+        # URDF or SDF model files
+        self._world = world
+        self._model = model
+
+        # Simulation attributes
+        self._rtf = rtf
+        self._now = None
+        self._bias = 0.0
+
+        self._physics_rate = physics_rate
+
+        self._plane_id = None
+        self._pybullet = None
+        self._render_enabled = False
+        self._render_called = False
+
+        # Calculate the rate between agent and physics rate
+        physics_steps_per_agent_update = physics_rate / agent_rate
+        self._num_of_physics_steps = int(physics_steps_per_agent_update)
+
+        assert physics_rate >= agent_rate, "Agent cannot run faster than physics"
+
+        # If there is an incompatibility between the agent and physics rates, round the
+        # iterations and notify the user
+        if physics_steps_per_agent_update != round(physics_steps_per_agent_update):
+            self._num_of_physics_steps = round(physics_steps_per_agent_update)
+            logger.warn("The real physics rate will be {} Hz".format(
+                agent_rate * self._num_of_physics_steps))
+
+        logger.debug("RTF = {}".format(rtf))
+        logger.debug("Agent rate = {} Hz".format(agent_rate))
+        logger.debug("Physics rate = {} Hz".format(
+            agent_rate * self._num_of_physics_steps))
+
+        # Initialize the simulator and the robot
+        robot_object = self._get_robot()
+
+        logger.debug("Initializing the Task")
+        task = task_cls(robot=robot_object, **kwargs)
+
+        assert isinstance(task, base.task.Task), \
+            "'task_cls' object must inherit from Task"
+
+        # Wrap the task with this runtime
+        super().__init__(task=task, agent_rate=agent_rate)
+
+    # =======================
+    # PyBulletRuntime METHODS
+    # =======================
+
+    @property
+    def pybullet(self) -> bullet_client.BulletClient:
+        if self._pybullet is not None:
+            return self._pybullet
+
+        if self._render_enabled:
+            self._pybullet = bullet_client.BulletClient(pybullet.GUI)
+        else:
+            # Connects to an existing instance or, if it fails, creates an headless
+            # simulation (DIRECT)
+            self._pybullet = bullet_client.BulletClient()
+
+        assert self._pybullet, "Failed to create the bullet client"
+
+        # Find the ground plane
+        resource_finder.add_path(pybullet_data.getDataPath())
+        world_abs_path = resource_finder.find_resource(self._world)
+
+        # Load the ground plane
+        self._plane_id = self._load_model(world_abs_path)
+
+        # Configure the physics engine
+        self._pybullet.setGravity(0, 0, -9.81)
+        self._pybullet.setPhysicsEngineParameter(numSolverIterations=10)
+
+        # Configure the physics engine with a single big time step divided in multiple
+        # substeps. As an alternative, we could use a single substep and step the
+        # simulation multiple times.
+        self._pybullet.setTimeStep(1.0 / self._physics_rate / self._num_of_physics_steps)
+        self._pybullet.setPhysicsEngineParameter(numSubSteps=self._num_of_physics_steps)
+
+        # Disable real-time update. We step the simulation when needed.
+        self._pybullet.setRealTimeSimulation(0)
+
+        logger.info("PyBullet Physic Engine Parameters:")
+        logger.info(str(self._pybullet.getPhysicsEngineParameters()))
+
+        step_time = 1.0 / self._physics_rate / self._rtf
+        logger.info("Nominal step time: {} seconds".format(step_time))
+
+        return self._pybullet
+
+    def _get_robot(self) -> robot.robot_abc.RobotABC:
+        if not self.pybullet:
+            raise Exception("Failed to instantiate the pybullet simulator")
+
+        # Find the model file
+        model_abs_path = resource_finder.find_resource(self._model)
+
+        # Load the model
+        robot_id = self._load_model(model_abs_path)
+        assert robot_id is not None, "Failed to load the robot model"
+
+        if not issubclass(self._robot_cls, robots.pybullet_robot.PyBulletRobot):
+            raise Exception("The 'robot_cls' must inherit from PyBulletRobot")
+
+        # Build the robot object
+        logger.debug("Creating the robot object")
+        robot = self._robot_cls(robot_id=robot_id,
+                                plane_id=self._plane_id,
+                                pybullet=self._pybullet,
+                                **self._kwargs)
+
+        return robot
+
+    def _load_model(self, filename: str, **kwargs) -> int:
+        # Get the file extension
+        extension = os.path.splitext(filename)[1][1:]
+
+        if extension == "sdf":
+            model_id = self._pybullet.loadSDF(filename, **kwargs)[0]
+        else:
+            model_id = self._pybullet.loadURDF(
+                filename,
+                flags=pybullet.URDF_USE_INERTIA_FROM_FILE,
+                **kwargs)
+
+        return model_id
+
+    def _enforce_rtf(self):
+        if self._now is not None:
+            # Compute the actual elapsed time from last cycle
+            elapsed = time.time() - self._now
+
+            # Nominal timestep with the desired RTF
+            expected_dt = 1.0 / self.agent_rate / self._rtf
+
+            # Compute the amount of sleep time to match the desired RTF
+            sleep_amount = expected_dt - elapsed - self._bias
+
+            # Sleep if needed
+            real_sleep = 0
+            if sleep_amount > 0:
+                now = time.time()
+                time.sleep(sleep_amount)
+                real_sleep = time.time() - now
+
+            # We use a low-filtered bias to compensate delays due to code running outside
+            # the step method
+            self._bias = \
+                0.01 * (real_sleep - np.max([sleep_amount, 0.0])) +\
+                0.99 * self._bias
+
+        # Update the time for the next cycle
+        self._now = time.time()
+
+    # ===============
+    # gym.Env METHODS
+    # ===============
+
+    def step(self, action: Action) -> State:
+        if not self.action_space.contains(action):
+            logger.warn("The action does not belong to the action space")
+
+        # Set the action
+        ok_action = self.task._set_action(action)
+        assert ok_action, "Failed to set the action"
+
+        # Step the simulator
+        self.pybullet.stepSimulation()
+
+        # Get the observation
+        observation = self.task._get_observation()
+
+        if not self.observation_space.contains(observation):
+            logger.warn("The observation does not belong to the observation space")
+
+        # Get the reward
+        reward = self.task._get_reward()
+        assert reward is not None, "Failed to get the reward"
+
+        # Check termination
+        done = self.task._is_done()
+
+        # Enforce the real-time factor
+        self._enforce_rtf()
+
+        return State((observation, reward, done, {}))
+
+    def reset(self) -> Observation:
+        # Initialize pybullet if not yet done
+
+        p = self.pybullet
+        assert p, "PyBullet object not valid"
+
+        # Reset the environment
+        ok_reset = self.task._reset()
+        assert ok_reset, "Failed to reset the task"
+
+        # Get the observation
+        observation = self.task._get_observation()
+
+        if not self.observation_space.contains(observation):
+            logger.warn("The observation does not belong to the observation space")
+
+        return Observation(observation)
+
+    def render(self, mode: str = 'human', **kwargs) -> None:
+        if mode != "human":
+            raise Exception("Render mode '{}' not yet supported".format(mode))
+
+        # If render has been already called once, and the simulator is ok, return
+        if self._render_enabled and self._pybullet:
+            return
+
+        # Enable rendering
+        self._render_enabled = True
+
+        # If the simulator is already allocated (in DIRECT mode, headless), we have to
+        # disconnect it, starting it in GUI mode, and recreate the robot object.
+        if self._pybullet is not None:
+            logger.warn(
+                "The simulator was allocated in DIRECT mode before calling render. "
+                "The simulation has been reset. All changes to the simulation state "
+                "will be lost.")
+
+            # Disconnect the simulator and deletes the robot object
+            self.close()
+
+            # Create a new simulator and robot object
+            self.task._robot = self._get_robot()
+
+    def close(self) -> None:
+        # Disconnect the simulator
+        self._pybullet = None
+
+        # Delete the outdated robot object.
+        # It was connected to the deleted simulator instance.
+        if self.task._robot:
+            self.task._robot = None
+
+    def seed(self, seed: int = None) -> SeedList:
+        # Tasks in most cases need the robot object to create the spaces.
+        # We initialize it lazily here.
+        if not self.task._robot:
+            self.task.robot = self._get_robot()
+
+        # Seed the wrapped environment (task)
+        seed = self.task.seed(seed)
+
+        # Update the spaces of the wrapper
+        self.action_space = self.task.action_space
+        self.observation_space = self.task.observation_space
+
+        return seed

--- a/gym_ignition/utils/__init__.py
+++ b/gym_ignition/utils/__init__.py
@@ -3,3 +3,4 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 from gym_ignition.utils.typing import *
+from gym_ignition.utils import resource_finder

--- a/gym_ignition/utils/logger.py
+++ b/gym_ignition/utils/logger.py
@@ -1,11 +1,47 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import warnings
 from gym import logger
-from gym.logger import debug, info, warn, error
-from gym_ignition import gympp_bindings as bindings
+from gym.utils import colorize
+from gym.logger import debug, info, error
+
+try:
+    from gym_ignition import gympp_bindings as bindings
+    bindings_found = True
+except:
+    bindings_found = False
 
 
-def set_level(level):
+def custom_formatwarning(msg, *args, **kwargs):
+    print(args)
+    print(kwargs)
+    # raise
+    if logger.MIN_LEVEL is logger.DEBUG:
+        warning = "{}:{} {}: {}\n".format(args[1], args[2], args[0].__name__, msg)
+    else:
+        warning = "{}\n".format(msg)
+
+    return warning
+
+
+def warn(msg: str, *args) -> None:
+    global MIN_LEVEL
+    if logger.MIN_LEVEL <= logger.WARN:
+        warnings.warn(colorize('%s: %s'%('WARN', msg % args), 'yellow'), stacklevel=2)
+
+
+# Monkey patch warning formatting
+warnings.formatwarning = custom_formatwarning
+
+
+def set_level(level: int) -> None:
     # Set the gym verbosity
     logger.set_level(level)
+
+    if not bindings_found:
+        return
 
     # Set the gympp verbosity
     if logger.MIN_LEVEL <= logger.DEBUG:

--- a/gym_ignition/utils/resource_finder.py
+++ b/gym_ignition/utils/resource_finder.py
@@ -1,0 +1,66 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+from os import environ
+from typing import List
+from os.path import exists, isfile
+from gym_ignition.utils import logger
+
+GYM_IGNITION_DATA_PATH = []
+
+
+def get_search_paths() -> List[str]:
+    global GYM_IGNITION_DATA_PATH
+    return GYM_IGNITION_DATA_PATH
+
+
+def add_path(data_path: str) -> None:
+    if not exists(data_path):
+        logger.warn("The path '{}' does not exist. Not added to the data path.".format(
+            data_path))
+        return
+
+    global GYM_IGNITION_DATA_PATH
+
+    for path in GYM_IGNITION_DATA_PATH:
+        if path == data_path:
+            logger.debug("The path '{}' is already present in the data path".format(
+                data_path))
+            return
+
+    logger.debug("Adding new search path: '{}'".format(data_path))
+    GYM_IGNITION_DATA_PATH.append(data_path)
+
+
+def add_path_from_env_var(env_variable: str) -> None:
+    if not env_variable in environ:
+        logger.warn("Failed to find '{}' environment variable".format(env_variable))
+        return
+
+    env_var_paths = environ[env_variable].split(":")
+
+    for path in env_var_paths:
+        add_path(path)
+
+
+def find_resource(file_name: str) -> str:
+    file_abs_path = ""
+    global GYM_IGNITION_DATA_PATH
+
+    logger.debug("Looking for file '{}'".format(file_name))
+
+    for path in GYM_IGNITION_DATA_PATH:
+        logger.debug("  Exploring folder '{}'".format(path))
+        path_with_slash = path if path[-1] is '/' else path + "/"
+        candidate_abs_path = path_with_slash + file_name
+
+        if isfile(candidate_abs_path):
+            logger.debug("  Found resource: '{}'".format(candidate_abs_path))
+            file_abs_path = candidate_abs_path
+            break
+
+    if not file_abs_path:
+        raise Exception("Failed to find resource '{}'".format(file_name))
+
+    return file_abs_path

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@
 
 from setuptools import setup, find_packages
 
+icub_model_zip = "https://github.com/diegoferigo/icub-model-pybullet/archive/master.zip"
+
 setup(name='gym_ignition',
       version='0.1',
       author="Diego Ferigo",
@@ -18,6 +20,7 @@ setup(name='gym_ignition',
       install_requires=[
             'gym >= 0.13.1',
             'numpy',
+            'icub-model-pybullet @ {}'.format(icub_model_zip),
       ],
       packages=find_packages(),
       )

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(name='gym_ignition',
       install_requires=[
             'gym >= 0.13.1',
             'numpy',
+            'pybullet',
             'icub-model-pybullet @ {}'.format(icub_model_zip),
       ],
       packages=find_packages(),

--- a/tests/python/test_rates.py
+++ b/tests/python/test_rates.py
@@ -6,7 +6,6 @@
 
 import gym
 import time
-import pytest
 import itertools
 import numpy as np
 import gym_ignition
@@ -164,8 +163,8 @@ def template_test(rtf: float,
 
 def test_rates():
     # Test matrix
-    rtf_list = [1, 2, 5, 10]
-    agent_rate_list = [100, 1000, 5000]
+    rtf_list = [0.5, 1, 2, 5, 10]
+    agent_rate_list = [100, 1000]
     physics_rate_list = [100, 500, 1000, 2000]
 
     for agent_rate in agent_rate_list:
@@ -174,6 +173,10 @@ def test_rates():
         combinations = list(itertools.product(rtf_list, physics_rate_list))
 
         for rtf, physics_rate in combinations:
+
+            # Remove some combination too demanding for a single process
+            if physics_rate * rtf >= 5000:
+                continue
 
             # This case is not allowed
             if agent_rate > physics_rate:


### PR DESCRIPTION
This PR adds a new simulated runtime that exploits pybullet, the python bindings around [bulletphysics/bullet3](https://github.com/bulletphysics/bullet3). Closes #35.

The existing Tasks can be used also on this runtime. A new `PyBulletRobot` class implements all the interfaces to get data from a simulated model.

![pybullet](https://user-images.githubusercontent.com/469199/65797298-2501b880-e16f-11e9-9796-49444ab3ffe4.png)

