### PR TITLE
Search only required CMake components of ignition-physics

### DIFF
--- a/plugins/Physics/CMakeLists.txt
+++ b/plugins/Physics/CMakeLists.txt
@@ -6,7 +6,7 @@
 # Physics PLUGIN
 # ==============
 
-find_package(ignition-physics1 COMPONENTS all REQUIRED)
+find_package(ignition-physics1 COMPONENTS dartsim REQUIRED)
 
 add_library(PhysicsSystem SHARED
     Physics.h
@@ -15,7 +15,7 @@ add_library(PhysicsSystem SHARED
 target_link_libraries(PhysicsSystem
     PUBLIC
     ignition-gazebo2::core
-    ignition-physics1::ignition-physics1-all
+    ignition-physics1
     PRIVATE
     ExtraComponents)
 


### PR DESCRIPTION
Our CI pipeline is currently failing with the following error:

```
CMake Error in plugins/Physics/CMakeLists.txt:
  Imported target "ignition-physics1::ignition-physics1-all" includes
  non-existent path

    "/usr/include/sdformat-8.3"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.
```

Likely this is a `ignition-physics` packaging problem. At the moment the ppa contains `sdformat`  8.4.