### PR TITLE
Add fixed-base torque controllers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,16 @@ add_subdirectory(deps)
 # Add the C++ sources subdirectory
 add_subdirectory(gympp)
 
+find_package(Eigen3)
+find_package(iDynTree)
+
+# Add the controllers
+if(${Eigen3_FOUND} AND ${iDynTree_FOUND})
+    add_subdirectory(controllers)
+else()
+    message(STATUS "Disabling controllers. Either iDynTree of Eigen3 not found")
+endif()
+
 # ========
 # IGNITION
 # ========

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ The project is composed of the following components:
 | [**`plugins`**](plugins/)                     | Ignition Gazebo plugins.                                     |
 | [**`gym_ignition`**](gym_ignition/)           | Python package for creating OpenAI Gym environments. Environments can be implemented either in C++ using `gympp` or in Python using the SWIG binded classes of the `ignition` component. |
 | [**`gym_ignition_data`**](gym_ignition_data/) | SDF and URDF models and Gazebo worlds.                       |
+| [**`controllers`**](controllers/)             | Generic implementation of fixed-base and floating-base robot controllers. |
 | [**`gympp`**](gympp/)                         | An _experimental_ C++ port of the OpenAI [Gym interfaces](https://github.com/openai/gym/tree/master/gym), used to create pure C++ environments. |
 
 ## Why
@@ -205,6 +206,8 @@ Execute all the setup commands in the same terminal.
    virtualenv -p python3.6 $HOME/venv
    source $HOME/venv/bin/activate
    ```
+
+1. _Optional_: install `libeigen3-dev` and [iDynTree](https://github.com/robotology/iDynTree) to enable the provided robot controllers. Make sure to enable the CMake option `IDYNTREE_USES_PYTHON` while configuring the project.
 
 ### User setup
 

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${swig_name} PUBLIC
     RobotSingleton
     GazeboWrapper
     IgnitionRobot
+    Controllers
     ${PYTHON_LIBRARIES})
 
 set_property(TARGET ${swig_name} PROPERTY

--- a/bindings/gympp_bindings.i
+++ b/bindings/gympp_bindings.i
@@ -3,6 +3,10 @@
 %{
 #define SWIG_FILE_WITH_INIT
 #include "gympp/Common.h"
+#include "gympp/controllers/Controller.h"
+#include "gympp/controllers/PositionController.h"
+#include "gympp/controllers/PositionControllerReferences.h"
+#include "gympp/controllers/ComputedTorqueFixedBase.h"
 #include "gympp/Environment.h"
 #include "gympp/gazebo/IgnitionEnvironment.h"
 #include "gympp/gazebo/GazeboWrapper.h"
@@ -55,6 +59,7 @@
 %template(Optional_d) std::optional<double>;
 %template(Optional_state) std::optional<gympp::State>;
 %template(Optional_sample) std::optional<gympp::data::Sample>;
+%template(Optional_vector_d) std::optional<std::vector<double>>;
 
 %include <std_shared_ptr.i>
 %shared_ptr(gympp::spaces::Space)
@@ -105,3 +110,8 @@
 %include "gympp/Metadata.h"
 %include "gympp/GymFactory.h"
 %include "gympp/gazebo/RobotSingleton.h"
+
+%include "gympp/controllers/Controller.h"
+%include "gympp/controllers/PositionControllerReferences.h"
+%include "gympp/controllers/PositionController.h"
+%include "gympp/controllers/ComputedTorqueFixedBase.h"

--- a/controllers/CMakeLists.txt
+++ b/controllers/CMakeLists.txt
@@ -1,0 +1,53 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+set(ControllersPublicHeaders
+    include/gympp/controllers/Controller.h
+    include/gympp/controllers/PositionController.h
+    include/gympp/controllers/PositionControllerReferences.h
+    include/gympp/controllers/ComputedTorqueFixedBase.h)
+
+add_library(Controllers
+    ${ControllersPublicHeaders}
+    src/ComputedTorqueFixedBase.cpp)
+
+set_target_properties(Controllers PROPERTIES PUBLIC_HEADER
+     "${ControllersPublicHeaders}")
+
+target_include_directories(Controllers PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+target_include_directories(Controllers PRIVATE ${EIGEN3_INCLUDE_DIR})
+
+target_link_libraries(Controllers
+    PUBLIC
+    gympp
+    PRIVATE
+    iDynTree::idyntree-core
+    iDynTree::idyntree-model
+    iDynTree::idyntree-modelio-urdf
+    iDynTree::idyntree-high-level)
+
+find_package(ignition-common3 QUIET)
+if(ignition-common3_FOUND)
+    target_compile_definitions(Controllers PRIVATE USE_IGNITION_LOGS)
+    target_link_libraries(Controllers PRIVATE
+        ignition-common3::ignition-common3)
+endif()
+
+# ===================
+# INSTALL THE TARGETS
+# ===================
+
+if(NOT CMAKE_BUILD_TYPE STREQUAL "PyPI")
+    install(
+        TARGETS
+        Controllers
+        EXPORT gympp
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gympp/controllers)
+endif()

--- a/controllers/include/gympp/controllers/ComputedTorqueFixedBase.h
+++ b/controllers/include/gympp/controllers/ComputedTorqueFixedBase.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef GYMPP_CONTROLLERS_COMPUTEDTORQUEFIXEDBASE_H
+#define GYMPP_CONTROLLERS_COMPUTEDTORQUEFIXEDBASE_H
+
+#include "gympp/Robot.h"
+#include "gympp/controllers/Controller.h"
+#include "gympp/controllers/PositionController.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace gympp {
+    namespace controllers {
+        class ComputedTorqueFixedBase;
+    } // namespace controllers
+} // namespace gympp
+
+class gympp::controllers::ComputedTorqueFixedBase
+    : public gympp::controllers::Controller
+    , public gympp::controllers::PositionController
+{
+private:
+    class Impl;
+    std::unique_ptr<Impl> pImpl;
+
+public:
+    ComputedTorqueFixedBase() = delete;
+    ComputedTorqueFixedBase(const std::string& urdfFile,
+                            gympp::RobotPtr robot,
+                            const std::vector<double>& kp,
+                            const std::vector<double>& kd,
+                            const std::vector<std::string>& controlledJoints);
+    ~ComputedTorqueFixedBase() override;
+
+    bool initialize() override;
+    std::optional<std::vector<double>> step() override;
+    bool terminate() override;
+
+    bool setReferences(const gympp::controllers::PositionControllerReferences& references) override;
+};
+
+#endif // GYMPP_CONTROLLERS_COMPUTEDTORQUEFIXEDBASE_H

--- a/controllers/include/gympp/controllers/Controller.h
+++ b/controllers/include/gympp/controllers/Controller.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef GYMPP_CONTROLLERS_CONTROLLER_H
+#define GYMPP_CONTROLLERS_CONTROLLER_H
+
+#include <chrono>
+#include <optional>
+#include <vector>
+
+namespace gympp {
+    class Robot;
+    namespace controllers {
+        class Controller;
+    } // namespace controllers
+} // namespace gympp
+
+class gympp::controllers::Controller
+{
+public:
+    using StepSize = std::chrono::duration<double>;
+
+    virtual ~Controller() = default;
+
+    virtual bool initialize() = 0;
+    virtual std::optional<std::vector<double>> step() = 0;
+    virtual bool terminate() = 0;
+};
+
+#endif // GYMPP_CONTROLLERS_CONTROLLER_H

--- a/controllers/include/gympp/controllers/PositionController.h
+++ b/controllers/include/gympp/controllers/PositionController.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef GYMPP_CONTROLLERS_POSITIONCONTROLLER_H
+#define GYMPP_CONTROLLERS_POSITIONCONTROLLER_H
+
+namespace gympp {
+    class Robot;
+    namespace controllers {
+        class PositionController;
+        class PositionControllerReferences;
+    } // namespace controllers
+} // namespace gympp
+
+class gympp::controllers::PositionController
+{
+public:
+    virtual ~PositionController() = default;
+    virtual bool
+    setReferences(const gympp::controllers::PositionControllerReferences& references) = 0;
+};
+
+#endif // GYMPP_CONTROLLERS_POSITIONCONTROLLER_H

--- a/controllers/include/gympp/controllers/PositionControllerReferences.h
+++ b/controllers/include/gympp/controllers/PositionControllerReferences.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef GYMPP_CONTROLLERS_POSITIONREFERENCES_H
+#define GYMPP_CONTROLLERS_POSITIONREFERENCES_H
+
+#include <array>
+#include <string>
+#include <vector>
+
+namespace gympp {
+    class Robot;
+    namespace controllers {
+        struct BaseReferences;
+        struct JointReferences;
+        class PositionControllerReferences;
+    } // namespace controllers
+} // namespace gympp
+
+struct gympp::controllers::BaseReferences
+{
+    std::array<double, 3> position = {0, 0, 0};
+    std::array<double, 4> orientation = {1, 0, 0, 0};
+    std::array<double, 3> linearVelocity = {0, 0, 0};
+    std::array<double, 3> angularVelocity = {0, 0, 0};
+};
+
+struct gympp::controllers::JointReferences
+{
+    std::vector<double> position;
+    std::vector<double> velocity;
+    std::vector<double> acceleration;
+};
+
+class gympp::controllers::PositionControllerReferences
+{
+public:
+    PositionControllerReferences(const size_t controlledDofs = 0)
+    {
+        const std::vector<double> zeros(controlledDofs, 0.0);
+        joints.position = zeros;
+        joints.velocity = zeros;
+        joints.acceleration = zeros;
+    }
+
+    BaseReferences base = {};
+    JointReferences joints = {};
+
+    inline bool valid() const
+    {
+        size_t dofs = joints.position.size();
+        return dofs > 0 && joints.velocity.size() == dofs && joints.acceleration.size() == dofs;
+    }
+
+    // TODO: flatten()
+    // TODO: import(const std::vector<double>& input, size_t options)
+};
+
+#endif // GYMPP_CONTROLLERS_POSITIONREFERENCES_H

--- a/controllers/src/ComputedTorqueFixedBase.cpp
+++ b/controllers/src/ComputedTorqueFixedBase.cpp
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include "gympp/controllers/ComputedTorqueFixedBase.h"
+#include "gympp/Log.h"
+#include "gympp/controllers/PositionControllerReferences.h"
+
+#include <Eigen/Dense>
+#include <iDynTree/Core/EigenHelpers.h>
+#include <iDynTree/Core/MatrixDynSize.h>
+#include <iDynTree/Core/VectorDynSize.h>
+#include <iDynTree/Core/VectorFixSize.h>
+#include <iDynTree/KinDynComputations.h>
+#include <iDynTree/Model/FreeFloatingState.h>
+#include <iDynTree/ModelIO/ModelLoader.h>
+
+using namespace gympp::controllers;
+
+class ComputedTorqueFixedBase::Impl
+{
+public:
+    class Buffers;
+
+    std::string urdfFile;
+    gympp::RobotPtr robot;
+    std::vector<std::string> controlledJoints;
+
+    std::vector<double> kpInitial;
+    std::vector<double> kdInitial;
+    std::unordered_map<std::string, JointControlMode> initialControlMode;
+
+    PositionControllerReferences references;
+    std::unique_ptr<Buffers> buffers;
+    std::unique_ptr<iDynTree::KinDynComputations> kinDyn;
+
+    static Eigen::Map<Eigen::VectorXd> toEigen(const std::vector<double>& vector)
+    {
+        return {const_cast<double*>(vector.data()), Eigen::Index(vector.size())};
+    }
+};
+
+class ComputedTorqueFixedBase::Impl::Buffers
+{
+public:
+    Buffers(const unsigned controlledDofs = 0)
+    {
+        jointPositions.resize(controlledDofs);
+        jointVelocities.resize(controlledDofs);
+        massMatrix.resize(controlledDofs + 6, controlledDofs + 6);
+
+        kp = Eigen::ArrayXd(controlledDofs);
+        kd = Eigen::ArrayXd(controlledDofs);
+
+        torques = Eigen::VectorXd(controlledDofs);
+        s_ddot_star = Eigen::VectorXd(controlledDofs);
+        positionError = Eigen::VectorXd(controlledDofs);
+        velocityError = Eigen::VectorXd(controlledDofs);
+    }
+
+    iDynTree::Vector3 gravity;
+    iDynTree::MatrixDynSize massMatrix;
+    iDynTree::VectorDynSize jointPositions;
+    iDynTree::VectorDynSize jointVelocities;
+    iDynTree::FreeFloatingGeneralizedTorques biasForces;
+
+    Eigen::ArrayXd kp;
+    Eigen::ArrayXd kd;
+
+    Eigen::VectorXd torques;
+    Eigen::VectorXd s_ddot_star;
+    Eigen::VectorXd positionError;
+    Eigen::VectorXd velocityError;
+};
+
+ComputedTorqueFixedBase::ComputedTorqueFixedBase(const std::string& urdfFile,
+                                                 gympp::RobotPtr robot,
+                                                 const std::vector<double>& kp,
+                                                 const std::vector<double>& kd,
+                                                 const std::vector<std::string>& controlledJoints)
+    : pImpl{std::make_unique<Impl>()}
+{
+    pImpl->robot = robot;
+    pImpl->urdfFile = urdfFile;
+    pImpl->controlledJoints = controlledJoints;
+    assert(robot->valid());
+    assert(!pImpl->urdfFile.empty());
+    assert(robot->dofs() == controlledJoints.size() || controlledJoints.empty());
+
+    pImpl->kpInitial = kp;
+    pImpl->kdInitial = kd;
+    assert(robot->dofs() == kp.size());
+    assert(kp.size() == kd.size());
+}
+
+ComputedTorqueFixedBase::~ComputedTorqueFixedBase() = default;
+
+bool ComputedTorqueFixedBase::initialize()
+{
+    gymppDebug << "Initializing ComputedTorqueFixedBaseCpp" << std::endl;
+
+    if (pImpl->kinDyn) {
+        gymppWarning << "The KinDynComputations object has been already initialized" << std::endl;
+        return true;
+    }
+
+    if (!(pImpl->robot && pImpl->robot->valid())) {
+        gymppError << "Couldn't initialize controller. Robot not valid." << std::endl;
+        return false;
+    }
+
+    if (pImpl->controlledJoints.empty()) {
+        gymppDebug << "No list of controlled joints. Controlling all the robots joints."
+                   << std::endl;
+
+        // Read the joint names from the robot object.
+        // This is useful to use the same joint serialization in the vectorized methods.
+        pImpl->controlledJoints = pImpl->robot->jointNames();
+    }
+
+    iDynTree::ModelLoader loader;
+    if (!loader.loadReducedModelFromFile(pImpl->urdfFile, pImpl->controlledJoints)) {
+        gymppError << "Failed to load reduced model from the urdf file" << std::endl;
+        return false;
+    }
+
+    pImpl->kinDyn = std::make_unique<iDynTree::KinDynComputations>();
+    pImpl->kinDyn->setFrameVelocityRepresentation(iDynTree::MIXED_REPRESENTATION);
+
+    if (!pImpl->kinDyn->loadRobotModel(loader.model())) {
+        gymppError << "Failed to insert model in the KinDynComputations object" << std::endl;
+        return false;
+    }
+
+    // Set controlled joints in torque control mode
+    for (const auto& jointName : pImpl->controlledJoints) {
+        pImpl->initialControlMode[jointName] = pImpl->robot->jointControlMode(jointName);
+
+        if (!pImpl->robot->setJointControlMode(jointName, JointControlMode::Torque)) {
+            gymppError << "Failed to control joint '" << jointName << "' in Torque" << std::endl;
+            return false;
+        }
+    }
+
+    // Initialize buffers
+    gymppDebug << "Controlling " << pImpl->controlledJoints.size() << " DoFs" << std::endl;
+    pImpl->buffers = std::make_unique<Impl::Buffers>(pImpl->controlledJoints.size());
+
+    pImpl->buffers->kp = Impl::toEigen(pImpl->kpInitial);
+    pImpl->buffers->kd = Impl::toEigen(pImpl->kdInitial);
+    pImpl->buffers->gravity.zero(); // TODO: if we randomize gravity, this has to be exposed
+    pImpl->buffers->gravity(2) = -9.8182;
+    pImpl->buffers->biasForces.resize(loader.model());
+
+    return true;
+}
+
+std::optional<std::vector<double>> ComputedTorqueFixedBase::step()
+{
+    // ==================
+    // KINDYNCOMPUTATIONS
+    // ==================
+
+    for (unsigned i = 0; i < pImpl->controlledJoints.size(); ++i) {
+        const auto& jointName = pImpl->controlledJoints[i];
+        pImpl->buffers->jointPositions.setVal(i, pImpl->robot->jointPosition(jointName));
+        pImpl->buffers->jointVelocities.setVal(i, pImpl->robot->jointVelocity(jointName));
+    }
+
+    if (!pImpl->kinDyn->setRobotState(pImpl->buffers->jointPositions,
+                                      pImpl->buffers->jointVelocities,
+                                      pImpl->buffers->gravity)) {
+        gymppError << "Failed to set the robot state" << std::endl;
+        return {};
+    }
+
+    if (!pImpl->kinDyn->getFreeFloatingMassMatrix(pImpl->buffers->massMatrix)) {
+        gymppError << "Failed to get the mass matrix" << std::endl;
+        return {};
+    }
+
+    if (!pImpl->kinDyn->generalizedBiasForces(pImpl->buffers->biasForces)) {
+        gymppError << "Failed to get the bias forces " << std::endl;
+        return {};
+    }
+
+    // ===================
+    // INTERMEDIATE VALUES
+    // ===================
+
+    const auto nrControlledDofs = pImpl->buffers->jointPositions.size();
+
+    auto Mfloating = iDynTree::toEigen(pImpl->buffers->massMatrix);
+
+    auto h = iDynTree::toEigen(pImpl->buffers->biasForces.jointTorques());
+    auto M = Mfloating.bottomRightCorner(nrControlledDofs, nrControlledDofs);
+    assert(h.size() == nrControlledDofs);
+    assert(M.size() == nrControlledDofs * nrControlledDofs);
+
+    auto s = iDynTree::toEigen(pImpl->buffers->jointPositions);
+    auto s_dot = iDynTree::toEigen(pImpl->buffers->jointVelocities);
+    assert(s.size() == nrControlledDofs);
+    assert(s_dot.size() == nrControlledDofs);
+
+    auto s_ref = Impl::toEigen(pImpl->references.joints.position);
+    auto s_ref_dot = Impl::toEigen(pImpl->references.joints.velocity);
+    auto s_ref_ddot = Impl::toEigen(pImpl->references.joints.acceleration);
+    assert(s_ref.size() == nrControlledDofs);
+    assert(s_ref_dot.size() == nrControlledDofs);
+    assert(s_ref_ddot.size() == nrControlledDofs);
+
+    auto& kp = pImpl->buffers->kp;
+    auto& kd = pImpl->buffers->kd;
+    auto& s_tilde = pImpl->buffers->positionError;
+    auto& s_dot_tilde = pImpl->buffers->velocityError;
+    assert(kp.size() == nrControlledDofs);
+    assert(kd.size() == nrControlledDofs);
+    assert(s_tilde.size() == nrControlledDofs);
+    assert(s_dot_tilde.size() == nrControlledDofs);
+
+    auto& tau = pImpl->buffers->torques;
+    auto& s_ddot_star = pImpl->buffers->s_ddot_star;
+    assert(tau.size() == nrControlledDofs);
+    assert(s_ddot_star.size() == nrControlledDofs);
+
+    // ===========
+    // CONTROL LAW
+    // ===========
+
+    s_tilde = s - s_ref;
+    s_dot_tilde = s_dot - s_ref_dot;
+
+    s_ddot_star = s_ref_ddot.array() - kp * s_tilde.array() - kd * s_dot_tilde.array();
+
+    tau = M * pImpl->buffers->s_ddot_star + h;
+
+    return std::vector<double>(pImpl->buffers->torques.data(),
+                               pImpl->buffers->torques.data() + pImpl->buffers->torques.size());
+}
+
+bool ComputedTorqueFixedBase::terminate()
+{
+    bool ok = true;
+
+    for (const auto& [jointName, controlMode] : pImpl->initialControlMode) {
+        if (!pImpl->robot->setJointControlMode(jointName, controlMode)) {
+            gymppError << "Failed to restore original control mode of joint '" << jointName << "'"
+                       << std::endl;
+            ok = false;
+        }
+    }
+
+    pImpl->kinDyn.reset();
+    pImpl->buffers.reset();
+    return ok;
+}
+
+bool ComputedTorqueFixedBase::setReferences(const PositionControllerReferences& references)
+{
+    if (!references.valid()) {
+        gymppError << "References are not valid" << std::endl;
+        return false;
+    }
+
+    pImpl->references = references;
+    return true;
+}

--- a/gym_ignition/base/__init__.py
+++ b/gym_ignition/base/__init__.py
@@ -6,6 +6,7 @@
 from . import task
 from . import robot
 from . import runtime
+from gym_ignition.base import controllers
 
 # Base C++ environment
 from . import gympp_env

--- a/gym_ignition/base/controllers.py
+++ b/gym_ignition/base/controllers.py
@@ -1,0 +1,96 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import abc
+import os.path
+import numpy as np
+from typing import List, NamedTuple
+from gym_ignition.utils import logger
+from gym_ignition.base.robot import RobotFeatures
+
+
+class Controller:
+    def __init__(self,
+                 dt: float,
+                 urdf: str,
+                 robot: RobotFeatures,
+                 controlled_joints: List[str]):
+
+        self.dt = dt
+        self.urdf = urdf
+        self.robot = robot
+        self.controlled_joints = controlled_joints
+
+        if not robot.valid():
+            raise Exception("The Robot object is not valid")
+
+        if not self.controlled_joints:
+            logger.debug("Controlling all robot joints")
+            self.controlled_joints = self.robot.joint_names()
+
+        if not os.path.isfile(urdf):
+            raise Exception(f"The urdf file '{urdf}' does not exist")
+
+    @property
+    def nr_controlled_dofs(self) -> int:
+        return len(self.controlled_joints)
+
+    @abc.abstractmethod
+    def initialize(self) -> bool:
+        pass
+
+    @abc.abstractmethod
+    def step(self) -> np.ndarray:
+        pass
+
+    @abc.abstractmethod
+    def terminate(self) -> bool:
+        pass
+
+
+class PositionControllerReferences(NamedTuple):
+    position: np.ndarray                         # (1 x DoF)
+    velocity: np.ndarray = None                  # (1 x DoF)
+    acceleration: np.ndarray = None              # (1 x DoF)
+    base_position: np.ndarray = np.zeros(3)      # (1 x 3)
+    base_orientation: np.ndarray = np.zeros(4)   # (1 x 4)
+    base_lin_velocity: np.ndarray = np.zeros(3)  # (1 x 3)
+    base_ang_velocity: np.ndarray = np.zeros(3)  # (1 x 3)
+
+    def flatten(self) -> np.ndarray:
+        output = np.ndarray([], dtype=np.float)
+        for _, value in self._asdict().items():
+            if value:
+                output = np.append(output, value)
+        return output
+
+    def valid(self) -> bool:
+        dofs = self.position.size
+        return \
+            dofs > 0 and \
+            self.velocity.size == self.acceleration.size == dofs and \
+            self.base_position.size == 3 and \
+            self.base_orientation.size == 4 and \
+            self.base_lin_velocity.size == 3 and \
+            self.base_ang_velocity.size == 3
+
+
+class PositionController(Controller, abc.ABC):
+    def __init__(self,
+                 dt: float,
+                 urdf: str,
+                 robot: RobotFeatures,
+                 controlled_joints: List[str],
+                 floating_base: bool = False):
+
+        self._is_floating_base = floating_base
+
+        super().__init__(dt=dt,
+                         urdf=urdf,
+                         robot=robot,
+                         controlled_joints=controlled_joints)
+
+    @abc.abstractmethod
+    def set_control_references(self, references: PositionControllerReferences) -> bool:
+        pass

--- a/gym_ignition/controllers/__init__.py
+++ b/gym_ignition/controllers/__init__.py
@@ -3,3 +3,4 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 from . import computed_torque_fixed_base
+from . import computed_torque_fixed_base_cpp

--- a/gym_ignition/controllers/__init__.py
+++ b/gym_ignition/controllers/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+from . import computed_torque_fixed_base

--- a/gym_ignition/controllers/computed_torque_fixed_base.py
+++ b/gym_ignition/controllers/computed_torque_fixed_base.py
@@ -1,0 +1,245 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import abc
+import numpy as np
+from typing import List
+from gym_ignition import base
+from gym_ignition.utils import logger, resource_finder
+from gym_ignition.base.robot import robot_abc, robot_joints
+from gym_ignition.base.controllers import PositionController, PositionControllerReferences
+
+
+@base.robot.feature_detector
+class RobotFeatures(robot_abc.RobotABC,
+                    robot_joints.RobotJoints,
+                    abc.ABC):
+    pass
+
+
+class ComputedTorqueFixedBase(PositionController):
+    """
+    """
+
+    def __init__(self,
+                 robot: RobotFeatures,
+                 urdf: str,
+                 controlled_joints: List[str],
+                 kp: np.ndarray,
+                 kd: np.ndarray,
+                 dt: float = None,
+                 clip_torques: bool = False,
+                 **kwargs) -> None:
+        import iDynTree as idyn
+
+        # Find the urdf file
+        abs_path_urdf = resource_finder.find_resource(urdf)
+
+        # Initialize base class
+        super().__init__(dt=dt,
+                         robot=robot,
+                         urdf=abs_path_urdf,
+                         controlled_joints=controlled_joints)
+
+        # Check that the robot has all the requested features
+        RobotFeatures.has_all_features(robot)
+
+        # Object to compute rigid-body dynamics quantities
+        self.kindyn = idyn.KinDynComputations()
+
+        # Set the velocity representation
+        self.kindyn.setFrameVelocityRepresentation(idyn.MIXED_REPRESENTATION)
+
+        # Gains
+        self.kp = kp
+        self.kd = kd
+
+        self._references = None
+        self._clip_torques = clip_torques
+        self._initial_control_mode = dict()
+
+    def __del__(self):
+        self.terminate()
+
+        # ===============
+    # PRIVATE METHODS
+    # ===============
+
+    def _load_model(self) -> bool:
+        logger.debug(f"Loading model '{self.urdf}' in the fixed-base controller")
+        if len(self.controlled_joints) == self.robot.dofs():
+            logger.debug("Controlling all joints")
+        else:
+            logger.debug(f"Controlling joints: {self.controlled_joints}")
+
+        # Load the urdf model
+        import iDynTree as idyn
+        mdl_loader = idyn.ModelLoader()
+        ok_load = mdl_loader.loadReducedModelFromFile(self.urdf,
+                                                      self.controlled_joints)
+        assert ok_load, "Failed to load urdf model from file"
+
+        # Insert the model in KinDynComputations
+        ok_model = self.kindyn.loadRobotModel(mdl_loader.model())
+        assert ok_model, "Failed to load model in KinDynComputations"
+
+        return ok_model
+
+    def _controlled_joint_positions(self) -> np.ndarray:
+        joint_positions = np.zeros(self.nr_controlled_dofs)
+
+        for idx, name in enumerate(self.controlled_joints):
+            joint_positions[idx] = self.robot.joint_position(name)
+
+        return joint_positions
+
+    def _controlled_joint_velocities(self) -> np.ndarray:
+        joint_velocities = np.zeros(self.nr_controlled_dofs)
+
+        for idx, name in enumerate(self.controlled_joints):
+            joint_velocities[idx] = self.robot.joint_velocity(name)
+
+        return joint_velocities
+
+    # ==================
+    # PositionController
+    # ==================
+
+    def set_control_references(self, references: PositionControllerReferences) -> bool:
+        dofs = references.position.size
+        assert dofs == self.nr_controlled_dofs
+
+        self._references = references
+
+        if references.velocity is None:
+            self._references = \
+                self._references._replace(velocity=np.zeros_like(references.position))
+
+        if references.acceleration is None:
+            self._references = \
+                self._references._replace(acceleration=np.zeros_like(references.position))
+
+        assert self._references.valid()
+        return True
+
+    # ==========
+    # Controller
+    # ==========
+
+    def initialize(self) -> bool:
+        # Load the model
+        ok_model = self._load_model()
+        assert ok_model, "Failed to load the model"
+
+        for name in self.controlled_joints:
+            # Store the initial control mode
+            self._initial_control_mode[name] = self.robot.joint_control_mode(name)
+
+            if self._initial_control_mode[name] is None:
+                self._initial_control_mode[name] = robot_joints.JointControlMode.POSITION
+
+            # Control the joint in TORQUE
+            ok_mode = self.robot.set_joint_control_mode(
+                name, base.robot.robot_joints.JointControlMode.TORQUE)
+            assert ok_mode, f"Failed to control joint '{name}' in TORQUE"
+
+        return True
+
+    def step(self) -> np.ndarray:
+        # ==============
+        # Get joint data
+        # ==============
+
+        joint_positions = self._controlled_joint_positions()
+        joint_velocities = self._controlled_joint_velocities()
+
+        dofs = self.nr_controlled_dofs
+
+        # =============================
+        # Compute rigid-body quantities
+        # =============================
+        import iDynTree as idyn
+
+        s = idyn.VectorDynSize(dofs)
+        s_dot = idyn.VectorDynSize(dofs)
+
+        s = s.FromPython(joint_positions)
+        s_dot = s_dot.FromPython(joint_velocities)
+
+        world_gravity = idyn.Vector3()
+        world_gravity.zero()
+        world_gravity.setVal(2, -9.8182)
+
+        # Not relevant for fixed-base robots
+        pos_base = np.array([0., 0, 0])
+        orient_base = np.array([1., 0, 0, 0])
+
+        world_T_base = idyn.Transform()
+        world_T_base.setPosition(idyn.Position(pos_base[0], pos_base[1], pos_base[2]))
+
+        rot_base = idyn.Rotation()
+        quaternion_base = idyn.Vector4()
+        quaternion_base = quaternion_base.FromPython(orient_base)
+
+        rot_base.fromQuaternion(quaternion_base)
+        world_T_base.setRotation(rot_base)
+
+        base_velocity = idyn.Twist()
+        base_velocity.zero()
+
+        # Set the robot state
+        ok_state = self.kindyn.setRobotState(
+            world_T_base, s, base_velocity, s_dot, world_gravity)
+        assert ok_state, "Failed to set the robot state"
+
+        M = idyn.MatrixDynSize(dofs + 6, dofs + 6)
+        ok_M = self.kindyn.getFreeFloatingMassMatrix(M)
+        assert ok_M, "Failed to get the Mass Matrix"
+
+        h = idyn.FreeFloatingGeneralizedTorques(self.kindyn.getRobotModel())
+        ok_h = self.kindyn.generalizedBiasForces(h)
+        assert ok_h, "Failed to get the Bias forces"
+
+        # ========================
+        # Convert to numpy objects
+        # ========================
+
+        # Extract only the joint-related components and discard the base elements
+        h_j_np = h.jointTorques().toNumPy()
+        M_j_np = M.toNumPy()[6:, 6:]
+
+        # ===============
+        # Get the torques
+        # ===============
+
+        # Compute the errors
+        s_tilde = joint_positions - self._references.position
+        s_dot_tilde = joint_velocities - self._references.velocity
+
+        assert self.kp.shape == s_tilde.shape, "Wrong shape of kp gains"
+        assert self.kd.shape == s_dot_tilde.shape, "Wrong shape of kd gains"
+
+        # Apply the gains
+        s_ddot_desired = self._references.acceleration
+        s_ddot_star = s_ddot_desired - (self.kp * s_tilde + self.kd * s_dot_tilde)
+
+        # Compute the torques
+        tau_np = M_j_np @ s_ddot_star + h_j_np
+
+        # Clip to the maximum torque allowed
+        if self._clip_torques:
+            for idx, joint_name in enumerate(self.controlled_joints):
+                print("Clipped torques")
+                tau_np[idx] = \
+                    np.min([tau_np[idx], self.robot.joint_torque_limits(joint_name)])
+
+        return tau_np
+
+    def terminate(self) -> bool:
+        for joint_name, initial_mode in self._initial_control_mode.items():
+            ok_mode = self.robot.set_joint_control_mode(joint_name, initial_mode)
+            assert ok_mode, \
+                f"Failed to restore initial control mode of joint '{joint_name}'"
+
+        return True

--- a/gym_ignition/controllers/computed_torque_fixed_base_cpp.py
+++ b/gym_ignition/controllers/computed_torque_fixed_base_cpp.py
@@ -1,0 +1,112 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import abc
+import numpy as np
+from typing import List
+import gympp_bindings as bindings
+from gym_ignition import base
+from gym_ignition.utils import logger, resource_finder
+from gym_ignition.base.robot import robot_abc, robot_joints
+from gym_ignition.base.controllers import PositionController, PositionControllerReferences
+
+
+@base.robot.feature_detector
+class RobotFeatures(robot_abc.RobotABC,
+                    robot_joints.RobotJoints,
+                    abc.ABC):
+    pass
+
+
+class ComputedTorqueFixedBaseCpp(PositionController):
+
+    def __init__(self,
+                 robot: RobotFeatures,
+                 urdf: str,
+                 controlled_joints: List[str],
+                 kp: np.ndarray,
+                 kd: np.ndarray,
+                 # dt: float = None,
+                 clip_torques: bool = False,
+                 **kwargs) -> None:
+
+        # Find the urdf file
+        abs_path_urdf = resource_finder.find_resource(urdf)
+
+        # Initialize base class
+        super().__init__(dt=0.0,
+                         robot=robot,
+                         urdf=abs_path_urdf,
+                         controlled_joints=controlled_joints)
+
+        # Check that the robot has all the requested features
+        assert robot.valid(), "The robot object is not valid"
+        RobotFeatures.has_all_features(robot)
+
+        # Make sure that the robot object is a C++ robot
+        try:
+            robot.gympp_robot
+        except AttributeError:
+            logger.error("This controller can be used only with C++ robots objects")
+            raise
+
+        # Prepare C++ controller arguments
+        robot_cpp = robot.gympp_robot
+
+        # Create the C++ controller
+        self._controller = bindings.ComputedTorqueFixedBase(
+            urdf, robot_cpp, kp, kd, controlled_joints)
+
+        # Initialize other attributes
+        self._clip_torques = clip_torques
+        self._references = bindings.PositionControllerReferences(len(controlled_joints))
+
+    # ==================
+    # PositionController
+    # ==================
+
+    def set_control_references(self, references: PositionControllerReferences) -> bool:
+        assert references.valid(), "References are not valid"
+
+        # Populate the C++ class with the references
+        self._references.joints.position = references.position
+        self._references.joints.velocity = references.velocity
+        self._references.joints.acceleration = references.acceleration
+
+        assert self._references.valid(), "Stored references are not valid"
+
+        # Insert the references in the controller
+        ok_refs = self._controller.setReferences(self._references)
+        assert ok_refs, "Failed to set references in the controller"
+
+        return True
+
+    # ==========
+    # Controller
+    # ==========
+
+    def initialize(self) -> bool:
+        ok_initialize = self._controller.initialize()
+        assert ok_initialize, "Failed to initialize cpp controller"
+        return True
+
+    def step(self) -> np.ndarray:
+        torques_optional = self._controller.step()
+        assert torques_optional.has_value(), "Failed to step the controller"
+
+        # Get the torques from the optional type
+        torques = np.array(torques_optional.value())
+
+        # Clip to the maximum torque allowed
+        if self._clip_torques:
+            for idx, joint_name in enumerate(self.controlled_joints):
+                torques[idx] = \
+                    np.min([torques[idx], self.robot.joint_torque_limits(joint_name)])
+
+        return torques
+
+    def terminate(self) -> bool:
+        ok_terminate = self._controller.terminate()
+        assert ok_terminate, "Failed to terminate the controller"
+        return True

--- a/gym_ignition/robots/base/gazebo_robot.py
+++ b/gym_ignition/robots/base/gazebo_robot.py
@@ -188,11 +188,11 @@ class GazeboRobot(robot_abc.RobotABC,
     def joint_velocity(self, joint_name: str) -> float:
         return self.gympp_robot.jointVelocity(joint_name)
 
-    def joint_positions(self) -> List[float]:
-        return self.gympp_robot.jointPositions()
+    def joint_positions(self) -> np.ndarray:
+        return np.array(self.gympp_robot.jointPositions(), dtype=np.float)
 
-    def joint_velocities(self) -> List[float]:
-        return self.gympp_robot.jointVelocities()
+    def joint_velocities(self) -> np.ndarray:
+        return np.array(self.gympp_robot.jointVelocities(), dtype=np.float)
 
     def joint_pid(self, joint_name: str) -> Union[robot_joints.PID, None]:
         gazebo_pid = self.gympp_robot.jointPID(joint_name)

--- a/gym_ignition/robots/base/pybullet_robot.py
+++ b/gym_ignition/robots/base/pybullet_robot.py
@@ -64,6 +64,13 @@ class JointInfoPyBullet(NamedTuple):
     parentIndex: int
 
 
+class JointStatePyBullet(NamedTuple):
+    jointPosition: float
+    jointVelocity: float
+    jointReactionForces: List[float]
+    appliedJointMotorTorque: float
+
+
 class PyBulletRobot(robot.robot_abc.RobotABC,
                     robot.robot_joints.RobotJoints,
                     robot.robot_contacts.RobotContacts,
@@ -330,20 +337,28 @@ class PyBulletRobot(robot.robot_abc.RobotABC,
 
     def joint_position(self, joint_name: str) -> float:
         joint_idx = self._joints_name2index[joint_name]
-        return self._pybullet.getJointState(self._robot_id, joint_idx)[0]
+        state = JointStatePyBullet._make(
+            self._pybullet.getJointState(self._robot_id, joint_idx))
+        return state.jointPosition
 
     def joint_velocity(self, joint_name: str) -> float:
         joint_idx = self._joints_name2index[joint_name]
-        return self._pybullet.getJointState(self._robot_id, joint_idx)[1]
+        state = JointStatePyBullet._make(
+            self._pybullet.getJointState(self._robot_id, joint_idx))
+        return state.jointVelocity
 
     def joint_positions(self) -> List[float]:
-        joint_states = self._pybullet.getJointStates(self._robot_id, range(self.dofs()))
-        joint_positions = [state[0] for state in joint_states]
+        joint_states = self._pybullet.getJointStates(self._robot_id,
+                                                     range(1, self.dofs() + 1))
+        joint_positions = \
+            [JointStatePyBullet._make(state).jointPosition for state in joint_states]
         return joint_positions
 
     def joint_velocities(self) -> List[float]:
-        joint_states = self._pybullet.getJointStates(self._robot_id, range(self.dofs()))
-        joint_velocities = [state[1] for state in joint_states]
+        joint_states = self._pybullet.getJointStates(self._robot_id,
+                                                     range(1, self.dofs() + 1))
+        joint_velocities = \
+            [JointStatePyBullet._make(state).jointVelocity for state in joint_states]
         return joint_velocities
 
     def joint_pid(self, joint_name: str) -> Union[robot.PID, None]:

--- a/gym_ignition/robots/base/pybullet_robot.py
+++ b/gym_ignition/robots/base/pybullet_robot.py
@@ -175,15 +175,18 @@ class PyBulletRobot(robot.robot_abc.RobotABC,
         self._robot_id = self._load_model(self.model_file)
         assert self._robot_id is not None, "Failed to load the robot model"
 
-        # Initialize all the joints in POSITION mode
         for name in self.joint_names():
-            self._jointname2jointcontrolinfo[name] = JointControlInfo(
-                mode=JointControlMode.POSITION)
-            ok_mode = self.set_joint_control_mode(name, JointControlMode.POSITION)
-            assert ok_mode, \
-                f"Failed to initialize the control mode of joint '{name}'"
+            # Initialize the dict with None. It will be changed to POSITION, VELOCITY, etc
+            # the first time the user wants to control the joint.
+            self._jointname2jointcontrolinfo[name] = JointControlInfo(mode=None)
 
-        # Initialize the joints state
+            # Initialize the position as constraint
+            self._pybullet.setJointMotorControl2(
+                bodyIndex=self._robot_id,
+                jointIndex=self._joints_name2index[name],
+                controlMode=pybullet.POSITION_CONTROL)
+
+        # Initialize the joint state
         for idx, name in enumerate(self.joint_names()):
             self.reset_joint(joint_name=name,
                              position=self.initial_joint_positions()[idx],

--- a/gym_ignition/tasks/__init__.py
+++ b/gym_ignition/tasks/__init__.py
@@ -5,3 +5,5 @@
 from . import pendulum_swingup
 from . import cartpole_discrete
 from . import cartpole_continuous
+
+from . import robot_position_controller

--- a/gym_ignition/tasks/robot_position_controller.py
+++ b/gym_ignition/tasks/robot_position_controller.py
@@ -1,0 +1,319 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import abc
+import gym
+import time
+import gym.logger as logger
+from typing import NamedTuple
+# import gympp_bindings as bindings
+from gym_ignition.base import task
+from gym_ignition.utils.typing import *
+from gym_ignition.base.robot import feature_detector
+from gym_ignition.base.robot import robot_abc, robot_joints, robot_initialstate
+from gym_ignition.base.controllers import PositionController, PositionControllerReferences
+
+
+class Config(NamedTuple):
+    position: bool = True        # (1 x DoF) array
+    velocity: bool = False       # (1 x DoF) array
+    acceleration: bool = False   # (1 x DoF) array
+    base_pose: bool = False      # (1 x 7) array: position and orientation quaternion
+    base_velocity: bool = False  # (1 x 6) array: linear and angular velocity
+    floating: bool = False       # Enable floating or fixed base controller
+
+
+# Initialize the robot features required by the task
+@feature_detector
+class RobotFeatures(robot_abc.RobotABC,
+                    robot_joints.RobotJoints,
+                    robot_initialstate.RobotInitialState,
+                    abc.ABC):
+    pass
+
+
+class RobotPositionController(task.Task, abc.ABC):
+    """
+    Environment that exposes a position-controlled robot with a Gym interface.
+
+    The environment is configured with the ControlledQuantities named tuple.  #  TODO
+    Depending on its configuration, the size of action and observation vectors change.
+
+    The configuration of the action and observation spaces depends on the
+
+    For fixed base robots, the action is an array with the joint position references.
+    For floating base robots, the action is expanded to have in its front the
+    """
+    def __init__(self,
+                 config: Config,
+                 controller_cls: type,
+                 controller_kwargs: Dict,
+                 floating_base: bool = False,
+                 controlled_joints: List[str] = None,
+                 initial_joint_positions: np.ndarray = None,
+                 **kwargs) -> None:
+
+        logger.debug("Initializing parent Task class")
+        super().__init__()
+
+        # Store the requested robot features for this task
+        self.robot_features = RobotFeatures
+
+        # Attributes
+        self._config = config  # TODO
+        self._controller = None
+        self._controller_cls = controller_cls
+        self._controller_kwargs = controller_kwargs
+        self._floating_base = floating_base
+        self._controlled_joints = controlled_joints
+        self._initial_joint_positions = initial_joint_positions
+
+    def _array_to_namedtuple(self, array: np.ndarray) -> PositionControllerReferences:
+        dofs = self.controller.nr_controlled_dofs
+        start = 0
+        end = dofs
+        references = PositionControllerReferences(position=array[start:end])
+        start = end
+
+        if self._config.velocity:
+            end = start + dofs
+            references = references._replace(velocity=array[start:end])
+            start = end
+        else:
+            references = references._replace(velocity=np.zeros_like(references.position))
+
+        if self._config.acceleration:
+            end = start + dofs
+            references = references._replace(velocity=array[start:end])
+            start = end
+        else:
+            references = references._replace(
+                acceleration=np.zeros_like(references.position))
+
+        if self._config.base_pose:
+            end = start + 7
+            references = references._replace(base_position=array[start:start+3],
+                                             base_orientation=array[start+3:end])
+            start = end
+
+        if self._config.base_velocity:
+            end = start + 6
+            references = references._replace(base_position=array[start:start+3],
+                                             base_orientation=array[start+3:end])
+
+        assert references.valid(), "References are not valid"
+        return references
+
+    @property
+    def controller(self) -> PositionController:
+        if self._controller is not None:
+            return self._controller
+
+        logger.debug("Creating the controller object")
+
+        def pop_kwargs(kw: str, kwargs: dict, default=None, required: bool = False):
+            if kw in kwargs:
+                value = kwargs[kw]
+                kwargs.pop(kw)
+                return value
+            else:
+                if required:
+                    raise Exception(f"Failed to find kwarg {kw}")
+
+                return default
+
+        dt = pop_kwargs("dt", self._controller_kwargs)
+        robot = pop_kwargs("robot", self._controller_kwargs, self.robot)
+        urdf = pop_kwargs("urdf", self._controller_kwargs, self.robot.model_file)
+
+        # Create the controller
+        self._controller = self._controller_cls(dt=dt,
+                                                robot=robot,
+                                                urdf=urdf,
+                                                controlled_joints=self._controlled_joints,
+                                                **self._controller_kwargs)
+
+        logger.debug("Controller object created")
+        return self._controller
+
+    def create_spaces(self) -> Tuple[ActionSpace, ObservationSpace]:
+        if not self.robot:
+            raise Exception("The robot class is not yet ready")
+
+        # Get joints limits
+        joints_limit_min = []
+        joints_limit_max = []
+
+        if not self._controlled_joints:
+            self._controlled_joints = self.robot.joint_names()
+
+        for joint_name in self._controlled_joints:
+            q_min, q_max = self.robot.joint_position_limits(joint_name)
+            joints_limit_min.append(q_min)
+            joints_limit_max.append(q_max)
+
+        # TODO: increase slightly the limits?
+        joints_limit_min = np.array(joints_limit_min)
+        joints_limit_max = np.array(joints_limit_max)
+
+        # Create the observation space
+        observation_space = gym.spaces.Box(low=joints_limit_min,
+                                           high=joints_limit_max,
+                                           dtype=np.float32)
+
+        # Create the action space
+        action_space = gym.spaces.Box(low=np.array(joints_limit_min),
+                                      high=np.array(joints_limit_max),
+                                      dtype=np.float32)
+
+        return action_space, observation_space
+
+    def set_action(self, action: Action) -> bool:
+        assert action.size == self.controller.nr_controlled_dofs, \
+            "%r (%s) invalid" % (action, type(action))
+
+        # TODO
+        # assert self.action_space.contains(action), \
+        #     "%r (%s) invalid" % (action, type(action))
+
+        # Check the controller was initialized
+        assert self.controller is not None, "Joint controller was not initialized"
+
+        # Check that the action is compatible with the robot
+        # assert action.size == robot.dofs(),
+        #     "Action size does not match the number or "robot joints"
+
+        # Get the joint torques from the controller
+        # now = time.time()
+
+        now = time.time()
+        refs = self._array_to_namedtuple(action)
+        print(f"arr2nt: {time.time() - now}")
+
+        ok_references = self.controller.set_control_references(references=refs)
+        assert ok_references  # TODO
+
+        now = time.time()
+        torques = self.controller.step()
+        print(f"contr step: {time.time() - now}")
+
+        # CPP
+        # pos_refs = bindings.PositionReferences(self.controller.nr_controlled_dofs)
+        # pos_refs.position = refs.position.tolist()
+        # ok_references2 = self._controllercpp.setReferences(pos_refs)
+        # assert ok_references2  # TODO
+        # now = time.time()
+        # _ = self.controller.step()
+        # print(f"contr cpp step: {time.time() - now}")
+
+        # print("=== Controller = {}".format(time.time() - now))
+        ok_torques = True
+
+        # Get the robot object
+        robot = self.robot
+
+        # Apply the joint torques
+        for idx, joint_name in enumerate(self.controller.controlled_joints):
+            ok_torques = ok_torques and robot.set_joint_force(joint_name, torques[idx])
+
+        assert ok_torques, "Failed to set torques"
+
+        return ok_torques
+
+    def get_observation(self) -> Observation:
+        # Create the observation object
+        observation = Observation(self.robot.joint_positions())
+
+        # Return the observation
+        return observation
+
+    def get_reward(self) -> Reward:
+        # Initialize the reward
+        reward = 0.0
+        return Reward(reward)
+
+    def is_done(self) -> bool:
+        return False
+
+    def reset_task(self) -> bool:
+        # ====================
+        # INITIALIZE THE ROBOT
+        # ====================
+
+        # Switch to fixed base if the robot is floating base
+        if self.robot.is_floating_base() and not self._floating_base:
+            ok_floating = self.robot.set_as_floating_base(False)
+            assert ok_floating, "Failed to set the robot as fixed base"
+
+            pos, orient = self.robot.base_pose()
+            ok_base = self.robot.reset_base_pose(position=pos, orientation=orient)
+            assert ok_base, "Failed to reset the base pose"
+
+        # Switch to floating base if the robot is fixed base
+        if not self.robot.is_floating_base() and self._floating_base:
+            ok_floating = self.robot.set_as_floating_base(True)
+            assert ok_floating, "Failed to set the robot as floating base"
+
+            pos, orient = self.robot.base_pose()
+            ok_base = self.robot.reset_base_pose(position=pos, orientation=orient)
+            assert ok_base, "Failed to reset the base pose"
+
+        # =====================
+        # INITIALIZE CONTROLLER
+        # =====================
+
+        if self._controller is not None:
+            ok_terminate = self.controller.terminate()
+            self._controller = None
+            assert ok_terminate, "Failed to terminate the controller"
+
+        # Initialize the controller
+        ok_initialize = self.controller.initialize()
+        assert ok_initialize, "Failed to initialize the controller"
+
+        # ======================
+        # INITIALIZE ROBOT STATE
+        # ======================
+
+        # TODO: Allow initializing also the velocity and base?
+
+        # Set initial position to 0 as default
+        # if self.initial_joint_positions is None:
+        #     self.initial_joint_positions = self.robot.initial_joint_positions()
+
+        if self._initial_joint_positions is not None:
+            for idx, name in enumerate(self.robot.joint_names()):
+                self.robot.set_joint_position(name, self._initial_joint_positions[idx])
+
+        # Validate the initial joint positions
+        # assert self.initial_joint_positions.size == robot.dofs(), \
+        #     "The size of the initial position array does not match the robot's DoFs"
+
+        # Get joint names
+        # joint_names = robot.joint_names()
+
+        # # Reset the joints
+        # for idx, pos in enumerate(self.initial_joint_positions):
+        #     # TODO: velocity
+        #     robot.reset_joint(joint_names[idx], pos, velocity=0.0)
+
+        # # Store the initial base position and orientation
+        # # TODO: this works only on simulated robots. This task though should work also
+        # #  on real-time robots.
+        # if self._initial_base_position is None or self._initial_base_orientation is None:
+        #     # Store the base pose
+        #     self._initial_base_position, self._initial_base_orientation = \
+        #         robot.base_pose()
+        #
+        #     # In the fixed-base case, lift the robot
+        #     if not self._floating_base:
+        #         self._initial_base_position *= 1.2
+        #
+        # # Set the base pose
+        # base_ok = robot.reset_base_pose(position=self._initial_base_position,
+        #                                 orientation=self._initial_base_orientation,
+        #                                 floating=self._floating_base)
+        # assert base_ok, "Failed to lift the base of the robot"
+
+        return True

--- a/gym_ignition/utils/__init__.py
+++ b/gym_ignition/utils/__init__.py
@@ -6,3 +6,4 @@ from .typing import *
 from . import misc
 from . import resource_finder
 from . import gazebo_env_vars
+from . import sinusoidal_trajectory_generator

--- a/gym_ignition/utils/sinusoidal_trajectory_generator.py
+++ b/gym_ignition/utils/sinusoidal_trajectory_generator.py
@@ -1,0 +1,55 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import abc
+import numpy as np
+from typing import Union
+from gym_ignition.base.robot import robot_joints, robot_abc, feature_detector
+
+
+@feature_detector
+class RobotFeatures(robot_abc.RobotABC, robot_joints.RobotJoints, abc.ABC):
+    pass
+
+
+class SinusoidalTrajectoryGenerator:
+    def __init__(self,
+                 dt: float,
+                 robot: RobotFeatures,
+                 initial_positions: np.ndarray,
+                 f: float,
+                 sine_amplitude: Union[np.ndarray, float]):
+        self.t = -dt
+        self.f = f
+        self.dt = dt
+        self.dofs = initial_positions.size
+        self.positions = initial_positions
+
+        assert robot.valid(), "Robot is not valid"
+
+        # Get the joint position limits
+        self.min_pos, self.max_pos = [], []
+        for joint_name in robot.joint_names():
+            min_lim, max_lim = robot.joint_position_limits(joint_name)
+            self.min_pos.append(min_lim)
+            self.max_pos.append(max_lim)
+
+        # Different amplitude for each joint
+        if isinstance(sine_amplitude, np.ndarray):
+            if sine_amplitude.size is not self.dofs:
+                raise Exception("Wrong number of joint sine amplitudes")
+            self.amplitudes = sine_amplitude
+        # Same amplitude for all joints
+        elif isinstance(sine_amplitude, float):
+            self.amplitudes = [sine_amplitude] * self.dofs
+        else:
+            raise Exception(f"Wrong data type: {type(sine_amplitude)}")
+
+    def _clip(self, position):
+        return np.clip(position, self.min_pos, self.max_pos)
+
+    def get_references(self) -> np.ndarray:
+        self.t += self.dt
+        pos = self.positions + self.amplitudes * np.sin(2 * np.pi * self.f * self.t)
+        return self._clip(pos)

--- a/gym_ignition_data/CartPole/CartPole.urdf
+++ b/gym_ignition_data/CartPole/CartPole.urdf
@@ -109,7 +109,7 @@
   <!-- ====== -->
   <!-- JOINTS -->
   <!-- ====== -->
-  <!--  http://gazebosim.org/tutorials/?tut=ros_urdf#RigidlyFixingAModeltotheWorld-->
+  <!-- http://gazebosim.org/tutorials/?tut=ros_urdf#RigidlyFixingAModeltotheWorld -->
   <joint name="world_to_rail" type="fixed">
     <parent link="world"/>
     <child link="rail"/>

--- a/tests/python/test_controller_fixed_base.py
+++ b/tests/python/test_controller_fixed_base.py
@@ -1,0 +1,103 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import abc
+import pytest
+import numpy as np
+from . import utils
+from gym_ignition.utils import sinusoidal_trajectory_generator
+from gym_ignition.controllers import computed_torque_fixed_base
+from gym_ignition.controllers import computed_torque_fixed_base_cpp
+from gym_ignition.base.robot import robot_joints, robot_abc, feature_detector
+from gym_ignition.base.controllers import Controller, PositionControllerReferences
+
+
+@feature_detector
+class RobotFeatures(robot_abc.RobotABC, robot_joints.RobotJoints, abc.ABC):
+    pass
+
+
+def get_pybullet_cartpole_resources():
+    pybullet = utils.PyBullet(physics_rate=100)
+    cart_pole = utils.get_cartpole(pybullet)
+
+    controller = computed_torque_fixed_base.ComputedTorqueFixedBase(
+        robot=cart_pole, urdf=cart_pole.model_file,
+        controlled_joints=cart_pole.joint_names(),
+        kp=np.array([1500.0, 1500.0]), kd=np.array([10.0, 10.0]))
+
+    return pybullet, controller, cart_pole
+
+
+def get_gazebo_cartpole_resources_python():
+    gazebo = utils.Gazebo(physics_rate=100)
+    cart_pole = utils.get_cartpole(gazebo)
+
+    controller = computed_torque_fixed_base.ComputedTorqueFixedBase(
+        robot=cart_pole, urdf=cart_pole.model_file,
+        controlled_joints=cart_pole.joint_names(),
+        kp=np.array([1500.0, 1500.0]), kd=np.array([10.0, 10.0]))
+
+    return gazebo, controller, cart_pole
+
+
+def get_gazebo_cartpole_resources_cpp():
+    gazebo = utils.Gazebo(physics_rate=100)
+    cart_pole = utils.get_cartpole(gazebo)
+
+    controller = computed_torque_fixed_base_cpp.ComputedTorqueFixedBaseCpp(
+        robot=cart_pole, urdf=cart_pole.model_file,
+        controlled_joints=cart_pole.joint_names(),
+        kp=np.array([1500.0, 1500.0]), kd=np.array([10.0, 10.0]))
+
+    return gazebo, controller, cart_pole
+
+
+@pytest.mark.parametrize(
+    "simulator,controller,cart_pole",
+    [
+        get_pybullet_cartpole_resources(),
+        get_gazebo_cartpole_resources_python(),
+        get_gazebo_cartpole_resources_cpp(),
+    ])
+def test_controller_fixed_base(simulator: utils.Simulator,
+                               controller: Controller,
+                               cart_pole: RobotFeatures):
+    dt = 0.01
+    generator = sinusoidal_trajectory_generator.SinusoidalTrajectoryGenerator(
+        dt=dt,
+        robot=cart_pole,
+        initial_positions=np.array([0.25, np.deg2rad(120.0)]),
+        f=1.0,
+        sine_amplitude=np.array([0.5, np.deg2rad(45.0)]))
+
+    ok_init = controller.initialize()
+    assert ok_init, "Failed to initialize controller"
+
+    simulation_duration = 5
+    num_steps = int(simulation_duration / dt)
+
+    for ts in range(num_steps):
+        position_reference = generator.get_references()
+        references = PositionControllerReferences(
+            position=position_reference,
+            velocity=np.zeros_like(position_reference),
+            acceleration=np.zeros_like(position_reference),
+        )
+        controller.set_control_references(references=references)
+
+        torques = controller.step()
+
+        for idx, joint_name in enumerate(cart_pole.joint_names()):
+            ok_torque = cart_pole.set_joint_force(joint_name, torques[idx])
+            assert ok_torque
+
+        simulator.step()
+        positions_after_step = cart_pole.joint_positions()
+
+        # Skip initial transient
+        if ts > 100:
+            assert np.allclose(position_reference, positions_after_step, atol=0.03)
+
+    simulator.close()


### PR DESCRIPTION
This PR adds the following:

- New C++ interface `gympp::controllers::Controller`. It is the base interface shared for all controllers, either fixed of floating base. All controllers have a torque output, and the references instead vary.
- New C++ interface `gympp::controllers::PositionController`. Implements method to set references for a position controller. Only joint position references are mandatory.
- New C++ class `gympp::controllers::ComputedTorqueFixedBase` (TODO: write the equations somewhere). This controller can be used only for robots implemented in C++.
- Small modification to add `dofs()` and joint control-mode support to the `Robot` interface. Tiny step for #65.
- New Python `gym_ignition.base.controllers.Controller` interface
- New Python `gym_ignition.controllers.ComputedTorqueFixedBase` class. This class can be used with all robots implemented in Python (even those that wrap C++ classes).
- New Python  `gym_ignition.controllers.ComputedTorqueFixedBaseCpp` class. This class wraps the C++ controller and exposes the same Python interface of the `ComputedTorqueFixedBase` controller.

Early feedback is welcome @traversaro 

### TODO:

- [x] Disable C++ controllers if idyntree is not found
- [x] Document the new idyntree and eigen optional dependencies
- [x] Test that python code works without idyntree if no controllers classes are used (the iDynTree import is deferred)
- [x] Finalize C++ control mode support

Fixes partially #88