### PR TITLE
Automatically add the data path in the resource finder if pip installed

### DIFF
--- a/gym_ignition/utils/__init__.py
+++ b/gym_ignition/utils/__init__.py
@@ -4,3 +4,13 @@
 
 from .typing import *
 from . import resource_finder
+
+# If not installed in editable mode, insert gym_ignition_data path to the search path
+try:
+    import gym_ignition_data
+    resource_finder.add_path(gym_ignition_data.get_data_path())
+    resource_finder.add_path(gym_ignition_data.get_data_path() + "/worlds")
+except ModuleNotFoundError:
+    pass
+
+import contextlib


### PR DESCRIPTION
In order to let python code find resources, we need somewhere to add `IGN_GAZEBO_RESOURCE_PATH` to the resource finder. This PR adds the support of loading this path when the resource finder is imported with:

```python
from gym_ignition.utils import resource_finder
```

Note that if the variable is exported in the environment, the C++ code is already fine.