### PR TITLE
Update setup instructions and Docker images

### DIFF
--- a/.docker/Dockerfile.ci
+++ b/.docker/Dockerfile.ci
@@ -39,33 +39,15 @@ RUN apt-get update &&\
     rm -rf /var/lib/apt/lists/*
 
 # Install ignition robotics
+ARG branch="master"
+COPY ignition-pkgs-${branch}.txt /usr/local/share/ignition-pkgs-${branch}.txt
 RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" \
         > /etc/apt/sources.list.d/gazebo-stable.list &&\
-    echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease `lsb_release -cs` main" \
-        > /etc/apt/sources.list.d/gazebo-prerelease.list &&\
-    echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-nightly `lsb_release -cs` main" \
-        > /etc/apt/sources.list.d/gazebo-prerelease.list &&\
     wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add - &&\
     apt-get update &&\
-    apt-get install -y --no-install-recommends \
-        libignition-cmake2-dev \
-        libignition-plugin-dev \
-        libignition-math6-dev \
-        libignition-common3-dev \
-        libignition-transport7-dev \
-        libignition-msgs4-dev \
-        libignition-tools-dev \
-        libignition-fuel-tools3-dev \
-        libsdformat8-dev \
-        libignition-physics-dev \
-        libignition-rendering-dev \
-        libignition-sensors2-dev \
-        libignition-gui2-dev \
-        libignition-gazebo2-dev \
-        ignition-gazebo2 \
-        &&\
+    xargs -a /usr/local/share/ignition-pkgs-${branch}.txt \
+        apt-get install -y --no-install-recommends &&\
     rm -rf /var/lib/apt/lists/*
-
 
 # Install idyntree
 RUN apt-get update &&\

--- a/.docker/Dockerfile.ci
+++ b/.docker/Dockerfile.ci
@@ -62,6 +62,7 @@ RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_releas
         libignition-sensors2-dev \
         libignition-gui2-dev \
         libignition-gazebo2-dev \
+        ignition-gazebo2 \
         &&\
     rm -rf /var/lib/apt/lists/*
 

--- a/.docker/Dockerfile.latest
+++ b/.docker/Dockerfile.latest
@@ -37,10 +37,11 @@ RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_releas
 
 # Install gym-ignition bdist in a virtualenv
 # Download also gym-ignition for the examples
+ARG pypi_package="gym-ignition"
 ENV VIRTUAL_ENV=/venv
 ENV PATH=/venv/bin:$PATH
 RUN virtualenv -p python3.6 ${VIRTUAL_ENV} &&\
-    pip install --pre gym-ignition &&\
+    pip install --pre ${pypi_package} &&\
     git clone https://github.com/robotology/gym-ignition /github
 
 CMD ["bash"]

--- a/.docker/Dockerfile.latest
+++ b/.docker/Dockerfile.latest
@@ -21,17 +21,14 @@ RUN apt-get update &&\
     rm -rf /var/lib/apt/lists/*
 
 # Install ignition gazebo
+ARG ign_major_ver=2
 RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" \
         > /etc/apt/sources.list.d/gazebo-stable.list &&\
-    echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease `lsb_release -cs` main" \
-        > /etc/apt/sources.list.d/gazebo-prerelease.list &&\
-    echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-nightly `lsb_release -cs` main" \
-        > /etc/apt/sources.list.d/gazebo-prerelease.list &&\
     wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add - &&\
     apt-get update &&\
     apt-get install -y --no-install-recommends \
-        ignition-gazebo2 \
-        libignition-gazebo2-dev \
+        ignition-gazebo${ign_major_ver} \
+        libignition-gazebo${ign_major_ver}-dev \
         &&\
     rm -rf /var/lib/apt/lists/*
 

--- a/.docker/Dockerfile.latest
+++ b/.docker/Dockerfile.latest
@@ -30,6 +30,7 @@ RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_releas
     wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add - &&\
     apt-get update &&\
     apt-get install -y --no-install-recommends \
+        ignition-gazebo2 \
         libignition-gazebo2-dev \
         &&\
     rm -rf /var/lib/apt/lists/*

--- a/.docker/Dockerfile.nightly
+++ b/.docker/Dockerfile.nightly
@@ -1,0 +1,1 @@
+Dockerfile.latest

--- a/.docker/Dockerfile.pypi
+++ b/.docker/Dockerfile.pypi
@@ -34,10 +34,6 @@ RUN apt-get update &&\
 # Install ignition robotics
 RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" \
         > /etc/apt/sources.list.d/gazebo-stable.list &&\
-    echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease `lsb_release -cs` main" \
-        > /etc/apt/sources.list.d/gazebo-prerelease.list &&\
-    echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-nightly `lsb_release -cs` main" \
-        > /etc/apt/sources.list.d/gazebo-prerelease.list &&\
     wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add - &&\
     apt-get update &&\
     apt-get install -y --no-install-recommends \
@@ -55,6 +51,7 @@ RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_releas
         libignition-sensors2-dev \
         libignition-gui2-dev \
         libignition-gazebo2-dev \
+        ignition-gazebo2 \
         &&\
     rm -rf /var/lib/apt/lists/*
 

--- a/.docker/Dockerfile.pypi
+++ b/.docker/Dockerfile.pypi
@@ -32,27 +32,14 @@ RUN apt-get update &&\
     rm -rf /var/lib/apt/lists/*
 
 # Install ignition robotics
+ARG branch="master"
+COPY ignition-pkgs-${branch}.txt /usr/local/share/ignition-pkgs-${branch}.txt
 RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" \
         > /etc/apt/sources.list.d/gazebo-stable.list &&\
     wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add - &&\
     apt-get update &&\
-    apt-get install -y --no-install-recommends \
-        libignition-cmake2-dev \
-        libignition-plugin-dev \
-        libignition-math6-dev \
-        libignition-common3-dev \
-        libignition-transport7-dev \
-        libignition-msgs4-dev \
-        libignition-tools-dev \
-        libignition-fuel-tools3-dev \
-        libsdformat8-dev \
-        libignition-physics-dev \
-        libignition-rendering-dev \
-        libignition-sensors2-dev \
-        libignition-gui2-dev \
-        libignition-gazebo2-dev \
-        ignition-gazebo2 \
-        &&\
+    xargs -a /usr/local/share/ignition-pkgs-${branch}.txt \
+        apt-get install -y --no-install-recommends &&\
     rm -rf /var/lib/apt/lists/*
 
 # Install idyntree (statically compiled)

--- a/.docker/ignition-pkgs-devel.txt
+++ b/.docker/ignition-pkgs-devel.txt
@@ -1,0 +1,15 @@
+libignition-cmake2-dev
+libignition-plugin-dev
+libignition-math6-dev
+libignition-common3-dev
+libignition-transport7-dev
+libignition-msgs4-dev
+libignition-tools-dev
+libignition-fuel-tools3-dev
+libsdformat8-dev
+libignition-physics-dev
+libignition-rendering-dev
+libignition-sensors2-dev
+libignition-gui2-dev
+libignition-gazebo2-dev
+ignition-gazebo2

--- a/.docker/ignition-pkgs-master.txt
+++ b/.docker/ignition-pkgs-master.txt
@@ -1,0 +1,15 @@
+libignition-cmake2-dev
+libignition-plugin-dev
+libignition-math6-dev
+libignition-common3-dev
+libignition-transport7-dev
+libignition-msgs4-dev
+libignition-tools-dev
+libignition-fuel-tools3-dev
+libsdformat8-dev
+libignition-physics-dev
+libignition-rendering-dev
+libignition-sensors2-dev
+libignition-gui2-dev
+libignition-gazebo2-dev
+ignition-gazebo2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           - clang7
           - clang8
     container:
-      image: diegoferigo/gym-ignition:ci
+      image: diegoferigo/gym-ignition:ci-master
       env:
         PYTHON_VERSION: ${{ matrix.python }}
 
@@ -30,8 +30,8 @@ jobs:
       - name: Execute entrypoint
         run: . /entrypoint.sh
 
-#      # Workaround to export environment variables that persist in next steps
-#      # https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+      # Workaround to export environment variables that persist in next steps
+      # https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
       - name: Setup Environment
         run: |
           case ${{ matrix.compiler }} in
@@ -84,7 +84,7 @@ jobs:
         os:
           - ubuntu-18.04
     container:
-      image: diegoferigo/gym-ignition:ci
+      image: diegoferigo/gym-ignition:ci-master
       env:
         PYTHON_VERSION: ${{ matrix.python }}
         CC: gcc-8

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,25 +21,34 @@ jobs:
       matrix:
         baseimage: ['ubuntu:bionic']
         tag:
-          - ci
-          - pypi
+          - ci-master
+          - ci-devel
+          - pypi-master
+          - pypi-devel
           - latest
           - nightly
         include:
+          - tag: ci-devel
+            extra_docker_options: --build-arg branch='devel'
+          - tag: pypi-devel
+            extra_docker_options: --build-arg branch='devel'
           - tag: nightly
-            extra_docker_options: "--build-arg pypi_package='gym-ignition-nightly'"
+            extra_docker_options: |
+              --build-arg pypi_package='gym-ignition-nightly' --build-arg ign_major_ver=2 \
 
     steps:
       - uses: actions/checkout@master
 
       - name: Build
+        env:
+          TAG: ${{ matrix.tag }}
         run: |
           cd .docker/
           docker build . \
             --pull --build-arg from=${{ matrix.baseimage }} \
-            --rm -t diegoferigo/gym-ignition:${{ matrix.tag }} \
+            --rm -t diegoferigo/gym-ignition:${TAG} \
             ${{ matrix.extra_docker_options }} \
-            -f Dockerfile.${{ matrix.tag }}
+            -f Dockerfile.${TAG%-*}
 
       - name: Login
         if: |
@@ -55,14 +64,5 @@ jobs:
         if: |
           github.repository == 'robotology/gym-ignition' &&
           github.event_name != 'pull_request' &&
-          github.ref == 'refs/heads/master' &&
-          matrix.tag != 'nightly'
-        run: docker push diegoferigo/gym-ignition:${{ matrix.tag }}
-
-      - name: Push nightly
-        if: |
-          github.repository == 'robotology/gym-ignition' &&
-          github.event_name != 'pull_request' &&
-          github.ref == 'refs/heads/devel' &&
-          matrix.tag == 'nightly'
+          (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/devel')
         run: docker push diegoferigo/gym-ignition:${{ matrix.tag }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: 'Docker Images'
+name: Docker Images
 
 on:
   push:
@@ -24,23 +24,28 @@ jobs:
           - ci
           - pypi
           - latest
+          - nightly
+        include:
+          - tag: nightly
+            extra_docker_options: "--build-arg pypi_package='gym-ignition-nightly'"
 
     steps:
       - uses: actions/checkout@master
 
-      - name: 'Build'
+      - name: Build
         run: |
           cd .docker/
           docker build . \
             --pull --build-arg from=${{ matrix.baseimage }} \
             --rm -t diegoferigo/gym-ignition:${{ matrix.tag }} \
+            ${{ matrix.extra_docker_options }} \
             -f Dockerfile.${{ matrix.tag }}
 
       - name: Login
         if: |
           github.repository == 'robotology/gym-ignition' &&
           github.event_name != 'pull_request' &&
-          github.ref == 'refs/heads/master'
+          (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/devel')
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -50,5 +55,14 @@ jobs:
         if: |
           github.repository == 'robotology/gym-ignition' &&
           github.event_name != 'pull_request' &&
-          github.ref == 'refs/heads/master'
+          github.ref == 'refs/heads/master' &&
+          matrix.tag != 'nightly'
+        run: docker push diegoferigo/gym-ignition:${{ matrix.tag }}
+
+      - name: Push nightly
+        if: |
+          github.repository == 'robotology/gym-ignition' &&
+          github.event_name != 'pull_request' &&
+          github.ref == 'refs/heads/devel' &&
+          matrix.tag == 'nightly'
         run: docker push diegoferigo/gym-ignition:${{ matrix.tag }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -27,7 +27,7 @@ jobs:
     container:
       # The sdist is tested using the :ci image tag that should mostly match the developer
       # setup with ignition robotics installed from the official ppa
-      image: diegoferigo/gym-ignition:ci
+      image: diegoferigo/gym-ignition:ci-master
       env:
         CC: gcc-8
         CXX: g++-8
@@ -83,15 +83,15 @@ jobs:
           echo "::set-env name=PYTHON_VERSION::${{ matrix.python_version }}"
           env
 
-      - name: Download diegoferigo/gym-ignition:pypi
-        run: 'docker pull diegoferigo/gym-ignition:pypi'
+      - name: Download diegoferigo/gym-ignition:pypi-master
+        run: 'docker pull diegoferigo/gym-ignition:pypi-master'
 
       - name: Create container
         run: |
           docker run \
             -d -i --rm --name pypi -v $(pwd):/github -w /github \
             -e PYTHON_VERSION=$PYTHON_VERSION -e CC=$CC -e CXX=$CXX \
-            diegoferigo/gym-ignition:pypi bash
+            diegoferigo/gym-ignition:pypi-master bash
           sleep 15
 
       - name: Create bdist_wheel
@@ -99,11 +99,11 @@ jobs:
 
       - name: Download and start clean system
         run : |
-          docker pull diegoferigo/gym-ignition:ci
+          docker pull diegoferigo/gym-ignition:ci-master
           docker run \
             -d -i --name test -e PYTHON_VERSION=$PYTHON_VERSION \
             -v $(pwd)/dist:/dist \
-            diegoferigo/gym-ignition:ci bash
+            diegoferigo/gym-ignition:ci-master bash
           sleep 15
 
       - name: Install bdist
@@ -130,7 +130,7 @@ jobs:
         python_version:
           - 3.6
     container:
-      image: diegoferigo/gym-ignition:ci
+      image: diegoferigo/gym-ignition:ci-master
       env:
         CC: gcc-8
         CXX: g++-8
@@ -184,4 +184,3 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
-

--- a/README.md
+++ b/README.md
@@ -113,9 +113,11 @@ We designed Gym-Ignition driven by the following reasons:
 
 ## How
 
-This project interfaces with the new generation of the [Gazebo](http://gazebosim.org) simulator, called [Ignition Gazebo](https://ignitionrobotics.org/libs/gazebo). It is part of the new [Ignition Robotics](http://ignitionrobotics.org) suite developed by [Open Robotics](https://www.openrobotics.org/).
+This project interfaces with the new generation of the [Gazebo](http://gazebosim.org) simulator, called [Ignition Gazebo](https://ignitionrobotics.org/libs/gazebo).
+It is part of the new [Ignition Robotics](http://ignitionrobotics.org) suite developed by [Open Robotics](https://www.openrobotics.org/).
 
-Ignition Robotics is currently under heavy development and is not yet stable. Though, it already offers enough functionalities for this project's aims:
+Ignition Robotics is currently under heavy development and is not yet stable.
+Though, it already offers enough functionalities for this project's aims:
 
 - Simulator-as-a-library
 - New modular architecture
@@ -148,7 +150,7 @@ We provide two different methods to test Gym-Ignition without the need to instal
 1. **Docker image**:
    ```sh
    docker pull diegoferigo/gym-ignition:latest
-   pip install rocker
+   pip3 install rocker
    
    # Intel GPU
    rocker --x11 diegoferigo/gym-ignition ./github/examples/python/launch_cartpole.py
@@ -159,23 +161,55 @@ We provide two different methods to test Gym-Ignition without the need to instal
 
 ## Setup
 
-The setup instructions expect a **Ubuntu** distribution with at least **Python 3.6**. Gym-Ignition is compatible also with other distributions (and, also, other OSs) under the assumption that the Ignition Robotics suite can be installed either from repos or source. Though, to keep the instruction simple, we only report the steps for the Ubuntu distro.
+The setup instructions expect a **Ubuntu** distribution with at least **Python 3.6**.
+Gym-Ignition is compatible also with other distributions (and, also, other OSs) under the assumption that the Ignition Robotics suite can be installed either from repos or source.
+Though, to keep the instructions simple, we only report the steps for the Ubuntu distro.
 
-The process is different whether you're an _user_ that wants to create environments using Gym-Ignition or you are a _developer_ that wants to edit the Python and C++ code.
+The process is different whether you're an _user_ that wants to create environments using Gym-Ignition or you are a _developer_ that wants to edit the Python and C++ upstream code.
+
+Execute all the setup commands in the same terminal.
+
+#### Common Steps
+
+1. Install the supported version of **Ignition Gazebo**:
+
+   ```sh
+   sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
+   wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+   sudo apt update
+   sudo apt install ignition-gazebo2
+   ```
+
+   We currently require the development version, that will be ABI-compatible with the upcoming **Citadel** release.
+   Refer to the [official documentation](https://ignitionrobotics.org/docs/latest/install) for more detailed information.
+
+1. Create a Python [virtual environment](https://docs.python.org/3.6/tutorial/venv.html) as follows:
+   ```sh
+   sudo apt install virtualenv
+   virtualenv -p python3.6 $HOME/venv
+   source $HOME/venv/bin/activate
+   ```
 
 ### User setup
 
-1. Install the Ignition Robotics suite following the [official documentation](https://ignitionrobotics.org/docs/latest/install)
-1. Install Gym-Ignition with `pip install gym-ignition` (preferably in a [virtual environment](https://docs.python.org/3.6/tutorial/venv.html))
-
-After these steps, you should be able to execute the example [`launch_cartpole.py`](examples/python/launch_cartpole.py).
+Check that the last release [includes a wheel](https://pypi.org/project/gym-ignition/#files).
+Then install Gym-Ignition with `pip3 install gym-ignition`.
+After this step, you should be able to execute the example [`launch_cartpole.py`](examples/python/launch_cartpole.py).
 
 ### Developer setup
 
+1. Install gcc 8 with `apt install gcc-8`.
+   Export the following environment variables to enable it temporarily:
+
+   ```sh
+   export CC=gcc-8
+   export CXX=g++-8
+   ```
+
 1. Install [SWIG](https://github.com/swig/swig) with `apt install swig`
-1. Install all the Ignition Robotics suite except `ignition-gazebo2` following the [official documentation](https://ignitionrobotics.org/docs/latest/install)
-1. Install `ign-gazebo` from our [temporary fork](https://github.com/diegoferigo/ign-gazebo)
+
 1. Clone this repository
+
 1. Build and install the CMake project
    ```sh
    mkdir build
@@ -184,10 +218,12 @@ After these steps, you should be able to execute the example [`launch_cartpole.p
    cmake --build .
    cmake --build . --target install
    ```
+   
 1. Install the Python package in [editable mode](https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs):
    ```sh
    pip3 install -e .
    ```
+   
 1. Export the following environment variable:
    ```sh
    # C++ bindings
@@ -198,11 +234,14 @@ After these steps, you should be able to execute the example [`launch_cartpole.p
 
 ### Unstable builds
 
-Gym-Ignition still doesn't have a steady release cycle strategy. This project targets mainly research, and its development is very active. In order to quickly deliver new features, we do our best to have a fast release cycle.
+Gym-Ignition still doesn't have a steady release cycle strategy.
+This project targets mainly research, and its development is very active.
+In order to quickly deliver new features, we do our best to have a fast release cycle.
 
-Though, if you find interesting [PRs](https://github.com/robotology/gym-ignition/pulls) that are not yet included in the [most recent release](https://github.com/robotology/gym-ignition/releases), you can get the most recent version as follows:
+If you find interesting [PRs](https://github.com/robotology/gym-ignition/pulls) that are not yet included in the [most recent release](https://github.com/robotology/gym-ignition/releases), you can get the latest unstable version as follows:
 
 1. **User installation**: install [`gym-ignition-nightly`](https://pypi.org/project/gym-ignition-nightly/). Be sure that the last release [includes a wheel](https://pypi.org/project/gym-ignition-nightly/#files).
+
 1. **Developer installation**: check-out the `devel` branch after cloning the repository.
 
 ## Citation

--- a/examples/colab/RandomPolicy.ipynb
+++ b/examples/colab/RandomPolicy.ipynb
@@ -44,60 +44,13 @@
         "# Disable stdout (use output.show() to print it)\n",
         "%%capture --no-stderr output\n",
         "\n",
-        "# INSTALL CMAKE, SWIG, NINJA\n",
-        "!\\\n",
-        "    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add - &&\\\n",
-        "    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' &&\\\n",
-        "    apt-get -qq update &&\\\n",
-        "    apt-get -qq install cmake swig ninja-build\n",
-        "\n",
-        "# INSTALL IGNITION LIBRARIES\n",
+        "# INSTALL IGNITION LIBRARIES FOR HEADLESS EXECUTION\n",
         "!\\\n",
         "    apt-get -qq update &&\\\n",
         "    echo \"deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main\" > /etc/apt/sources.list.d/gazebo-stable.list &&\\\n",
-        "    echo \"deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease `lsb_release -cs` main\" > /etc/apt/sources.list.d/gazebo-prerelease.list &&\\\n",
-        "    echo \"deb http://packages.osrfoundation.org/gazebo/ubuntu-nightly `lsb_release -cs` main\" > /etc/apt/sources.list.d/gazebo-prerelease.list &&\\\n",
         "    wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add - &&\\\n",
-        "    apt-get -qq update &&\\\n",
-        "    apt-get -qq install -y --no-install-recommends \\\n",
-        "        libgflags-dev \\\n",
-        "        libignition-cmake2-dev \\\n",
-        "        libignition-plugin-dev \\\n",
-        "        libignition-math6-dev \\\n",
-        "        libignition-common3-dev \\\n",
-        "        libignition-transport7-dev \\\n",
-        "        libignition-msgs4-dev \\\n",
-        "        libignition-tools-dev \\\n",
-        "        libignition-fuel-tools3-dev \\\n",
-        "        libsdformat8-dev \\\n",
-        "        libignition-physics-dev \\\n",
-        "        libignition-rendering-dev \\\n",
-        "        libignition-sensors2-dev \\\n",
-        "        libignition-gui2-dev"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "SSaAtuop-0Yx",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "# Disable stdout (use output.show() to print it)\n",
-        "%%capture --no-stderr output\n",
-        "\n",
-        "# INSTALL IGNITION GAZEBO\n",
-        "!\\\n",
-        "    cd /tmp &&\\\n",
-        "    rm -rf ign-gazebo &&\\\n",
-        "    git clone --depth 1 https://github.com/diegoferigo/ign-gazebo &&\\\n",
-        "    cd ign-gazebo && mkdir -p build && cd build &&\\\n",
-        "    cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=\"Release\" -DBUILD_TESTING:BOOL=OFF .. &&\\\n",
-        "    cmake --build . --target install -- -j8 &&\\\n",
-        "    rm -r /tmp/ign-gazebo"
+        "    apt update &&\\\n",
+        "    apt install -y ignition-gazebo2 libignition-physics-dartsim"
       ],
       "execution_count": 0,
       "outputs": []
@@ -107,64 +60,32 @@
       "metadata": {
         "id": "xVwacjF22a8x",
         "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 173
-        },
-        "outputId": "0f12ef24-ae99-495d-fdcd-9fbdfa7f957a"
-      },
-      "source": [
-        "# INSTALL GYM IGNITION\n",
-        "# Note that we have to prepend the PATH variable in order to get the updated CMake\n",
-        "!PATH=/usr/bin:$PATH pip3 install gym-ignition"
-      ],
-      "execution_count": 7,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Requirement already satisfied: gym-ignition in /usr/local/lib/python3.6/dist-packages (1.0.dev2)\n",
-            "Requirement already satisfied: numpy in /usr/local/lib/python3.6/dist-packages (from gym-ignition) (1.16.5)\n",
-            "Requirement already satisfied: gym>=0.13.1 in /usr/local/lib/python3.6/dist-packages (from gym-ignition) (0.14.0)\n",
-            "Requirement already satisfied: pybullet in /usr/local/lib/python3.6/dist-packages (from gym-ignition) (2.5.6)\n",
-            "Requirement already satisfied: scipy in /usr/local/lib/python3.6/dist-packages (from gym>=0.13.1->gym-ignition) (1.3.1)\n",
-            "Requirement already satisfied: pyglet<=1.3.2,>=1.2.0 in /usr/local/lib/python3.6/dist-packages (from gym>=0.13.1->gym-ignition) (1.3.2)\n",
-            "Requirement already satisfied: six in /usr/local/lib/python3.6/dist-packages (from gym>=0.13.1->gym-ignition) (1.12.0)\n",
-            "Requirement already satisfied: cloudpickle~=1.2.0 in /usr/local/lib/python3.6/dist-packages (from gym>=0.13.1->gym-ignition) (1.2.2)\n",
-            "Requirement already satisfied: future in /usr/local/lib/python3.6/dist-packages (from pyglet<=1.3.2,>=1.2.0->gym>=0.13.1->gym-ignition) (0.16.0)\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "YXEwhh0h26Cj",
-        "colab_type": "code",
         "colab": {}
       },
       "source": [
-        "# CONFIGURE THE ENVIRONMENT\n",
-        "import os\n",
-        "import gym_ignition\n",
-        "import gym_ignition_data\n",
-        "\n",
-        "data_path = gym_ignition_data.get_data_path()\n",
-        "module_path = gym_ignition.__path__[0]\n",
-        "\n",
-        "os.environ['IGN_GAZEBO_SYSTEM_PLUGIN_PATH'] = f\"{module_path}/plugins\"\n",
-        "os.environ['IGN_GAZEBO_RESOURCE_PATH'] = f\"{data_path}:{data_path}/worlds\""
+        "%%capture --no-stderr output\n",
+        "# INSTALL GYM IGNITION\n",
+        "!pip3 install gym-ignition"
       ],
       "execution_count": 0,
       "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "xxFtHW6W44br",
+        "colab_type": "text"
+      },
+      "source": [
+        "## CartPole: Random Policy"
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "38A4Q2Rmd29V",
         "colab_type": "code",
-        "outputId": "96983434-0227-4717-ff66-58b0c885ebba",
+        "outputId": "a19640f3-ebba-4115-ebd5-7ba509f53c09",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 243
@@ -173,18 +94,13 @@
       "source": [
         "%%capture --no-stderr --no-stdout output\n",
         "\n",
-        "import os\n",
         "import gym\n",
         "import gym_ignition\n",
-        "import gym_ignition_data\n",
-        "from gym_ignition.utils import logger, resource_finder\n",
-        "\n",
-        "# Add the search path to find the models and worlds\n",
-        "resource_finder.add_path_from_env_var(\"IGN_GAZEBO_RESOURCE_PATH\")\n",
+        "from gym_ignition.utils import logger\n",
         "\n",
         "# Set gym verbosity\n",
         "logger.set_level(gym.logger.INFO)\n",
-        "# logger.set_level(gym.logger.DEBUG)\n",
+        "#logger.set_level(gym.logger.DEBUG)\n",
         "\n",
         "logger.info(\"Initializing the environment\")\n",
         "\n",
@@ -193,8 +109,7 @@
         "env = gym.make(\"CartPoleDiscrete-Gazebo-v0\")\n",
         "# env = gym.make(\"CartPoleDiscrete-PyBullet-v0\")\n",
         "\n",
-        "\n",
-        "# Initialize the seed\n",
+        "# Seed the environment\n",
         "env.seed(42)\n",
         "\n",
         "for epoch in range(10):\n",
@@ -227,7 +142,7 @@
         "\n",
         "env.close()\n"
       ],
-      "execution_count": 12,
+      "execution_count": 3,
       "outputs": [
         {
           "output_type": "stream",


### PR DESCRIPTION
Following #82, the setup instructions can be simplified since we no longer need to use a fork of `ign-gazebo`.

I also made few modifications to the docker images:

- New image `gym-ignition:nightly`
- Duplicated `:ci` and `:pypi` images to have both `-master` and `-devel` versions

The second modification is not strictly required today. In the future, however, we might need to have different dependencies for master and devel branches (for example, if they require a different version of ignition libraries).