### PR TITLE
Fix Python tests

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           VERSION=$(python setup.py --version)
           cd tests/python
-          pip install \
+          pip install --pre \
             --index-url https://test.pypi.org/simple/ \
             --extra-index-url https://pypi.org/simple \
             $PACKAGE_NAME==$VERSION
@@ -217,7 +217,7 @@ jobs:
             -e PACKAGE_VERSION=$PACKAGE_VERSION \
             -e PACKAGE_NAME=$PACKAGE_NAME \
             test sh -c \
-            'pip install \
+            'pip install --pre \
               --index-url https://test.pypi.org/simple/ \
               --extra-index-url https://pypi.org/simple \
               $PACKAGE_NAME==$PACKAGE_VERSION'

--- a/tests/python/test_environments_gazebowrapper.py
+++ b/tests/python/test_environments_gazebowrapper.py
@@ -4,7 +4,6 @@
 
 import gym
 import pytest
-from multiprocessing import Process
 from gym_ignition.utils import logger
 
 # Set verbosity
@@ -32,9 +31,6 @@ def template_run_environment(env_name):
 
 @pytest.mark.parametrize("env_name",
                          ["CartPoleDiscrete-Gazebo-v0",
-                          "CartPoleContinuous-Gazebo--v0"])
+                          "CartPoleContinuous-Gazebo-v0"])
 def test_environment(env_name: str):
-    args = (env_name)
-    p = Process(target=template_run_environment, args=args)
-    p.start()
-    p.join()
+    template_run_environment(env_name)

--- a/tests/python/test_pendulum_wrt_ground_truth.py
+++ b/tests/python/test_pendulum_wrt_ground_truth.py
@@ -6,7 +6,6 @@ import gym
 import pytest
 import numpy as np
 from gym.envs import registry
-from multiprocessing import Process
 from gym_ignition.utils import logger
 from gym.envs.registration import register
 from gym_ignition.robots.sim import gazebo, pybullet
@@ -90,7 +89,7 @@ if "Pendulum-Ignition-PyTest-v0" not in [spec.id for spec in list(registry.all()
         max_episode_steps=1000,
         kwargs={'task_cls': PendulumSwingUp,
                 'robot_cls': gazebo.pendulum.PendulumGazeboRobot,
-                'sdf': "Pendulum/Pendulum.sdf",
+                'model': "Pendulum/Pendulum.sdf",
                 'world': "DefaultEmptyWorld.world",
                 'rtf': 100,
                 'agent_rate': 4000,
@@ -176,7 +175,4 @@ def template_pendulum_wrt_ground_truth(env_name: str, max_error_in_deg: float):
                           ("Pendulum-PyBullet-PyTest-v0", 3.0),
                           ])
 def test_pendulum_ignition(env_name: str, max_error_in_deg: float):
-    args = (env_name, max_error_in_deg)
-    p = Process(target=template_pendulum_wrt_ground_truth, args=args)
-    p.start()
-    p.join()
+    template_pendulum_wrt_ground_truth(env_name, max_error_in_deg)

--- a/tests/python/test_rates.py
+++ b/tests/python/test_rates.py
@@ -11,7 +11,6 @@ import itertools
 import numpy as np
 import gym_ignition
 from typing import List, Tuple
-from multiprocessing import Process
 from gym_ignition import gympp_bindings as bindings
 from gym_ignition.utils import logger, resource_finder
 
@@ -195,8 +194,8 @@ def template_test(rtf: float,
 
 def create_test_matrix() -> List[Tuple]:
     rtf_list = [0.5, 1, 2, 5, 10]
-    agent_rate_list = [100, 1000]
-    physics_rate_list = [100, 500, 1000, 2000]
+    agent_rate_list = [100, 500, 1000]
+    physics_rate_list = [100, 500, 1000]
 
     matrix = list()
 
@@ -206,7 +205,7 @@ def create_test_matrix() -> List[Tuple]:
 
         for rtf, physics_rate in combinations:
             # Remove some combination too demanding for a single process
-            if physics_rate * rtf >= 5000:
+            if physics_rate * rtf >= 2000:
                 continue
 
             # This case is not allowed
@@ -230,7 +229,4 @@ def test_rates(rtf, agent_rate, physics_rate):
     print("Agent rate = {}".format(agent_rate))
     print("Physics rate = {}".format(physics_rate))
 
-    # Test this combination in a separated process
-    p = Process(target=template_test, args=(rtf, physics_rate, agent_rate))
-    p.start()
-    p.join()
+    template_test(rtf, physics_rate, agent_rate)

--- a/tests/python/test_robot_controller.py
+++ b/tests/python/test_robot_controller.py
@@ -4,12 +4,11 @@
 
 import gym
 import numpy as np
-from multiprocessing import Process
 from gym_ignition import gympp_bindings as bindings
 from gym_ignition.utils import logger, resource_finder
 
 
-def run_joint_controller():
+def test_joint_controller():
     # ==========
     # PARAMETERS
     # ==========
@@ -107,9 +106,3 @@ def run_joint_controller():
     # Check that the trajectory was followed correctly
     assert np.abs(pos_cart_buffer - cart_ref).sum() / cart_ref.size < 5E-3, \
         "The reference trajectory was not tracked correctly"
-
-
-def test_joint_controller():
-    p = Process(target=run_joint_controller())
-    p.start()
-    p.join()

--- a/tests/python/test_runtimes.py
+++ b/tests/python/test_runtimes.py
@@ -6,7 +6,6 @@ import gym
 import pytest
 import numpy as np
 from gym.envs import registry
-from multiprocessing import Process
 from gym_ignition.utils import logger
 from gym.envs.registration import register
 from gym_ignition.robots.sim import gazebo, pybullet
@@ -23,7 +22,7 @@ if "Pendulum-Ignition-PyTest-v0" not in [spec.id for spec in list(registry.all()
         max_episode_steps=1000,
         kwargs={'task_cls': PendulumSwingUp,
                 'robot_cls': gazebo.pendulum.PendulumGazeboRobot,
-                'sdf': "Pendulum/Pendulum.sdf",
+                'model': "Pendulum/Pendulum.sdf",
                 'world': "DefaultEmptyWorld.world",
                 'rtf': 100,
                 'agent_rate': 4000,
@@ -53,7 +52,7 @@ if "CartPoleDiscrete-Ignition-PyTest-v0" not in [spec.id for spec in list(regist
         max_episode_steps=500,
         kwargs={'task_cls': CartPoleDiscrete,
                 'robot_cls': gazebo.cartpole.CartPoleGazeboRobot,
-                'sdf': "CartPole/CartPole.sdf",
+                'model': "CartPole/CartPole.sdf",
                 'world': "DefaultEmptyWorld.world",
                 'rtf': 100,
                 'agent_rate': 4000,
@@ -101,15 +100,13 @@ def template_compare_environments(env_name_a: str, env_name_b: str, max_error: f
         # Reset the environments
         observation_a = env_a.reset()
         observation_b = env_b.reset()
-        print(observation_a)
-        print(observation_b)
+
         assert np.allclose(observation_a, observation_b), \
             "Observations after reset don't match"
 
         # Initialize intermediate variables
         iteration = 0
         done_a = False
-        done_b = False
 
         while not done_a:
             iteration += 1
@@ -135,13 +132,13 @@ def template_compare_environments(env_name_a: str, env_name_b: str, max_error: f
                 print("===================")
                 assert False, "The error is bigger than the threshold"
 
+    env_a.close()
+    env_b.close()
+
 
 @pytest.mark.parametrize("env_name_a, env_name_b, max_error", [
-    ("Pendulum-Ignition-PyTest-v0", "Pendulum-PyBullet-PyTest-v0", 0.02),
+    ("Pendulum-Ignition-PyTest-v0", "Pendulum-PyBullet-PyTest-v0", 0.05),
     ("CartPoleDiscrete-Ignition-PyTest-v0", "CartPoleDiscrete-PyBullet-PyTest-v0", 0.03),
 ])
 def test_compare_environments(env_name_a: str, env_name_b: str, max_error: float):
-    args = (env_name_a, env_name_b, max_error)
-    p = Process(target=template_compare_environments, args=args)
-    p.start()
-    p.join()
+    template_compare_environments(env_name_a, env_name_b, max_error)


### PR DESCRIPTION
I noticed that the tests occasionally hang. Before #50, we needed to execute environments in different processes. The reason was a missing support of gazebo world / models scoped names.

Now everything is safe to run without resorting to Python multiprocessing support. The only important operation to remember is to call `GazeboWrapper.close()`, otherwise the object is not properly destroyed and the successive executions find unscoped ignition topics (like `/clock` and `/stats`) still running. I suspect that there might be a SWIG internal problem in our bindings that prevents the Python garbage collector to make its job.

Furthermore, the former processes were not forwarding the raised exception to the parent process. Therefore even if a test was failing, pytest was not complaining. The behaviour was hidden by the capture feature of pytest. This PR hence also fixes few minor leftovers forgot in the last refactoring.