### PR TITLE
Automatically set environment variable in Python applications

### DIFF
--- a/.docker/Dockerfile.ci
+++ b/.docker/Dockerfile.ci
@@ -95,19 +95,11 @@ ENV PYTHONPATH=${PYTHONPATH}:/usr/local/lib/python3/dist-packages
 
 # Setup gym-ignition if installed from source
 ARG install_prefix="/usr/local"
-ENV IGN_GAZEBO_SYSTEM_PLUGIN_PATH="${install_prefix}/lib/gympp/plugins"
-ENV IGN_GAZEBO_RESOURCE_PATH="${install_prefix}/share/gympp/gazebo/worlds:${install_prefix}/share/gympp/gazebo/models"
-ENV SDF_PATH="${install_prefix}/share/gympp/gazebo/models"
 ENV PYTHONPATH="${PYTHONPATH}:${install_prefix}/lib/python3.6/site-packages:${install_prefix}/lib/python3.7/site-packages"
 
 # Prepare virtualenv variables
 ENV VIRTUAL_ENV=/venv
 ENV PATH=${VIRTUAL_ENV}/bin:${PATH}
-
-# Setup gym-ignition if installed from pip
-ARG site_pkgs="${VIRTUAL_ENV}/lib/python3.6/site-packages"
-ENV IGN_GAZEBO_SYSTEM_PLUGIN_PATH="${IGN_GAZEBO_SYSTEM_PLUGIN_PATH}:${site_pkgs}/gym_ignition/plugins"
-ENV IGN_GAZEBO_RESOURCE_PATH="${IGN_GAZEBO_RESOURCE_PATH}:${site_pkgs}/gym_ignition_data:${site_pkgs}/gym_ignition_data/worlds"
 
 COPY entrypoint.sh /entrypoint.sh
 COPY setup_virtualenv.sh /setup_virtualenv.sh

--- a/README.md
+++ b/README.md
@@ -126,16 +126,6 @@ The process is different whether you're an _user_ that wants to create environme
 
 1. Install the Ignition Robotics suite following the [official documentation](https://ignitionrobotics.org/docs/latest/install)
 1. Install Gym-Ignition with `pip install gym-ignition` (preferably in a [virtual environment](https://docs.python.org/3.6/tutorial/venv.html))
-1. Execute the following to export the required environment variables:
-   ```sh
-   # Worlds and models path
-   data_path=$(python -c "import gym_ignition_data ; (gym_ignition_data.__path__[0])")
-   export IGN_GAZEBO_RESOURCE_PATH=${data_path}:${data_path}/worlds
-   
-   # Gazebo plugins
-   module_path=$(python -c "import gym_ignition ; print(gym_ignition.__path__[0])" | grep gym_ignition)
-   export IGN_GAZEBO_SYSTEM_PLUGIN_PATH=${module_path}/plugins
-   ```
 
 After these steps, you should be able to execute the example [`launch_cartpole.py`](examples/python/launch_cartpole.py).
 
@@ -156,14 +146,8 @@ After these steps, you should be able to execute the example [`launch_cartpole.p
    ```sh
    pip3 install -e .
    ```
-1. Export the following environment variables:
+1. Export the following environment variable:
    ```sh
-   # Worlds and models path
-   export IGN_GAZEBO_RESOURCE_PATH=<installprefix>/share/gympp/gazebo/worlds:<installprefix>/share/gympp/gazebo/models
-   
-   # Gazebo plugins
-   export IGN_GAZEBO_SYSTEM_PLUGIN_PATH=<installprefix>/lib/gympp/plugins
-   
    # C++ bindings
    export PYTHONPATH=<installprefix>/lib/python3.6/site-packages
    ```

--- a/gym_ignition/__init__.py
+++ b/gym_ignition/__init__.py
@@ -10,6 +10,11 @@ if sys.platform.startswith('linux') or sys.platform.startswith('darwin'):
     sys.setdlopenflags(sys.getdlopenflags() | ctypes.RTLD_GLOBAL)
 import gympp_bindings
 
+# Configure OS environment variables
+from gym_ignition.utils import gazebo_env_vars, resource_finder
+gazebo_env_vars.setup_gazebo_env_vars()
+resource_finder.add_path_from_env_var("IGN_GAZEBO_RESOURCE_PATH")
+
 # =========================
 # REGISTER THE ENVIRONMENTS
 # =========================
@@ -87,9 +92,6 @@ register(
 # =====================
 # PYBULLET ENVIRONMENTS
 # =====================
-
-# Add the folders specified in IGN_GAZEBO_RESOURCE_PATH to the search path
-resource_finder.add_path_from_env_var("IGN_GAZEBO_RESOURCE_PATH")
 
 register(
     id='Pendulum-PyBullet-v0',

--- a/gym_ignition/utils/__init__.py
+++ b/gym_ignition/utils/__init__.py
@@ -3,14 +3,6 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 from .typing import *
+from . import misc
 from . import resource_finder
-
-# If not installed in editable mode, insert gym_ignition_data path to the search path
-try:
-    import gym_ignition_data
-    resource_finder.add_path(gym_ignition_data.get_data_path())
-    resource_finder.add_path(gym_ignition_data.get_data_path() + "/worlds")
-except ModuleNotFoundError:
-    pass
-
-import contextlib
+from . import gazebo_env_vars

--- a/gym_ignition/utils/gazebo_env_vars.py
+++ b/gym_ignition/utils/gazebo_env_vars.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import os
+from pathlib import Path
+from gym_ignition.utils import logger, misc
+
+
+def setup_gazebo_env_vars() -> None:
+    # Configure the environment
+    ign_gazebo_resource_path = os.environ.get("IGN_GAZEBO_RESOURCE_PATH")
+    ign_gazebo_system_plugin_path = os.environ.get("IGN_GAZEBO_SYSTEM_PLUGIN_PATH")
+
+    if not ign_gazebo_resource_path:
+        ign_gazebo_resource_path = ""
+
+    if not ign_gazebo_system_plugin_path:
+        ign_gazebo_system_plugin_path = ""
+
+    if misc.installed_in_editable_mode():
+        # Detect the install prefix
+        import gympp_bindings
+        site_packages_path = Path(gympp_bindings.__file__).parent
+        install_prefix = site_packages_path.parent.parent.parent
+        logger.debug(f"Detected install prefix: '{install_prefix}'")
+
+        # Add the plugins path
+        ign_gazebo_system_plugin_path += f":{install_prefix}/lib/gympp/plugins"
+
+        # Add the worlds and models path
+        ign_gazebo_resource_path += f":{install_prefix}/share/gympp/gazebo/worlds"
+        ign_gazebo_resource_path += f":{install_prefix}/share/gympp/gazebo/models"
+    else:
+        # Add the plugins path
+        import gym_ignition
+        ign_gazebo_system_plugin_path += f":{gym_ignition.__path__[0]}/plugins"
+
+        # Add the worlds and models path
+        import gym_ignition_data
+        data_path = gym_ignition_data.__path__[0]
+        ign_gazebo_resource_path += f":{data_path}:/{data_path}/worlds"
+
+    os.environ["IGN_GAZEBO_RESOURCE_PATH"] = ign_gazebo_resource_path
+    os.environ["IGN_GAZEBO_SYSTEM_PLUGIN_PATH"] = ign_gazebo_system_plugin_path
+    logger.debug(f"IGN_GAZEBO_RESOURCE_PATH={ign_gazebo_resource_path}")
+    logger.debug(f"IGN_GAZEBO_SYSTEM_PLUGIN_PATH={ign_gazebo_system_plugin_path}")

--- a/gym_ignition/utils/misc.py
+++ b/gym_ignition/utils/misc.py
@@ -1,0 +1,12 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+
+def installed_in_editable_mode() -> bool:
+    # Note: the editable mode detection mechanism can be improved
+    import gym_ignition
+    import gympp_bindings
+    from pathlib import Path
+    return \
+        Path(gympp_bindings.__file__).parent != Path(gym_ignition.__file__).parent.parent

--- a/gym_ignition/utils/resource_finder.py
+++ b/gym_ignition/utils/resource_finder.py
@@ -17,28 +17,34 @@ def get_search_paths() -> List[str]:
 
 def add_path(data_path: str) -> None:
     if not exists(data_path):
-        logger.warn("The path '{}' does not exist. Not added to the data path.".format(
-            data_path))
+        logger.warn(f"The path '{data_path}' does not exist. Not added to the data path.")
         return
 
     global GYM_IGNITION_DATA_PATH
 
     for path in GYM_IGNITION_DATA_PATH:
         if path == data_path:
-            logger.debug("The path '{}' is already present in the data path".format(
-                data_path))
+            logger.debug(f"The path '{data_path}' is already present in the data path")
             return
 
-    logger.debug("Adding new search path: '{}'".format(data_path))
+    logger.debug(f"Adding new search path: '{data_path}'")
     GYM_IGNITION_DATA_PATH.append(data_path)
 
 
 def add_path_from_env_var(env_variable: str) -> None:
     if env_variable not in os.environ:
-        logger.warn("Failed to find '{}' environment variable".format(env_variable))
+        logger.warn(f"Failed to find '{env_variable}' environment variable")
         return
 
-    env_var_paths = os.environ[env_variable].split(":")
+    # Get the environment variable
+    env_var_content = os.environ[env_variable]
+
+    # Remove leading ':' characters
+    if env_var_content[0] == ':':
+        env_var_content = env_var_content[1:]
+
+    # Split multiple value
+    env_var_paths = env_var_content.split(":")
 
     for path in env_var_paths:
         add_path(path)
@@ -48,28 +54,28 @@ def find_resource(file_name: str) -> str:
     file_abs_path = ""
     global GYM_IGNITION_DATA_PATH
 
-    logger.debug("Looking for file '{}'".format(file_name))
+    logger.debug(f"Looking for file '{file_name}'")
 
     # Handle if the path is absolute
     if os.path.isabs(file_name):
         if isfile(file_name):
-            logger.debug("  Found resource: '{}'".format(file_name))
+            logger.debug(f"  Found resource: '{file_name}'")
             return file_name
         else:
-            raise Exception("Failed to find resource '{}'".format(file_name))
+            raise Exception(f"Failed to find resource '{file_name}'")
 
     # Handle if the path is relative
     for path in GYM_IGNITION_DATA_PATH:
-        logger.debug("  Exploring folder '{}'".format(path))
+        logger.debug(f"  Exploring folder '{path}'")
         path_with_slash = path if path[-1] == '/' else path + "/"
         candidate_abs_path = path_with_slash + file_name
 
         if isfile(candidate_abs_path):
-            logger.debug("  Found resource: '{}'".format(candidate_abs_path))
+            logger.debug(f"  Found resource: '{candidate_abs_path}'")
             file_abs_path = candidate_abs_path
             break
 
     if not file_abs_path:
-        raise Exception("Failed to find resource '{}'".format(file_name))
+        raise Exception(f"Failed to find resource '{file_name}'")
 
     return file_abs_path


### PR DESCRIPTION
This PR removes the need to configure environment variables, simplifying the configuration of the system.

Note that the Gazebo-related variables are still needed for the experimental `gympp` C++ component. In this case, some CMake logic might be used to automatically add the right installed folders to the resources search path. It will be implemented though in another PR.

cc @traversaro 