### PR TITLE
Improve CI/CD pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ on:
   pull_request:
 
 jobs:
-  ubuntu:
-    name: Ubuntu
+  developer:
+    name: Developer installation
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -72,3 +72,47 @@ jobs:
           docker exec -i ci sh -c 'pip3 install colour-valgrind'
           docker exec -i ci sh -c 'valgrind --log-file=/tmp/valgrind pytest tests/python'
           docker exec -i ci sh -c 'colour-valgrind -t /tmp/valgrind'
+
+  user:
+    name: User installation
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python:
+          - 3.6
+        os:
+          - ubuntu-18.04
+    container:
+      image: diegoferigo/gym-ignition:ci
+      env:
+        PYTHON_VERSION: ${{ matrix.python }}
+
+    steps:
+      - uses: actions/checkout@master
+
+      # The entrypoint is not called because it is overridden by GH Actions.
+      # Even using the 'jobs.<job_id>.container.options' does not work because the
+      # entrypoint of GH Actions overrides the one passed through YAML.
+      - name: Execute entrypoint
+        run: . /entrypoint.sh
+
+      - name: Create wheel
+        run: python setup.py bdist_wheel
+
+      - name: Install local wheel
+        run: |
+          cd dist
+          pip install -v *.whl
+
+      - name: Python Tests
+        run: |
+          cd tests/python
+          pytest -v
+
+      - name: Python Tests with Valgrind
+        if: failure()
+        run: |
+          pip3 install colour-valgrind
+          cd tests/python
+          valgrind --log-file=/tmp/valgrind.log pytest -v -s
+          colour-valgrind -t /tmp/valgrind.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,23 +10,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python:
-          - 3.6
-          # - 3.7
-        compiler:
-          - gcc7
-          # - gcc8
-          # - clang
-          # - clang8
-        build_type:
-          # - Release
-          - Debug
+        python: [3.6]
+        build_type: [Debug]
+        compiler: [gcc7]
+    container:
+      image: diegoferigo/gym-ignition:ci
+      env:
+        PYTHON_VERSION: ${{ matrix.python }}
 
     steps:
       - uses: actions/checkout@master
 
-      # Workaround to export environment variables that persist in next steps
-      # https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+      # The entrypoint is not called because it is overridden by GH Actions.
+      # Even using the 'jobs.<job_id>.container.options' does not work because the
+      # entrypoint of GH Actions overrides the one passed through YAML.
+      - name: Execute entrypoint
+        run: . /entrypoint.sh
+
+#      # Workaround to export environment variables that persist in next steps
+#      # https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
       - name: Setup Environment
         run: |
           case ${{ matrix.compiler }} in
@@ -41,37 +43,32 @@ jobs:
           echo "::set-env name=PYTHON_VERSION::${{ matrix.python }}"
           env
 
-      - name: Pull CI Docker Image
-        run: 'docker pull diegoferigo/gym-ignition:ci'
-
       - name: Build and Install C++
         run: |
-          set -u
-          docker run \
-            -d -i --name ci -v $(pwd):/github -w /github \
-            -e PYTHON_VERSION=$PYTHON_VERSION -e CC=$CC -e CXX=$CXX \
-            diegoferigo/gym-ignition:ci bash
-          docker exec -i ci sh -c 'mkdir -p build'
-          docker exec -i ci sh -c \
-            'cd build &&\
-             cmake .. \
-                 -GNinja \
-                 -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-                 -DPython_ADDITIONAL_VERSIONS=$PYTHON_VERSION'
-          docker exec -i ci sh -c 'cmake --build build --target install'
+          env
+          mkdir -p build
+          cd build
+          cmake .. \
+            -GNinja \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DPython_ADDITIONAL_VERSIONS=$PYTHON_VERSION
+          cmake --build . --target install
 
       - name: Setup Python Package
-        run: docker exec -i ci sh -c 'pip3 install -e .'
+        run: pip3 install -e .
 
       - name: Python Tests
-        run: docker exec -i ci sh -c 'pytest tests/python'
+        run: |
+          cd tests/python
+          pytest -v
 
       - name: Python Tests with Valgrind
         if: failure()
         run: |
-          docker exec -i ci sh -c 'pip3 install colour-valgrind'
-          docker exec -i ci sh -c 'valgrind --log-file=/tmp/valgrind pytest tests/python'
-          docker exec -i ci sh -c 'colour-valgrind -t /tmp/valgrind'
+          pip3 install colour-valgrind
+          cd tests/python
+          valgrind --log-file=/tmp/valgrind.log pytest -v -s
+          colour-valgrind -t /tmp/valgrind.log
 
   user:
     name: User installation

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -57,23 +57,31 @@ jobs:
       - name: Create package
         run: python setup.py sdist
 
-      - name: Install and test
-        run: |
-          cd dist
-          pip install $(find . -name gym-ignition-*.zip -o -name gym-ignition-*.gz)
-          cd ../tests/python
-          module_path=$(python -c "import gym_ignition ; print(gym_ignition.__path__[0])" | grep gym_ignition)
-          export IGN_GAZEBO_SYSTEM_PLUGIN_PATH=${module_path}/plugins
-          data_path=$(python -c "import gym_ignition_data ; print(gym_ignition_data.__path__[0])")
-          export IGN_GAZEBO_RESOURCE_PATH=${data_path}:${data_path}/worlds
-          pytest
-
-      - name: Install twine
-        if: github.event.action == 'published'
+      - name: Install Twine
         run: pip install twine
 
-      - name: Push to PyPI
-        if: github.event.action == 'published'
+      - name: TestPyPI Upload
+        run: |
+          twine upload --verbose --repository-url https://test.pypi.org/legacy/ dist/*
+          sleep 15
+        env:
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME_TESTPYPI }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD_TESTPYPI }}
+
+      - name: Install and test
+        run: |
+          cd tests/python
+          RELEASE_TAG=$(git describe --abbrev=0 --tags)
+          pip install \
+            --index-url https://test.pypi.org/simple/ \
+            --extra-index-url https://pypi.org/simple \
+            gym-ignition==$RELEASE_TAG
+          pytest -v
+
+      - name: PyPI Release
+        if: |
+          github.event.action == 'published' &&
+          github.repository == 'robotology/gym-ignition'
         run: twine upload --verbose dist/*
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
@@ -149,11 +157,13 @@ jobs:
           docker exec -i -w /github/dist pypi \
             sh -c 'find -type f -name "*.whl" -exec rename.ul linux manylinux1 {} +'
 
-      - name: Install twine
+      - name: Install Twine
         run: pip install twine
 
-      - name: Upload it to Test PiPY
-        run: twine upload --verbose --repository-url https://test.pypi.org/legacy/ dist/*
+      - name: TestPyPI Upload
+        run: |
+          twine upload --verbose --repository-url https://test.pypi.org/legacy/ dist/*
+          sleep 15
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME_TESTPYPI }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD_TESTPYPI }}
@@ -174,10 +184,12 @@ jobs:
               --extra-index-url https://pypi.org/simple \
               gym-ignition==$RELEASE_TAG'
           docker exec -i test sh -c "git clone https://github.com/robotology/gym-ignition"
-          docker exec -i test sh -c "cd gym-ignition/tests/python && pytest"
+          docker exec -i test sh -c "cd gym-ignition/tests/python && pytest -v"
 
-      - name: Push to PyPI
-        if: github.event.action == 'published'
+      - name: PyPI Release
+        if: |
+          github.event.action == 'published' &&
+          github.repository == 'robotology/gym-ignition'
         run: twine upload --verbose dist/*
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}


### PR DESCRIPTION
### PyPI CD Pipeline

- Pass through TestPyPI also for `sdist` packaging.
- Add a sleep in between pushing to TestPyPI and downloading the package. This is needed because apparently the backend need few seconds to process the operation and our CI tries to download the new version too soon.
- Remove the need to set environment variables (depends on #71).

### CI Pipeline

- Beyond running the checks on the commit under test in a editable environment (Developer setup), also package and install a local wheel and run the test in a configuration more similar to the User setup.
- Refactor the Developer setup test to run directly in the `gym-ignition:ci` container instead of starting in with docker in a dedicated step.