### PR TITLE
Improve Runtimes initialization

### DIFF
--- a/examples/python/launch_cartpole.py
+++ b/examples/python/launch_cartpole.py
@@ -5,19 +5,21 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 import gym
-import gym_ignition
-from gym_ignition.utils import logger
 
 # Set gym verbosity
-logger.set_level(gym.logger.INFO)
-assert logger.set_level(gym.logger.DEBUG) or True
+gym.logger.set_level(gym.logger.INFO)
+assert gym.logger.set_level(gym.logger.DEBUG) or True
+
+# Register gym-ignition environments
+import gym_ignition
+from gym_ignition.utils import logger
 
 # Create the environment
 # env = gym.make("CartPole-v1")
 # env = gym.make("CartPoleDiscrete-Gympp-v0")
 env = gym.make("CartPoleDiscrete-Gazebo-v0")
 # env = gym.make("CartPoleContinuous-Gazebo-v0")
-# env = gym.make("CartPole-PyBullet-Discrete-v0")
+# env = gym.make("CartPoleDiscrete-PyBullet-v0")
 
 # Enable the rendering
 env.render('human')

--- a/gym_ignition/base/task.py
+++ b/gym_ignition/base/task.py
@@ -68,6 +68,13 @@ class Task(gym.Env, abc.ABC):
         # Set the robot
         self._robot = robot
 
+    def has_robot(self) -> bool:
+        if not self._robot:
+            return False
+        else:
+            assert self._robot.valid(), "The robot object is not valid"
+            return True
+
     # ==============
     # TASK INTERFACE
     # ==============

--- a/gym_ignition/runtimes/gazebo_runtime.py
+++ b/gym_ignition/runtimes/gazebo_runtime.py
@@ -55,10 +55,10 @@ class GazeboRuntime(runtime.Runtime):
         super().__init__(task=task_object, agent_rate=agent_rate)
 
         # Initialize the simulator and the robot
-        robot = self._get_robot()
+        self.task.robot = self._get_robot()
 
-        # Store the robot in the task
-        self.task.robot = robot
+        # Initialize the spaces
+        self.task.action_space, self.task.observation_space = self.task.create_spaces()
 
         # Seed the environment
         self.seed()

--- a/gym_ignition/runtimes/gazebo_runtime.py
+++ b/gym_ignition/runtimes/gazebo_runtime.py
@@ -3,8 +3,9 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 import gym
+from gym_ignition import base
 from gym_ignition.utils import logger
-from gym_ignition.base import task, runtime
+from gym_ignition.base import runtime
 from gym_ignition.base.robot import robot_abc
 from gym_ignition import gympp_bindings as bindings
 from gym_ignition.utils.typing import State, Action, Observation, SeedList
@@ -46,13 +47,13 @@ class GazeboRuntime(runtime.Runtime):
         self._gazebo_wrapper = None
 
         # Build the environment
-        task_object = task_cls(**kwargs)
+        task = task_cls(**kwargs)
 
-        assert isinstance(task_object, task.Task), \
+        assert isinstance(task, base.task.Task), \
             "'task_cls' object must inherit from Task"
 
         # Wrap the environment with this class
-        super().__init__(task=task_object, agent_rate=agent_rate)
+        super().__init__(task=task, agent_rate=agent_rate)
 
         # Initialize the simulator and the robot
         self.task.robot = self._get_robot()

--- a/gym_ignition/runtimes/gazebo_runtime.py
+++ b/gym_ignition/runtimes/gazebo_runtime.py
@@ -186,7 +186,7 @@ class GazeboRuntime(runtime.Runtime):
         # reset fixed-based robots. Though, while avoiding the model deletion might
         # provide better performance, we should be sure that all the internal buffers
         # (e.g. those related to the low-level PIDs) are correctly re-initialized.
-        if self._hard_reset and self.task._robot:
+        if self._hard_reset and self.task.has_robot():
             if not self._first_run:
                 logger.debug("Hard reset: deleting the robot")
                 self.task.robot.delete_simulated_robot()
@@ -224,6 +224,10 @@ class GazeboRuntime(runtime.Runtime):
         self.gazebo.close()
 
     def seed(self, seed: int = None) -> SeedList:
+        # This method also seeds the spaces. To create them, the robot object is often
+        # needed. Here we check that is has been created.
+        assert self.task.has_robot(), "The robot has not yet been created"
+
         # Seed the wrapped environment (task)
         seed = self.env.seed(seed)
 

--- a/gym_ignition/runtimes/gazebo_runtime.py
+++ b/gym_ignition/runtimes/gazebo_runtime.py
@@ -34,6 +34,7 @@ class GazeboRuntime(runtime.Runtime):
         self._robot_cls = robot_cls
 
         # Delete and create a new robot every environment reset
+        self._first_run = True
         self._hard_reset = hard_reset
 
         # SDF files
@@ -186,11 +187,14 @@ class GazeboRuntime(runtime.Runtime):
         # provide better performance, we should be sure that all the internal buffers
         # (e.g. those related to the low-level PIDs) are correctly re-initialized.
         if self._hard_reset and self.task._robot:
-            logger.debug("Hard reset: deleting the robot")
-            self.task.robot.delete_simulated_robot()
+            if not self._first_run:
+                logger.debug("Hard reset: deleting the robot")
+                self.task.robot.delete_simulated_robot()
 
-            logger.debug("Hard reset: creating new robot")
-            self.task.robot = self._get_robot()
+                logger.debug("Hard reset: creating new robot")
+                self.task.robot = self._get_robot()
+            else:
+                self._first_run = False
 
         # Reset the environment
         ok_reset = self.task.reset_task()

--- a/gym_ignition/runtimes/pybullet_runtime.py
+++ b/gym_ignition/runtimes/pybullet_runtime.py
@@ -244,7 +244,7 @@ class PyBulletRuntime(base.runtime.Runtime):
         p = self.pybullet
         assert p, "PyBullet object not valid"
 
-        if self._hard_reset and self.task._robot:
+        if self._hard_reset and self.task.has_robot():
             if not self._first_run:
                 logger.debug("Hard reset: deleting the robot")
                 self.task.robot.delete_simulated_robot()
@@ -301,10 +301,9 @@ class PyBulletRuntime(base.runtime.Runtime):
             self.task._robot = None
 
     def seed(self, seed: int = None) -> SeedList:
-        # Tasks in most cases need the robot object to create the spaces.
-        # We initialize it lazily here.
-        if not self.task._robot:
-            self.task.robot = self._get_robot()
+        # This method also seeds the spaces. To create them, the robot object is often
+        # needed. Here we check that is has been created.
+        assert self.task.has_robot(), "The robot has not yet been created"
 
         # Seed the wrapped environment (task)
         seed = self.env.seed(seed)

--- a/gym_ignition/runtimes/pybullet_runtime.py
+++ b/gym_ignition/runtimes/pybullet_runtime.py
@@ -87,6 +87,9 @@ class PyBulletRuntime(base.runtime.Runtime):
         # Initialize the spaces
         self.task.action_space, self.task.observation_space = self.task.create_spaces()
 
+        # Seed the environment
+        self.seed()
+
     # =======================
     # PyBulletRuntime METHODS
     # =======================

--- a/gym_ignition/runtimes/pybullet_runtime.py
+++ b/gym_ignition/runtimes/pybullet_runtime.py
@@ -85,6 +85,9 @@ class PyBulletRuntime(base.runtime.Runtime):
         # Initialize the simulator and the robot
         self.task.robot = self._get_robot()
 
+        # Initialize the spaces
+        self.task.action_space, self.task.observation_space = self.task.create_spaces()
+
     # =======================
     # PyBulletRuntime METHODS
     # =======================

--- a/gym_ignition/runtimes/pybullet_runtime.py
+++ b/gym_ignition/runtimes/pybullet_runtime.py
@@ -68,10 +68,9 @@ class PyBulletRuntime(base.runtime.Runtime):
             logger.warn("The real physics rate will be {} Hz".format(
                 agent_rate * self._num_of_physics_steps))
 
-        logger.debug("RTF = {}".format(rtf))
-        logger.debug("Agent rate = {} Hz".format(agent_rate))
-        logger.debug("Physics rate = {} Hz".format(
-            agent_rate * self._num_of_physics_steps))
+        logger.debug(f"RTF = {rtf}")
+        logger.debug(f"Agent rate = {agent_rate} Hz")
+        logger.debug(f"Physics rate = {agent_rate * self._num_of_physics_steps} Hz")
 
         logger.debug("Initializing the Task")
         task = task_cls(**kwargs)
@@ -132,7 +131,7 @@ class PyBulletRuntime(base.runtime.Runtime):
         logger.info(str(self._pybullet.getPhysicsEngineParameters()))
 
         step_time = 1.0 / self._physics_rate / self._rtf
-        logger.info("Nominal step time: {} seconds".format(step_time))
+        logger.info(f"Nominal step time: {step_time} seconds")
 
         logger.debug("PyBullet simulator created")
         return self._pybullet
@@ -260,7 +259,7 @@ class PyBulletRuntime(base.runtime.Runtime):
 
     def render(self, mode: str = 'human', **kwargs) -> None:
         if mode != "human":
-            raise Exception("Render mode '{}' not yet supported".format(mode))
+            raise Exception(f"Render mode '{mode}' not yet supported")
 
         # If render has been already called once, and the simulator is ok, return
         if self._render_enabled and self._pybullet:

--- a/gym_ignition/runtimes/pybullet_runtime.py
+++ b/gym_ignition/runtimes/pybullet_runtime.py
@@ -37,6 +37,7 @@ class PyBulletRuntime(base.runtime.Runtime):
         self._robot_cls = robot_cls
 
         # Delete and create a new robot every environment reset
+        self._first_run = True
         self._hard_reset = hard_reset
 
         # URDF or SDF model files
@@ -244,9 +245,14 @@ class PyBulletRuntime(base.runtime.Runtime):
         assert p, "PyBullet object not valid"
 
         if self._hard_reset and self.task._robot:
-            logger.debug("Hard reset: deleting the robot")
-            self.task.robot.delete_simulated_robot()
-            self.task.robot = self._get_robot()
+            if not self._first_run:
+                logger.debug("Hard reset: deleting the robot")
+                self.task.robot.delete_simulated_robot()
+
+                logger.debug("Hard reset: creating new robot")
+                self.task.robot = self._get_robot()
+            else:
+                self._first_run = False
 
         # Reset the environment
         ok_reset = self.task.reset_task()

--- a/gym_ignition/utils/gazebo_env_vars.py
+++ b/gym_ignition/utils/gazebo_env_vars.py
@@ -19,6 +19,8 @@ def setup_gazebo_env_vars() -> None:
         ign_gazebo_system_plugin_path = ""
 
     if misc.installed_in_editable_mode():
+        logger.debug("Developer setup")
+
         # Detect the install prefix
         import gympp_bindings
         site_packages_path = Path(gympp_bindings.__file__).parent
@@ -32,6 +34,8 @@ def setup_gazebo_env_vars() -> None:
         ign_gazebo_resource_path += f":{install_prefix}/share/gympp/gazebo/worlds"
         ign_gazebo_resource_path += f":{install_prefix}/share/gympp/gazebo/models"
     else:
+        logger.debug("User setup")
+
         # Add the plugins path
         import gym_ignition
         ign_gazebo_system_plugin_path += f":{gym_ignition.__path__[0]}/plugins"


### PR DESCRIPTION
In the constructor of Runtime objects, among other things, the Robot object is initialized. When to do it to get the right resources at all the stages has always been quite tricky.

This PR hopefully fixes the order in such a way that all the phases have the right resources initialized. The order is the following:

1. **Initialize private attributes**
1. **Create the Task object**.  The constructor should _not_ use any robot information since the object does not yet exist.
1. **Create the Robot object and store in the Task**
1. **Create the action and observation spaces.** This has to be done _after_ the robot creation since spaces might need to access the Robot interface.
1. **Seed the environment**. In particular, RNG and spaces.

As soon as we start writing a complete documentation, this information should be moved there.

In addition, this PR also prevents recreating the Robot object right after initialization. This was happening because the Robot was created the first time in the Runtime constructor, and then again at the first `Runtime.reset()` call that should precede all rollouts.