### PR TITLE
Load custom physics plugins

### DIFF
--- a/plugins/Physics/Physics.h
+++ b/plugins/Physics/Physics.h
@@ -37,6 +37,7 @@ namespace gympp {
 
 class gympp::plugins::Physics final
     : public ignition::gazebo::System
+    , public ignition::gazebo::ISystemConfigure
     , public ignition::gazebo::ISystemUpdate
 {
 public:
@@ -45,6 +46,11 @@ public:
 
     void Update(const ignition::gazebo::UpdateInfo& info,
                 ignition::gazebo::EntityComponentManager& ecm) override;
+
+    void Configure(const ignition::gazebo::Entity& entity,
+                   const std::shared_ptr<const sdf::Element>& sdf,
+                   ignition::gazebo::EntityComponentManager& ecm,
+                   ignition::gazebo::EventManager& eventMgr) override;
 
 private:
     class Impl;


### PR DESCRIPTION
This is an experimental attempt to load custom physics plugins in the `gympp::plugins::Physics` system. The rationale behind this need is explained in https://github.com/robotology/gym-ignition/pull/82#issuecomment-544231636:

> Moreover, if we plan to develop new ign-physics plugins, there's no easy way in upstream to load the corresponding plugins. Right now the path to the library is taken from configuration time and hardcoded in a compiler definition. In other words, there's no support of selecting during runtime a new physics engine plugin (not known during build time). And, what's more concerning, is that I don't see any solution that does not involve changing the SDF specifications.

Contrarily to my previous comment, I found a workaround, even if not very clean. The implemented logic assumes that the plugin library with the physics class:

1. Is contained in a folder specified by `IGN_GAZEBO_SYSTEM_PLUGIN_PATH`
1. Has the name `ignition-physics1-<engine>-plugin`

The name constraint is quite a hack, but it works fine. Though, I don't think I will merge this soon, at least not before we have the real need of loading custom physics plugins. Beyond that, the experimental new physics engine I'm using for testing has limitations that prevent the implementation of all features required by the `Physics` system. 

cc @traversaro 