### PR TITLE
Finalize the implementation of base pose feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,22 +27,26 @@ endif()
 include(cmake/AddNewBuildMode.cmake)
 add_new_build_mode(NAME "PyPI" TEMPLATE "Release")
 
-if(CMAKE_BUILD_TYPE STREQUAL "PyPI")
+# Expose shared or static compilation
+set(GYMPP_BUILD_SHARED_LIBRARY TRUE
+    CACHE BOOL "Compile libraries as shared libraries")
+
+if(NOT ${CMAKE_BUILD_TYPE} STREQUAL "PyPI")
+    # Apply the user choice
+    set(BUILD_SHARED_LIBS ${GYMPP_BUILD_SHARED_LIBRARY})
+else()
     # Check that is Linux
     if(NOT (UNIX AND NOT APPLE))
         message(FATAL_ERROR "PyPI packages can be only created for Linux at the moment")
     endif()
 
-    # Compile libraries as static, if possible
-    set(GYMPP_BUILD_SHARED_LIBRARY FALSE
-        CACHE BOOL "Compile libraries as shared libraries" FORCE)
-else()
-    set(GYMPP_BUILD_SHARED_LIBRARY TRUE BOOL
-        CACHE BOOL "Compile libraries as shared libraries")
-endif()
+    if(${GYMPP_BUILD_SHARED_LIBRARY})
+        message(WARNING "Enabling static compilation, required by the PyPI build mode")
+    endif()
 
-# Set the final option for shared / static libraries
-set(BUILD_SHARED_LIBS ${GYMPP_BUILD_SHARED_LIBRARY})
+    # Force static compilation
+    set(BUILD_SHARED_LIBS FALSE)
+endif()
 
 # Use -fPIC even if statically compiled
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/bindings/gympp_bindings.i
+++ b/bindings/gympp_bindings.i
@@ -32,6 +32,7 @@
 // Convert python list to std::array
 %template(Array3d) std::array<double, 3>;
 %template(Array4d) std::array<double, 4>;
+%template(Array6d) std::array<double, 6>;
 
 %include "gympp/Common.h"
 %template(BufferContainer_i) gympp::BufferContainer<int>;

--- a/gym_ignition/base/robot/__init__.py
+++ b/gym_ignition/base/robot/__init__.py
@@ -7,5 +7,7 @@ from . import robot_links
 from . import robot_joints
 from . import robot_contacts
 from . import robot_baseframe
+from . import robot_initialstate
+
 from .robot_joints import PID
 from .robot_features import feature_detector, RobotFeatures

--- a/gym_ignition/base/robot/robot_baseframe.py
+++ b/gym_ignition/base/robot/robot_baseframe.py
@@ -14,7 +14,29 @@ class RobotBaseFrame(ABC):
     This interface provides methods to get and set quantities related to the robot base.
     """
 
-    def __init__(self) -> None: ...
+    def __init__(self) -> None:
+        self._is_floating_base = True
+
+    @abstractmethod
+    def set_as_floating_base(self, floating: bool) -> bool:
+        """
+        Specify if the robot is floating or fixed base.
+
+        Args:
+            floating: True for floating base robots, False for fixed based robots.
+
+        Returns:
+            True if successful, False otherwise.
+        """
+
+    @abstractmethod
+    def is_floating_base(self) -> bool:
+        """
+        Check the base type of the robot.
+
+        Returns:
+            True if the robot is floating base, False is the robot is fixed base.
+        """
 
     @abstractmethod
     def set_base_frame(self, frame_name: str) -> bool:
@@ -41,7 +63,7 @@ class RobotBaseFrame(ABC):
     @abstractmethod
     def base_pose(self) -> Tuple[np.ndarray, np.ndarray]:
         """
-        Returns the pose of the robot base.
+        Return the pose of the robot base.
 
         The pose is composed of a position and a quaternion associated to the base frame,
         both expressed in the the world inertial frame.
@@ -71,8 +93,7 @@ class RobotBaseFrame(ABC):
     @abstractmethod
     def reset_base_pose(self,
                         position: np.ndarray,
-                        orientation: np.ndarray,
-                        floating: bool = False) -> bool:
+                        orientation: np.ndarray) -> bool:
         """
         Reset the pose of the robot base.
 
@@ -85,8 +106,6 @@ class RobotBaseFrame(ABC):
         Args:
             position: 3D array in the [x, y, z] form
             orientation: a 4D array containing a quaternion in the [w, x, y, z] form.
-            floating: a boolean flag that, if false, fixes the base in the configured
-                position.
 
         Returns:
             True if successful, False otherwise.
@@ -107,7 +126,7 @@ class RobotBaseFrame(ABC):
 
         Args:
             linear_velocity: a 3D array in the [vx, vy, vz] form.
-            angular_velocity: a 3D array in the [wx, wy, wx] form.
+            angular_velocity: a 3D array in the [wx, wy, wz] form.
 
         Returns:
             True if successful, False otherwise.

--- a/gym_ignition/base/robot/robot_contacts.py
+++ b/gym_ignition/base/robot/robot_contacts.py
@@ -14,8 +14,6 @@ class RobotContacts(ABC):
     This interface provides methods to get and set contact-related quantities.
     """
 
-    def __init__(self) -> None: ...
-
     @abstractmethod
     def links_in_contact(self) -> List[str]:
         """

--- a/gym_ignition/base/robot/robot_initialstate.py
+++ b/gym_ignition/base/robot/robot_initialstate.py
@@ -1,0 +1,127 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import numpy as np
+from typing import Tuple
+from abc import ABC, abstractmethod
+
+
+class RobotInitialState(ABC):
+    """
+    Robot initial state interface.
+
+    This interface provides methods to get and set the initial state of the joints and
+    the base.
+    """
+
+    def __init__(self) -> None:
+        self._initial_joint_positions = None
+        self._initial_joint_velocities = None
+        self._initial_base_pose = (np.array([0., 0., 0.]), np.array([1., 0., 0., 0.]))
+        self._initial_base_velocity = (np.array([0., 0., 0.]), np.array([0., 0., 0.]))
+
+    @abstractmethod
+    def initial_joint_positions(self) -> np.ndarray:
+        """
+        Return the initial joint positions.
+
+        Returns:
+            The initial joint positions.
+        """
+
+    @abstractmethod
+    def set_initial_joint_positions(self, positions: np.ndarray) -> bool:
+        """
+        Set the initial joint positions.
+
+        Note that this does not actuate the robot, it only stores the initial joint
+        positions values.
+
+        Args:
+            positions: The initial joint positions.
+
+        Returns:
+             True if successful, False otherwise.
+        """
+
+    @abstractmethod
+    def initial_joint_velocities(self) -> np.ndarray:
+        """
+        Return the initial joint velocities.
+
+        Returns:
+            The initial joint velocities.
+        """
+
+    @abstractmethod
+    def set_initial_joint_velocities(self, velocities: np.ndarray) -> bool:
+        """
+        Set the initial joint velocities.
+
+        Note that this does not actuate the robot, it only stores the initial joint
+        velocities values.
+
+        Args:
+            velocities: The initial joint velocities.
+
+        Returns:
+             True if successful, False otherwise.
+        """
+
+    @abstractmethod
+    def initial_base_pose(self) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Return the initial base pose.
+
+        Returns:
+            A tuple containing the the initial position and orientation of the base:
+
+            - position: 3D array in the [x, y, z] form.
+            - orientation: a 4D array containing a quaternion in the [w, x, y, z] form.
+        """
+
+    @abstractmethod
+    def set_initial_base_pose(self, position: np.ndarray,
+                              orientation: np.ndarray) -> bool:
+        """
+         Set the initial base pose.
+
+         Note that this does not actuate the robot, it only stores the initial base
+         pose values.
+
+         Args:
+             position: The initial base position expressed as a 3D array.
+             orientation: The initial base orientation expressed as a wxyz quaternion.
+
+         Returns:
+              True if successful, False otherwise.
+         """
+
+    @abstractmethod
+    def initial_base_velocity(self) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Return the initial base velocity.
+
+        Returns:
+            A tuple containing the the linear and angular initial velocity of the base:
+
+            - linear: 3D array in the [vx, vy, vz] form.
+            - angular: a 3D array in the [wx, wy, wz] form.
+        """
+
+    @abstractmethod
+    def set_initial_base_velocity(self, linear: np.ndarray, angular: np.ndarray) -> bool:
+        """
+         Set the initial base velocity.
+
+         Note that this does not actuate the robot, it only stores the initial base
+         pose values.
+
+         Args:
+             linear: The linear initial velocity expressed as a 3D array.
+             angular: The angular initial velocity expressed as a 3D array.
+
+         Returns:
+              True if successful, False otherwise.
+         """

--- a/gym_ignition/base/robot/robot_joints.py
+++ b/gym_ignition/base/robot/robot_joints.py
@@ -92,30 +92,6 @@ class RobotJoints(ABC):
         """
 
     @abstractmethod
-    def initial_positions(self) -> np.ndarray:
-        """
-        Return the initial joint positions.
-
-        Returns:
-            The initial joint positions.
-        """
-
-    @abstractmethod
-    def set_initial_positions(self, positions: np.ndarray) -> bool:
-        """
-        Set the initial joint positions.
-
-        Note that this does not actuate the robot, it only stores the initial joint
-        positions values.
-
-        Args:
-            positions: The initial joint positions.
-
-        Returns:
-             True if successful, False otherwise.
-        """
-
-    @abstractmethod
     def joint_position(self, joint_name: str) -> float:
         """
         Return the generalized position of the specified joint.

--- a/gym_ignition/base/robot/robot_joints.py
+++ b/gym_ignition/base/robot/robot_joints.py
@@ -34,8 +34,6 @@ class RobotJoints(ABC):
     This interface provides methods to get and set joint-related quantities.
     """
 
-    def __init__(self) -> None: ...
-
     @abstractmethod
     def dofs(self) -> int:
         """

--- a/gym_ignition/robots/base/gazebo_robot.py
+++ b/gym_ignition/robots/base/gazebo_robot.py
@@ -123,8 +123,8 @@ class GazeboRobot(robot_abc.RobotABC,
     # RobotJoints
     # ===========
 
-    def dofs(self) -> None:
-        raise NotImplementedError
+    def dofs(self) -> int:
+        return len(self.joint_names())
 
     def joint_names(self) -> List[str]:
         return self.gympp_robot.jointNames()

--- a/gym_ignition/robots/base/gazebo_robot.py
+++ b/gym_ignition/robots/base/gazebo_robot.py
@@ -26,7 +26,9 @@ class GazeboRobot(robot_abc.RobotABC,
         model_abs_path = resource_finder.find_resource(model_file)
 
         # Initialize the parent classes
-        super().__init__()
+        robot_abc.RobotABC.__init__(self)
+        robot_baseframe.RobotBaseFrame.__init__(self)
+        robot_initialstate.RobotInitialState.__init__(self)
         self.model_file = model_abs_path
 
         # Private attributes

--- a/gym_ignition/robots/base/pybullet_robot.py
+++ b/gym_ignition/robots/base/pybullet_robot.py
@@ -90,7 +90,9 @@ class PyBulletRobot(robot.robot_abc.RobotABC,
         model_abs_path = resource_finder.find_resource(model_file)
 
         # Initialize the parent classes
-        super().__init__()
+        robot.robot_abc.RobotABC.__init__(self)
+        robot.robot_baseframe.RobotBaseFrame.__init__(self)
+        robot.robot_initialstate.RobotInitialState.__init__(self)
         self.model_file = model_abs_path
 
         # Private attributes

--- a/gym_ignition/robots/sim/gazebo/cartpole.py
+++ b/gym_ignition/robots/sim/gazebo/cartpole.py
@@ -11,3 +11,6 @@ class CartPoleGazeboRobot(gazebo_robot.GazeboRobot):
         super().__init__(model_file=model_file,
                          gazebo=gazebo,
                          controller_rate=kwargs.get("controller_rate"))
+
+        # Insert the model in the simulation
+        _ = self.gympp_robot

--- a/gym_ignition/robots/sim/gazebo/cartpole.py
+++ b/gym_ignition/robots/sim/gazebo/cartpole.py
@@ -2,6 +2,7 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
+import numpy as np
 from gym_ignition.robots import gazebo_robot
 
 
@@ -11,6 +12,23 @@ class CartPoleGazeboRobot(gazebo_robot.GazeboRobot):
         super().__init__(model_file=model_file,
                          gazebo=gazebo,
                          controller_rate=kwargs.get("controller_rate"))
+
+        # Configure the pendulum as fixed-base robot
+        floating = False if "floating" not in kwargs else kwargs["floating"]
+        ok_floating = self.set_as_floating_base(floating)
+        assert ok_floating, "Failed to set the robot as floating base"
+
+        # Initial base position
+        base_position = np.array([0., 0., 0.]) \
+            if "base_position" not in kwargs else kwargs["base_position"]
+
+        # Initial base orientation
+        base_orientation = np.array([1., 0., 0., 0.]) \
+            if "base_orientation" not in kwargs else kwargs["base_orientation"]
+
+        # Set the base pose
+        ok_base_pose = self.set_initial_base_pose(base_position, base_orientation)
+        assert ok_base_pose, "Failed to set base pose"
 
         # Insert the model in the simulation
         _ = self.gympp_robot

--- a/gym_ignition/robots/sim/gazebo/pendulum.py
+++ b/gym_ignition/robots/sim/gazebo/pendulum.py
@@ -11,3 +11,6 @@ class PendulumGazeboRobot(gazebo_robot.GazeboRobot):
         super().__init__(model_file=model_file,
                          gazebo=gazebo,
                          controller_rate=kwargs.get("controller_rate"))
+
+        # Insert the model in the simulation
+        _ = self.gympp_robot

--- a/gym_ignition/robots/sim/gazebo/pendulum.py
+++ b/gym_ignition/robots/sim/gazebo/pendulum.py
@@ -2,6 +2,7 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
+import numpy as np
 from gym_ignition.robots import gazebo_robot
 
 
@@ -11,6 +12,23 @@ class PendulumGazeboRobot(gazebo_robot.GazeboRobot):
         super().__init__(model_file=model_file,
                          gazebo=gazebo,
                          controller_rate=kwargs.get("controller_rate"))
+
+        # Configure the pendulum as fixed-base robot
+        floating = False if "floating" not in kwargs else kwargs["floating"]
+        ok_floating = self.set_as_floating_base(floating)
+        assert ok_floating, "Failed to set the robot as floating base"
+
+        # Initial base position
+        base_position = np.array([0., 0., 0.]) \
+            if "base_position" not in kwargs else kwargs["base_position"]
+
+        # Initial base orientation
+        base_orientation = np.array([1., 0., 0., 0.]) \
+            if "base_orientation" not in kwargs else kwargs["base_orientation"]
+
+        # Set the base pose
+        ok_base_pose = self.set_initial_base_pose(base_position, base_orientation)
+        assert ok_base_pose, "Failed to set base pose"
 
         # Insert the model in the simulation
         _ = self.gympp_robot

--- a/gym_ignition/robots/sim/pybullet/cartpole.py
+++ b/gym_ignition/robots/sim/pybullet/cartpole.py
@@ -3,6 +3,7 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 import pybullet
+import numpy as np
 from gym_ignition.robots import pybullet_robot
 
 
@@ -14,6 +15,23 @@ class CartPolePyBulletRobot(pybullet_robot.PyBulletRobot):
             model_file=model_file,
             plane_id=plane_id,
             keep_fixed_joints=False)
+
+        # Configure the pendulum as fixed-base robot
+        floating = False if "floating" not in kwargs else kwargs["floating"]
+        ok_floating = self.set_as_floating_base(floating)
+        assert ok_floating, "Failed to set the robot as floating base"
+
+        # Initial base position
+        base_position = np.array([0., 0., 0.]) \
+            if "base_position" not in kwargs else kwargs["base_position"]
+
+        # Initial base orientation
+        base_orientation = np.array([1., 0., 0., 0.]) \
+            if "base_orientation" not in kwargs else kwargs["base_orientation"]
+
+        # Set the base pose
+        ok_base_pose = self.set_initial_base_pose(base_position, base_orientation)
+        assert ok_base_pose, "Failed to set base pose"
 
         # Insert the model in the simulation
         self.initialize_model()

--- a/gym_ignition/robots/sim/pybullet/cartpole.py
+++ b/gym_ignition/robots/sim/pybullet/cartpole.py
@@ -14,3 +14,6 @@ class CartPolePyBulletRobot(pybullet_robot.PyBulletRobot):
             model_file=model_file,
             plane_id=plane_id,
             keep_fixed_joints=False)
+
+        # Insert the model in the simulation
+        self.initialize_model()

--- a/gym_ignition/robots/sim/pybullet/icub.py
+++ b/gym_ignition/robots/sim/pybullet/icub.py
@@ -18,3 +18,6 @@ class ICubPyBulletRobot(pybullet_robot.PyBulletRobot):
         # Set the base frame
         ok_base_frame = self.set_base_frame("root_link")
         assert ok_base_frame, "Failed to set base frame"
+
+        # Insert the model in the simulation
+        self.initialize_model()

--- a/gym_ignition/robots/sim/pybullet/pendulum.py
+++ b/gym_ignition/robots/sim/pybullet/pendulum.py
@@ -14,3 +14,6 @@ class PendulumPyBulletRobot(pybullet_robot.PyBulletRobot):
             model_file=model_file,
             plane_id=plane_id,
             keep_fixed_joints=False)
+
+        # Insert the model in the simulation
+        self.initialize_model()

--- a/gym_ignition/robots/sim/pybullet/pendulum.py
+++ b/gym_ignition/robots/sim/pybullet/pendulum.py
@@ -3,6 +3,7 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 import pybullet
+import numpy as np
 from gym_ignition.robots import pybullet_robot
 
 
@@ -14,6 +15,23 @@ class PendulumPyBulletRobot(pybullet_robot.PyBulletRobot):
             model_file=model_file,
             plane_id=plane_id,
             keep_fixed_joints=False)
+
+        # Configure the pendulum as fixed-base robot
+        floating = False if "floating" not in kwargs else kwargs["floating"]
+        ok_floating = self.set_as_floating_base(floating)
+        assert ok_floating, "Failed to set the robot as floating base"
+
+        # Initial base position
+        base_position = np.array([0., 0., 0.3]) \
+            if "base_position" not in kwargs else kwargs["base_position"]
+
+        # Initial base orientation
+        base_orientation = np.array([1., 0., 0., 0.]) \
+            if "base_orientation" not in kwargs else kwargs["base_orientation"]
+
+        # Set the base pose
+        ok_base_pose = self.set_initial_base_pose(base_position, base_orientation)
+        assert ok_base_pose, "Failed to set base pose"
 
         # Insert the model in the simulation
         self.initialize_model()

--- a/gym_ignition_data/CartPole/CartPole.sdf
+++ b/gym_ignition_data/CartPole/CartPole.sdf
@@ -1,17 +1,17 @@
 <sdf version='1.6'>
   <model name='cartpole_xacro'>
     <link name='rail'>
-      <pose>0 0 0.5 0 -0 0</pose>
+      <pose>0 0 1.2 0 -0 0</pose>
       <inertial>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 1.5708 -0 0</pose>
         <mass>5</mass>
         <inertia>
-          <ixx>100</ixx>
+          <ixx>10.4167</ixx>
           <ixy>0</ixy>
           <ixz>0</ixz>
-          <iyy>100</iyy>
+          <iyy>10.4167</iyy>
           <iyz>0</iyz>
-          <izz>100</izz>
+          <izz>6.25e-05</izz>
         </inertia>
       </inertial>
       <visual name='rail_visual'>
@@ -37,7 +37,7 @@
       <parent>world</parent>
     </joint>
     <link name='cart'>
-      <pose>0 0 0.5 0 -0 0</pose>
+      <pose>0 0 1.2 0 -0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>1</mass>
@@ -45,11 +45,27 @@
           <ixx>0.00354167</ixx>
           <ixy>0</ixy>
           <ixz>0</ixz>
-          <iyy>0.00416667</iyy>
+          <iyy>0.00104167</iyy>
           <iyz>0</iyz>
-          <izz>0.00104167</izz>
+          <izz>0.00416667</izz>
         </inertia>
       </inertial>
+      <collision name='cart_collision'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.1 0.2 0.05</size>
+          </box>
+        </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
+      </collision>
       <visual name='cart_visual'>
         <pose>0 0 0 0 -0 0</pose>
         <geometry>
@@ -82,11 +98,11 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>1</use_parent_model_frame>
+        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name='pole'>
-      <pose>0 0 0.525 0 -0 0</pose>
+      <pose>0 0 1.225 0 -0 0</pose>
       <inertial>
         <pose>0 0 0.5 0 -0 0</pose>
         <mass>0.1</mass>
@@ -99,6 +115,23 @@
           <izz>1.25e-06</izz>
         </inertia>
       </inertial>
+      <collision name='pole_collision'>
+        <pose>0 0 0.5 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>1</length>
+            <radius>0.005</radius>
+          </cylinder>
+        </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
+      </collision>
       <visual name='pole_visual'>
         <pose>0 0 0.5 0 -0 0</pose>
         <geometry>
@@ -130,7 +163,7 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>1</use_parent_model_frame>
+        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
   </model>

--- a/gym_ignition_data/CartPole/CartPole.urdf
+++ b/gym_ignition_data/CartPole/CartPole.urdf
@@ -4,6 +4,8 @@
 <!-- |    EDITING THIS FILE BY HAND IS NOT RECOMMENDED                                 | -->
 <!-- =================================================================================== -->
 <robot name="cartpole_xacro" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <!-- CartPole properties match the OpenAI Gym CartPole-v1 environment -->
+  <!-- https://github.com/openai/gym/blob/master/gym/envs/classic_control/cartpole.py -->
   <!-- ====== -->
   <!-- COLORS -->
   <!-- ====== -->
@@ -52,10 +54,9 @@
   <link name="world"/>
   <link name="rail">
     <inertial>
-      <!-- This link is fixed, inertial values are not relevant -->
-      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <origin rpy="1.57079632679 0 0" xyz="0 0 0"/>
       <mass value="5"/>
-      <inertia ixx="100" ixy="0" ixz="0" iyy="100" iyz="0" izz="100"/>
+      <inertia ixx="10.4166979167" ixy="0" ixz="0" iyy="10.4166979167" iyz="0" izz="6.25e-05"/>
     </inertial>
     <visual>
       <geometry>
@@ -71,7 +72,7 @@
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <mass value="1.0"/>
-      <inertia ixx="0.00354166666667" ixy="0" ixz="0" iyy="0.00416666666667" iyz="0" izz="0.00104166666667"/>
+      <inertia ixx="0.00354166666667" ixy="0" ixz="0" iyy="0.00104166666667" iyz="0" izz="0.00416666666667"/>
     </inertial>
     <visual>
       <geometry>
@@ -82,6 +83,12 @@
         <color rgba="0.2 0.2 0.2 0.8"/>
       </material>
     </visual>
+    <collision>
+      <geometry>
+        <box size="0.1 0.2 0.05"/>
+      </geometry>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+    </collision>
   </link>
   <link name="pole">
     <inertial>
@@ -98,6 +105,15 @@
         <color rgba="1 0 0 0.8"/>
       </material>
     </visual>
+    <collision>
+      <geometry>
+        <cylinder length="1.0" radius="0.005"/>
+      </geometry>
+      <origin rpy="0 0 0" xyz="0 0 0.5"/>
+      <material name="red">
+        <color rgba="1 0 0 0.8"/>
+      </material>
+    </collision>
   </link>
   <!-- ====== -->
   <!-- JOINTS -->
@@ -106,7 +122,7 @@
   <joint name="world_to_rail" type="fixed">
     <parent link="world"/>
     <child link="rail"/>
-    <origin rpy="0 0 0" xyz="0 0 0.5"/>
+    <origin rpy="0 0 0" xyz="0 0 1.2"/>
   </joint>
   <joint name="linear" type="prismatic">
     <parent link="rail"/>
@@ -119,8 +135,8 @@
     <parent link="cart"/>
     <child link="pole"/>
     <axis xyz="1 0 0"/>
-    <origin rpy="0 0 0" xyz="0 0 0.025"/>
-    <limit effort="500" lower="-1.57079632679" upper="1.57079632679" velocity="10"/>
+    <origin rpy="0.0 0 0" xyz="0 0 0.025"/>
+    <limit effort="500" lower="-6.28318530718" upper="6.28318530718" velocity="10"/>
   </joint>
 </robot>
 

--- a/gym_ignition_data/CartPole/CartPole.urdf.xacro
+++ b/gym_ignition_data/CartPole/CartPole.urdf.xacro
@@ -2,173 +2,184 @@
 
 <robot name="cartpole_xacro" xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <!-- CartPole properties match the OpenAI Gym CartPole-v1 environment -->
-  <!-- https://github.com/openai/gym/blob/master/gym/envs/classic_control/cartpole.py -->
-  <xacro:property name="rail_height" value="0.5" />
-  <xacro:property name="rail_length" value="5" />
-  <xacro:property name="rail_radius" value="0.005" />
-  <xacro:property name="rail_mass" value="5" />
+    <!-- CartPole properties match the OpenAI Gym CartPole-v1 environment -->
+    <!-- https://github.com/openai/gym/blob/master/gym/envs/classic_control/cartpole.py -->
 
-  <xacro:property name="cart_size_x" value="0.1" />
-  <xacro:property name="cart_size_y" value="0.2" />
-  <xacro:property name="cart_size_z" value="0.05" />
-  <xacro:property name="cart_mass" value="1.0" />
+    <xacro:property name="rail_height" value="1.2"/>
+    <xacro:property name="rail_length" value="5"/>
+    <xacro:property name="rail_radius" value="0.005"/>
+    <xacro:property name="rail_mass" value="5"/>
 
-  <xacro:property name="pole_length" value="1.0" />
-  <xacro:property name="pole_radius" value="0.005" />
-  <xacro:property name="pole_mass" value="0.1" />
-  <xacro:property name="theta_0" value="0" />
+    <xacro:property name="cart_size_x" value="0.1"/>
+    <xacro:property name="cart_size_y" value="0.2"/>
+    <xacro:property name="cart_size_z" value="0.05"/>
+    <xacro:property name="cart_mass" value="1.0"/>
 
-  <xacro:property name="epsilon" value="1e-09"/>
+    <xacro:property name="pole_length" value="1.0"/>
+    <xacro:property name="pole_radius" value="0.005"/>
+    <xacro:property name="pole_mass" value="0.1"/>
+    <xacro:property name="theta_0" value="0.0"/>
 
-  <xacro:property name="rgba_black" value="0 0 0 0.8"/>
-  <xacro:property name="rgba_white" value="1 1 1 0.8"/>
-  <xacro:property name="rgba_grey" value="0.2 0.2 0.2 0.8"/>
-  <xacro:property name="rgba_red" value="1 0 0 0.8"/>
+    <xacro:property name="epsilon" value="1e-09"/>
 
-  <xacro:macro name="box_inertia" params="mass dimx dimy dimz xyz rpy">
-    <inertial>
-      <origin xyz="${xyz}" rpy="${rpy}"/>
-      <mass value="${mass}"/>
-      <xacro:property name="ixx" value="${1/12*mass*(dimz*dimz+dimy*dimy)}"/>
-      <xacro:property name="iyy" value="${1/12*mass*(dimx*dimx+dimy*dimy)}"/>
-      <xacro:property name="izz" value="${1/12*mass*(dimx*dimx+dimz*dimz)}"/>
-      <inertia ixx="${ixx}"  ixy="0"  ixz="0" iyy="${iyy}" iyz="0" izz="${izz}" />
-    </inertial>
-  </xacro:macro>
+    <xacro:property name="rgba_black" value="0 0 0 0.8"/>
+    <xacro:property name="rgba_white" value="1 1 1 0.8"/>
+    <xacro:property name="rgba_grey" value="0.2 0.2 0.2 0.8"/>
+    <xacro:property name="rgba_red" value="1 0 0 0.8"/>
 
-  <xacro:macro name="cylinder_inertial_element"
-               params="mass rotaxis length radius xyz rpy">
-    <inertial>
-      <origin xyz="${xyz}" rpy="${rpy}"/>
-      <mass value="${mass}"/>
-      <xacro:property name="ixx" value="${1/12*mass*(3*radius*radius+length*length)}"/>
-      <xacro:property name="iyy" value="${1/12*mass*(3*radius*radius+length*length)}"/>
-      <xacro:property name="izz" value="${0.5*mass*radius*radius}"/>
-      <inertia ixx="${ixx}"  ixy="0"  ixz="0" iyy="${iyy}" iyz="0" izz="${izz}" />
-    </inertial>
-  </xacro:macro>
+    <xacro:macro name="box_inertia" params="mass dimx dimy dimz xyz rpy">
+        <inertial>
+            <origin xyz="${xyz}" rpy="${rpy}"/>
+            <mass value="${mass}"/>
+            <xacro:property name="ixx" value="${1/12*mass*(dimy*dimy+dimz*dimz)}"/>
+            <xacro:property name="iyy" value="${1/12*mass*(dimx*dimx+dimz*dimz)}"/>
+            <xacro:property name="izz" value="${1/12*mass*(dimx*dimx+dimy*dimy)}"/>
+            <inertia ixx="${ixx}" ixy="0" ixz="0" iyy="${iyy}" iyz="0" izz="${izz}"/>
+        </inertial>
+    </xacro:macro>
 
-  <xacro:macro name="mymaterial" params="name rgba">
-    <material name="${name}">
-        <color rgba="${rgba}"/>
-    </material>
-  </xacro:macro>
+    <xacro:macro name="cylinder_inertial_element"
+                 params="mass length radius xyz rpy">
+        <inertial>
+            <origin xyz="${xyz}" rpy="${rpy}"/>
+            <mass value="${mass}"/>
+            <xacro:property name="ixx"
+                            value="${1/12*mass*(3*radius*radius+length*length)}"/>
+            <xacro:property name="iyy"
+                            value="${1/12*mass*(3*radius*radius+length*length)}"/>
+            <xacro:property name="izz" value="${0.5*mass*radius*radius}"/>
+            <inertia ixx="${ixx}" ixy="0" ixz="0" iyy="${iyy}" iyz="0" izz="${izz}"/>
+        </inertial>
+    </xacro:macro>
 
-  <xacro:macro name="gzmaterial" params="reference rgba">
-    <gazebo reference="${reference}">
-      <visual>
-        <material>
-            <ambient>${rgba}</ambient>
-            <diffuse>${rgba}</diffuse>
-            <specular>${rgba}</specular>
-            <emissive>${rgba}</emissive>
-            <script>
-              <uri></uri>
-              <name></name>
-            </script>
+    <xacro:macro name="mymaterial" params="name rgba">
+        <material name="${name}">
+            <color rgba="${rgba}"/>
         </material>
+    </xacro:macro>
+
+    <xacro:macro name="gzmaterial" params="reference rgba">
+        <gazebo reference="${reference}">
+            <visual>
+                <material>
+                    <ambient>${rgba}</ambient>
+                    <diffuse>${rgba}</diffuse>
+                    <specular>${rgba}</specular>
+                    <emissive>${rgba}</emissive>
+                </material>
+            </visual>
+        </gazebo>
+    </xacro:macro>
+
+    <!-- ====== -->
+    <!-- COLORS -->
+    <!-- ====== -->
+
+    <material name="black">
+        <color rgba="${rgba_black}"/>
+    </material>
+    <material name="white">
+        <color rgba="${rgba_white}"/>
+    </material>
+    <material name="grey">
+        <color rgba="${rgba_grey}"/>
+    </material>
+
+    <xacro:gzmaterial reference="rail" rgba="${rgba_black}"/>
+    <xacro:gzmaterial reference="cart" rgba="${rgba_grey}"/>
+    <xacro:gzmaterial reference="pole" rgba="${rgba_red}"/>
+
+    <!-- ===== -->
+    <!-- LINKS -->
+    <!-- ===== -->
+
+    <link name="world"/>
+
+    <link name="rail">
+        <xacro:cylinder_inertial_element mass="${rail_mass}"
+                                         length="${rail_length}"
+                                         radius="${rail_radius}"
+                                         xyz="0 0 0"
+                                         rpy="${pi/2} 0 0"/>
+        <visual>
+            <geometry>
+                <cylinder length="${rail_length}" radius="${rail_radius}"/>
+            </geometry>
+            <origin xyz="0 0 0" rpy="${pi/2} 0 0"/>
+            <xacro:mymaterial name="black" rgba="${rgba_black}"/>
         </visual>
-    </gazebo>
-  </xacro:macro>
+    </link>
 
-  <!-- ====== -->
-  <!-- COLORS -->
-  <!-- ====== -->
+    <link name="cart">
+        <xacro:box_inertia mass="${cart_mass}"
+                           dimx="${cart_size_x}"
+                           dimy="${cart_size_y}"
+                           dimz="${cart_size_z}"
+                           xyz="0 0 0"
+                           rpy="0 0 0"/>
+        <visual>
+            <geometry>
+                <box size="${cart_size_x} ${cart_size_y} ${cart_size_z}"/>
+            </geometry>
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <xacro:mymaterial name="grey" rgba="${rgba_grey}"/>
+        </visual>
+        <collision>
+            <geometry>
+                <box size="${cart_size_x} ${cart_size_y} ${cart_size_z}"/>
+            </geometry>
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+        </collision>
+    </link>
 
-  <material name="black">
-    <color rgba="${rgba_black}"/>
-  </material>
-  <material name="white">
-    <color rgba="${rgba_white}"/>
-  </material>
-  <material name="grey">
-    <color rgba="${rgba_grey}"/>
-  </material>
+    <link name="pole">
+        <xacro:cylinder_inertial_element mass="${pole_mass}"
+                                         length="${pole_length}"
+                                         radius="${pole_radius}"
+                                         xyz="0 0 ${pole_length/2}"
+                                         rpy="0 0 0"/>
+        <visual>
+            <geometry>
+                <cylinder length="${pole_length}" radius="${pole_radius}"/>
+            </geometry>
+            <origin xyz="0 0 ${pole_length/2}" rpy="0 0 0"/>
+            <xacro:mymaterial name="red" rgba="${rgba_red}"/>
+        </visual>
+        <collision>
+            <geometry>
+                <cylinder length="${pole_length}" radius="${pole_radius}"/>
+            </geometry>
+            <origin xyz="0 0 ${pole_length/2}" rpy="0 0 0"/>
+            <xacro:mymaterial name="red" rgba="${rgba_red}"/>
+        </collision>
+    </link>
 
-  <xacro:gzmaterial reference="rail" rgba="${rgba_black}"/>
-  <xacro:gzmaterial reference="cart" rgba="${rgba_grey}"/>
-  <xacro:gzmaterial reference="pole" rgba="${rgba_red}"/>
+    <!-- ====== -->
+    <!-- JOINTS -->
+    <!-- ====== -->
 
-  <!-- ===== -->
-  <!-- LINKS -->
-  <!-- ===== -->
+    <!-- http://gazebosim.org/tutorials/?tut=ros_urdf#RigidlyFixingAModeltotheWorld -->
+    <joint name="world_to_rail" type="fixed">
+        <parent link="world"/>
+        <child link="rail"/>
+        <origin xyz="0 0 ${rail_height}" rpy="0 0 0"/>
+    </joint>
 
-  <link name="world"/>
+    <joint name="linear" type="prismatic">
+        <parent link="rail"/>
+        <child link="cart"/>
+        <axis xyz="0 1 0"/>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <limit lower="-${rail_length/2-cart_size_y/2}"
+               upper="${rail_length/2-cart_size_y/2}" effort="500" velocity="10"/>
+    </joint>
 
-  <link name="rail">
-    <inertial>
-      <!-- This link is fixed, inertial values are not relevant -->
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <mass value="${rail_mass}"/>
-      <inertia ixx="100"  ixy="0"  ixz="0" iyy="100" iyz="0" izz="100" />
-    </inertial>
-    <visual>
-      <geometry>
-        <cylinder length="${rail_length}" radius="${rail_radius}"/>
-      </geometry>
-      <origin xyz="0 0 0" rpy="${pi/2} 0 0"/>
-      <xacro:mymaterial name="black" rgba="${rgba_black}" />
-    </visual>
-  </link>
-
-  <link name="cart">
-    <xacro:box_inertia mass="${cart_mass}"
-                       dimx="${cart_size_x}"
-                       dimy="${cart_size_y}"
-                       dimz="${cart_size_z}"
-                       xyz="0 0 0"
-                       rpy="0 0 0"/>
-    <visual>
-      <geometry>
-        <box size="${cart_size_x} ${cart_size_y} ${cart_size_z}"/>
-      </geometry>
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <xacro:mymaterial name="grey" rgba="${rgba_grey}" />
-    </visual>
-  </link>
-
-  <link name="pole">
-    <xacro:cylinder_inertial_element mass="${pole_mass}"
-                                     rotaxis="x"
-                                     length="${pole_length}"
-                                     radius="${pole_radius}"
-                                     xyz="0 0 ${pole_length/2}"
-                                     rpy="0 0 0"/>
-    <visual>
-      <geometry>
-        <cylinder length="${pole_length}" radius="${pole_radius}"/>
-      </geometry>
-      <origin xyz="0 0 ${pole_length/2}" rpy="0 0 0"/>
-      <xacro:mymaterial name="red" rgba="${rgba_red}" />
-    </visual>
-  </link>
-
-  <!-- ====== -->
-  <!-- JOINTS -->
-  <!-- ====== -->
-
-  <!--  http://gazebosim.org/tutorials/?tut=ros_urdf#RigidlyFixingAModeltotheWorld-->
-  <joint name="world_to_rail" type="fixed">
-    <parent link="world"/>
-    <child link="rail"/>
-    <origin xyz="0 0 ${rail_height}" rpy="0 0 0" />
-  </joint>
-
-  <joint name="linear" type="prismatic">
-    <parent link="rail" />
-    <child link="cart" />
-    <axis xyz="0 1 0" />
-    <origin xyz="0 0 0" rpy="0 0 0" />
-    <limit lower="-${rail_length/2-cart_size_y/2}" upper="${rail_length/2-cart_size_y/2}" effort="500" velocity="10"/>
-  </joint>
-
-  <joint name="pivot" type="continuous">
-    <parent link="cart" />
-    <child link="pole" />
-    <axis xyz="1 0 0"/>
-    <origin xyz="0 0 ${cart_size_z/2}" rpy="${theta_0} 0 0" />
-    <limit lower="-${pi/2}" upper="${pi/2}" effort="500" velocity="10"/>
-  </joint>
+    <joint name="pivot" type="continuous">
+        <parent link="cart"/>
+        <child link="pole"/>
+        <axis xyz="1 0 0"/>
+        <origin xyz="0 0 ${cart_size_z/2}" rpy="${theta_0} 0 0"/>
+        <limit lower="-${2*pi}" upper="${2*pi}" effort="500" velocity="10"/>
+    </joint>
 
 </robot>

--- a/gym_ignition_data/Pendulum/Pendulum.sdf
+++ b/gym_ignition_data/Pendulum/Pendulum.sdf
@@ -1,21 +1,29 @@
 <sdf version='1.6'>
   <model name='pendulum_xacro'>
     <link name='support'>
-      <pose>0 0 0.6 0 -0 0</pose>
+      <pose>0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0 0 0.3 0 -0 0</pose>
-        <mass>10</mass>
+        <mass>1000</mass>
         <inertia>
-          <ixx>1</ixx>
+          <ixx>30.8333</ixx>
           <ixy>0</ixy>
           <ixz>0</ixz>
-          <iyy>1</iyy>
+          <iyy>30.2083</iyy>
           <iyz>0</iyz>
-          <izz>1</izz>
+          <izz>1.04167</izz>
         </inertia>
       </inertial>
+      <collision name='support_collision'>
+        <pose>0 0 0.3 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.05 0.1 0.6</size>
+          </box>
+        </geometry>
+      </collision>
       <visual name='support_visual'>
-        <pose>0 0 -0.3 0 -0 0</pose>
+        <pose>0 0 0.3 0 -0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.1 0.6</size>
@@ -23,10 +31,6 @@
         </geometry>
       </visual>
     </link>
-    <joint name='world_to_support' type='fixed'>
-      <child>support</child>
-      <parent>world</parent>
-    </joint>
     <link name='pendulum'>
       <pose>0.035 0 0.57 0 -0 0</pose>
       <inertial>
@@ -41,6 +45,23 @@
           <izz>5e-05</izz>
         </inertia>
       </inertial>
+      <collision name='pendulum_collision'>
+        <pose>0 0 0.25 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.5</length>
+            <radius>0.01</radius>
+          </cylinder>
+        </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
+      </collision>
       <visual name='pendulum_visual'>
         <pose>0 0 0.25 0 -0 0</pose>
         <geometry>
@@ -89,8 +110,7 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>1</use_parent_model_frame>
-        <use_parent_model_frame>1</use_parent_model_frame>
+        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
   </model>

--- a/gym_ignition_data/Pendulum/Pendulum.urdf
+++ b/gym_ignition_data/Pendulum/Pendulum.urdf
@@ -14,10 +14,6 @@
         <diffuse>1 0 0 0.8</diffuse>
         <specular>1 0 0 0.8</specular>
         <emissive>1 0 0 0.8</emissive>
-        <script>
-          <uri/>
-          <name/>
-        </script>
       </material>
     </visual>
   </gazebo>
@@ -28,33 +24,33 @@
         <diffuse>0.2 0.2 0.2 0.8</diffuse>
         <specular>0.2 0.2 0.2 0.8</specular>
         <emissive>0.2 0.2 0.2 0.8</emissive>
-        <script>
-          <uri/>
-          <name/>
-        </script>
       </material>
     </visual>
   </gazebo>
   <!-- ===== -->
   <!-- LINKS -->
   <!-- ===== -->
-  <link name="world"/>
   <link name="support">
     <inertial>
-      <!-- This link is fixed, inertial values are not relevant -->
       <origin rpy="0 0 0" xyz="0 0 0.3"/>
-      <mass value="10"/>
-      <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
+      <mass value="1000"/>
+      <inertia ixx="30.8333333333" ixy="0" ixz="0" iyy="30.2083333333" iyz="0" izz="1.04166666667"/>
     </inertial>
     <visual>
       <geometry>
         <box size="0.05 0.1 0.6"/>
       </geometry>
-      <origin rpy="0 0 0" xyz="0 0 -0.3"/>
+      <origin rpy="0 0 0" xyz="0 0 0.3"/>
       <material name="black">
         <color rgba="0.2 0.2 0.2 0.8"/>
       </material>
     </visual>
+    <collision>
+      <geometry>
+        <box size="0.05 0.1 0.6"/>
+      </geometry>
+      <origin rpy="0 0 0" xyz="0 0 0.3"/>
+    </collision>
   </link>
   <link name="pendulum">
     <inertial>
@@ -80,21 +76,21 @@
         <color rgba="1 0 0 0.8"/>
       </material>
     </visual>
+    <collision>
+      <geometry>
+        <cylinder length="0.5" radius="0.01"/>
+      </geometry>
+      <origin rpy="0 0 0" xyz="0 0 0.25"/>
+    </collision>
   </link>
   <!-- ====== -->
   <!-- JOINTS -->
   <!-- ====== -->
-  <!--  http://gazebosim.org/tutorials/?tut=ros_urdf#RigidlyFixingAModeltotheWorld-->
-  <joint name="world_to_support" type="fixed">
-    <parent link="world"/>
-    <child link="support"/>
-    <origin rpy="0 0 0" xyz="0 0 0.6"/>
-  </joint>
   <joint name="pivot" type="continuous">
     <parent link="support"/>
     <child link="pendulum"/>
     <axis xyz="1 0 0"/>
-    <origin rpy="0.0 0 0" xyz="0.035 0 -0.03"/>
+    <origin rpy="0.0 0 0" xyz="0.035 0 0.57"/>
     <limit effort="500" lower="-6.28318530718" upper="6.28318530718" velocity="10"/>
     <dynamics damping="0" friction="0"/>
   </joint>

--- a/gym_ignition_data/Pendulum/Pendulum.urdf.xacro
+++ b/gym_ignition_data/Pendulum/Pendulum.urdf.xacro
@@ -10,7 +10,7 @@
     <xacro:property name="support_x" value="0.05"/>
     <xacro:property name="support_y" value="0.1"/>
     <xacro:property name="support_z" value="${pendulum_length*1.2}"/>
-    <xacro:property name="support_mass" value="10"/>
+    <xacro:property name="support_mass" value="1000"/>
 
     <xacro:property name="rgba_black" value="0 0 0 0.8"/>
     <xacro:property name="rgba_white" value="1 1 1 0.8"/>
@@ -18,7 +18,7 @@
     <xacro:property name="rgba_red" value="1 0 0 0.8"/>
 
     <xacro:macro name="cylinder_inertial_element"
-                 params="mass rotaxis length radius xyz rpy">
+                 params="mass length radius xyz rpy">
         <inertial>
             <origin xyz="${xyz}" rpy="${rpy}"/>
             <mass value="${mass}"/>
@@ -27,6 +27,21 @@
             <xacro:property name="iyy"
                             value="${1/12*mass*(3*radius*radius+length*length)}"/>
             <xacro:property name="izz" value="${0.5*mass*radius*radius}"/>
+            <inertia ixx="${ixx}" ixy="0" ixz="0" iyy="${iyy}" iyz="0" izz="${izz}"/>
+        </inertial>
+    </xacro:macro>
+
+    <xacro:macro name="box_inertial_element"
+                 params="mass dimx dimy dimz xyz rpy">
+        <inertial>
+            <origin xyz="${xyz}" rpy="${rpy}"/>
+            <mass value="${mass}"/>
+            <xacro:property name="ixx"
+                            value="${1/12*mass*(dimy*dimy+dimz*dimz)}"/>
+            <xacro:property name="iyy"
+                            value="${1/12*mass*(dimx*dimx+dimz*dimz)}"/>
+            <xacro:property name="izz"
+                            value="${1/12*mass*(dimx*dimx+dimy*dimy)}"/>
             <inertia ixx="${ixx}" ixy="0" ixz="0" iyy="${iyy}" iyz="0" izz="${izz}"/>
         </inertial>
     </xacro:macro>
@@ -45,10 +60,6 @@
                     <diffuse>${rgba}</diffuse>
                     <specular>${rgba}</specular>
                     <emissive>${rgba}</emissive>
-                    <script>
-                        <uri></uri>
-                        <name></name>
-                    </script>
                 </material>
             </visual>
         </gazebo>
@@ -65,27 +76,30 @@
     <!-- LINKS -->
     <!-- ===== -->
 
-    <link name="world"/>
-
     <link name="support">
-        <inertial>
-            <!-- This link is fixed, inertial values are not relevant -->
-            <origin xyz="0 0 ${support_z*0.5}" rpy="0 0 0"/>
-            <mass value="${support_mass}"/>
-            <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
-        </inertial>
+        <xacro:box_inertial_element mass="${support_mass}"
+                                    dimx="${support_x}"
+                                    dimy="${support_y}"
+                                    dimz="${support_z}"
+                                    xyz="0 0 ${support_z*0.5}"
+                                    rpy="0 0 0"/>
         <visual>
             <geometry>
                 <box size="${support_x} ${support_y} ${support_z}"/>
             </geometry>
-            <origin xyz="0 0 -${support_z*0.5}" rpy="0 0 0"/>
+            <origin xyz="0 0 ${support_z*0.5}" rpy="0 0 0"/>
             <xacro:mymaterial name="black" rgba="${rgba_grey}"/>
         </visual>
+        <collision>
+            <geometry>
+                <box size="${support_x} ${support_y} ${support_z}"/>
+            </geometry>
+            <origin xyz="0 0 ${support_z*0.5}" rpy="0 0 0"/>
+        </collision>
     </link>
 
     <link name="pendulum">
         <xacro:cylinder_inertial_element mass="${pendulum_mass}"
-                                         rotaxis="x"
                                          length="${pendulum_length}"
                                          radius="${pendulum_radius}"
                                          xyz="0 0 ${pendulum_length/2}"
@@ -105,24 +119,23 @@
             <origin xyz="0 0 0" rpy="0 ${pi/2} 0"/>
             <xacro:mymaterial name="red" rgba="${rgba_red}"/>
         </visual>
+        <collision>
+            <geometry>
+                <cylinder length="${pendulum_length}" radius="${pendulum_radius}"/>
+            </geometry>
+            <origin xyz="0 0 ${pendulum_length/2}" rpy="0 0 0"/>
+        </collision>
     </link>
 
     <!-- ====== -->
     <!-- JOINTS -->
     <!-- ====== -->
 
-    <!--  http://gazebosim.org/tutorials/?tut=ros_urdf#RigidlyFixingAModeltotheWorld-->
-    <joint name="world_to_support" type="fixed">
-        <parent link="world"/>
-        <child link="support"/>
-        <origin xyz="0 0 ${support_z}" rpy="0 0 0"/>
-    </joint>
-
     <joint name="pivot" type="continuous">
         <parent link="support"/>
         <child link="pendulum"/>
         <axis xyz="1 0 0"/>
-        <origin xyz="${support_x/2+pendulum_radius} 0 ${-pendulum_circle_radius}"
+        <origin xyz="${support_x/2+pendulum_radius} 0 ${support_z-pendulum_circle_radius}"
                 rpy="${theta_0} 0 0"/>
         <limit lower="${-2*pi}" upper="${2*pi}" effort="500" velocity="10"/>
         <dynamics damping="0" friction="0"/>

--- a/gympp/include/gympp/Robot.h
+++ b/gympp/include/gympp/Robot.h
@@ -18,6 +18,8 @@ namespace gympp {
     class Robot;
     using RobotPtr = std::shared_ptr<gympp::Robot>;
     struct PID;
+    struct BasePose;
+    struct BaseVelocity;
 } // namespace gympp
 
 struct gympp::PID
@@ -34,11 +36,24 @@ struct gympp::PID
     double d;
 };
 
+struct gympp::BasePose
+{
+    std::array<double, 3> position;
+    std::array<double, 4> orientation;
+};
+
+struct gympp::BaseVelocity
+{
+    std::array<double, 3> linear;
+    std::array<double, 3> angular;
+};
+
 class gympp::Robot
 {
 public:
     using VectorContainer = std::vector<double>;
 
+    using LinkName = std::string;
     using RobotName = std::string;
     using JointName = std::string;
     using JointNames = std::vector<JointName>;
@@ -93,6 +108,22 @@ public:
                             const double jointVelocity = 0) = 0;
 
     virtual bool update(const std::chrono::duration<double> time) = 0;
+
+    // ==============
+    // RobotBaseFrame
+    // ==============
+
+    virtual LinkName baseFrame() = 0;
+    virtual bool setBaseFrame(const LinkName& baseLink) = 0;
+
+    virtual BasePose basePose() = 0;
+    virtual BaseVelocity baseVelocity() = 0;
+    virtual bool setAsFloatingBase(bool isFloating) = 0;
+    virtual bool resetBasePose(const std::array<double, 3>& position,
+                               const std::array<double, 4>& orientation) = 0;
+    virtual bool resetBaseVelocity(const std::array<double, 3>& linear,
+                                   const std::array<double, 3>& angular) = 0;
+    virtual std::array<double, 6> baseWrench() = 0;
 };
 
 #endif // GYMPP_ROBOT_H

--- a/ignition/include/gympp/gazebo/GazeboWrapper.h
+++ b/ignition/include/gympp/gazebo/GazeboWrapper.h
@@ -40,10 +40,14 @@ namespace sdf {
 struct gympp::gazebo::ModelInitData
 {
     std::string sdfString;
+    bool fixedPose = false;
+    std::string baseLink = "";
     std::string modelName = "";
     std::array<double, 3> position = {0, 0, 0};
     std::array<double, 4> orientation = {1, 0, 0, 0};
 
+    inline void setFixedPose(const bool f) { fixedPose = f; }
+    inline void setBaseLink(const std::string& b) { baseLink = b; }
     inline void setSdfString(const std::string& s) { sdfString = s; }
     inline void setModelName(const std::string& m) { modelName = m; }
     inline void setPosition(const std::array<double, 3> p) { position = p; }

--- a/ignition/include/gympp/gazebo/IgnitionRobot.h
+++ b/ignition/include/gympp/gazebo/IgnitionRobot.h
@@ -13,6 +13,7 @@
 
 #include <ignition/gazebo/Entity.hh>
 #include <ignition/gazebo/EntityComponentManager.hh>
+#include <ignition/gazebo/EventManager.hh>
 #include <sdf/Element.hh>
 
 #include <functional>
@@ -36,7 +37,8 @@ public:
 
     bool configureECM(const ignition::gazebo::Entity& entity,
                       const std::shared_ptr<const sdf::Element>& sdf,
-                      ignition::gazebo::EntityComponentManager& ecm);
+                      ignition::gazebo::EntityComponentManager& ecm,
+                      ignition::gazebo::EventManager& eventManager);
     bool valid() const override;
 
     // ===========
@@ -77,6 +79,22 @@ public:
                     const double jointVelocity = 0) override;
 
     bool update(const std::chrono::duration<double> time) override;
+
+    // ==============
+    // RobotBaseFrame
+    // ==============
+
+    LinkName baseFrame() override;
+    bool setBaseFrame(const LinkName& baseLink) override;
+
+    BasePose basePose() override;
+    BaseVelocity baseVelocity() override;
+    bool setAsFloatingBase(bool isFloating) override;
+    bool resetBasePose(const std::array<double, 3>& position,
+                       const std::array<double, 4>& orientation) override;
+    bool resetBaseVelocity(const std::array<double, 3>& linear,
+                           const std::array<double, 3>& angular) override;
+    std::array<double, 6> baseWrench() override;
 };
 
 #endif // GYMPP_GAZEBO_IGNITIONROBOT_H

--- a/tests/python/test_robot_base.py
+++ b/tests/python/test_robot_base.py
@@ -1,0 +1,143 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import abc
+import pytest
+import numpy as np
+import pybullet_data
+import pybullet as p
+import gympp_bindings as bindings
+from pybullet_utils import bullet_client
+from gym_ignition.utils import resource_finder
+from gym_ignition.robots.sim import gazebo, pybullet
+
+
+class Simulator(abc.ABC):
+    simulator_name: str = ""
+    @abc.abstractmethod
+    def step(self): ...
+
+
+class Gazebo(Simulator):
+    simulator_name = "gazebo"
+
+    def __init__(self, physics_rate: float):
+        rtf = 1.0
+        iterations = 1
+        self._gazebo = bindings.GazeboWrapper(iterations, rtf, physics_rate)
+        assert self._gazebo
+
+        self._gazebo.setVerbosity(4)
+
+        empty_world = resource_finder.find_resource("DefaultEmptyWorld.world")
+        ok_world = self._gazebo.setupGazeboWorld(worldFile=empty_world)
+        assert ok_world
+
+        ok_initialize = self._gazebo.initialize()
+        assert ok_initialize
+
+    def step(self):
+        self._gazebo.run()
+
+
+class PyBullet(Simulator):
+    simulator_name = "pybullet"
+
+    def __init__(self, physics_rate: float):
+        self._pybullet = bullet_client.BulletClient(p.DIRECT)
+        assert self._pybullet
+
+        self._pybullet.setRealTimeSimulation(0)
+        self._pybullet.setGravity(0, 0, -9.81)
+        self._pybullet.setTimeStep(1.0 / physics_rate)
+
+        self._pybullet.setAdditionalSearchPath(pybullet_data.getDataPath())
+        self.plane_id = self._pybullet.loadURDF("plane_implicit.urdf")
+
+    def step(self):
+        self._pybullet.stepSimulation()
+
+
+def get_simulator(simulator_name: str) -> Simulator:
+    if simulator_name == "gazebo":
+        return Gazebo(500.0)
+    elif simulator_name == "pybullet":
+        return PyBullet(500.0)
+    else:
+        raise Exception(f"Simulator {simulator_name} not recognized")
+
+
+def get_robot(simulator: Simulator, **kwargs):
+    if simulator.simulator_name == "gazebo":
+        return gazebo.pendulum.PendulumGazeboRobot(model_file="Pendulum/Pendulum.sdf",
+                                                   gazebo=simulator._gazebo,
+                                                   **kwargs)
+    elif simulator.simulator_name == "pybullet":
+        return pybullet.pendulum.PendulumPyBulletRobot(model_file="Pendulum/Pendulum.sdf",
+                                                       p=simulator._pybullet,
+                                                       plane_id=simulator.plane_id,
+                                                       **kwargs)
+    else:
+        raise Exception(f"Simulator {simulator.simulator_name} not recognized")
+
+
+@pytest.mark.parametrize("simulator_name", ["gazebo", "pybullet"])
+def test_robot_fixed_base(simulator_name: str):
+    simulator = get_simulator(simulator_name)
+    base_position = np.array([-3, 3, 2])
+    robot = get_robot(simulator, base_position=base_position, floating=False)
+
+    # Robot should not fall due to gravity
+    for _ in range(100):
+        simulator.step()
+
+    assert np.allclose(robot.base_pose()[0], base_position, atol=1e-3)
+    assert np.allclose(robot.base_pose()[1], np.array([1.0, 0, 0, 0]), atol=1e-3)
+
+
+@pytest.mark.parametrize("simulator_name", ["gazebo", "pybullet"])
+def test_robot_floating_base(simulator_name: str):
+    simulator = get_simulator(simulator_name)
+    base_position = np.array([-3, 3, 2])
+    robot = get_robot(simulator, base_position=base_position, floating=True)
+
+    assert np.allclose(robot.base_pose()[0], base_position, atol=1e-3)
+    assert np.allclose(robot.base_pose()[1], np.array([1.0, 0, 0, 0]), atol=1e-3)
+
+    old_pos_z = base_position[2]
+
+    # Robot will fall due to gravity
+    for _ in range(100):
+        simulator.step()
+        current_pos_z = robot.base_pose()[0][2]
+        assert current_pos_z < old_pos_z
+        old_pos_z = current_pos_z
+
+
+@pytest.mark.parametrize("simulator_name", ["pybullet"])
+def test_robot_floating_to_fixed(simulator_name: str):
+    simulator = get_simulator(simulator_name)
+    base_position = np.array([-3, 3, 2])
+    robot = get_robot(simulator, base_position=base_position, floating=True)
+
+    # Let's make the robot fall a little
+    for _ in range(10):
+        simulator.step()
+
+    current_base_position, current_base_orientation = robot.base_pose()
+    assert current_base_position[2] < base_position[2]
+
+    ok_fixed_base = robot.set_as_floating_base(False)
+    assert ok_fixed_base, "Failed to set the robot as fixed base"
+
+    ok_reset_base_pose = robot.reset_base_pose(current_base_position,
+                                               current_base_orientation)
+    assert ok_reset_base_pose, "Failed to reset the base pose"
+
+    # Robot should now not fall due to gravity
+    for _ in range(100):
+        simulator.step()
+
+    assert np.allclose(robot.base_pose()[0], current_base_position, atol=1e-3)
+    assert np.allclose(robot.base_pose()[1], current_base_orientation, atol=1e-3)


### PR DESCRIPTION
This PR finalizes the support of specifying and setting the base pose of models that are inserted during runtime. There are few different cases to consider.

Models specified in the SDF can be:

- Fixed base, by fixing the base to the world with a fixed joint ([documentation](http://gazebosim.org/tutorials/?tut=ros_urdf#RigidlyFixingAModeltotheWorld))
- Floating base

If a fixed-base model is inserted during runtime in Ignition Gazebo, its pose cannot be changed [1] without dirty workarounds (e.g. removing in the ECM the world to base joint and, _in the following physics step_, change the pose). To keep things simple, I propose we support only:

1. Inserting a fixed-base model and do not allow changing its pose.
1. Inserting a floating-base model. Users can change the base pose as they wish.
1. Transforming a floating-base robot to a fixed base robot. Due to 1) this operation cannot be undone unless removing and inserting again the model in the world.

Closes https://github.com/robotology/gym-ignition/issues/80

---

[1] If I recall, the reason of this behaviour is that DART creates a weld joint between world and base. The resulting model chain is not considered a FreeGroup and therefore changing its pose using the `WorldPoseCmd` component would not work.