### PR TITLE
Implement dofs, get / set joint control mode in Ignition Gazebo, refactor PID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ jobs:
         PYTHON_VERSION: ${{ matrix.python }}
 
     steps:
+      - name: Update git
+        run: |
+          add-apt-repository ppa:git-core/ppa
+          apt update
+          apt install -y git
+
       - uses: actions/checkout@master
 
       # The entrypoint is not called because it is overridden by GH Actions.
@@ -91,6 +97,12 @@ jobs:
         CXX: g++-8
 
     steps:
+      - name: Update git
+        run: |
+          add-apt-repository ppa:git-core/ppa
+          apt update
+          apt install -y git
+
       - uses: actions/checkout@master
 
       # The entrypoint is not called because it is overridden by GH Actions.

--- a/gym_ignition/robots/base/gazebo_robot.py
+++ b/gym_ignition/robots/base/gazebo_robot.py
@@ -51,6 +51,30 @@ class GazeboRobot(robot_abc.RobotABC,
         ok_model = self._gazebo.removeModel(self._robot_name)
         assert ok_model, f"Failed to remove the model '{self._robot_name}' from gazebo"
 
+    @staticmethod
+    def _to_cpp_controlmode(mode: robot_joints.JointControlMode):
+        map_cm = {
+            robot_joints.JointControlMode.POSITION: bindings.JointControlMode_Position,
+            robot_joints.JointControlMode.POSITION_INTERPOLATED:
+                bindings.JointControlMode_PositionInterpolated,
+            robot_joints.JointControlMode.VELOCITY: bindings.JointControlMode_Velocity,
+            robot_joints.JointControlMode.TORQUE: bindings.JointControlMode_Torque,
+        }
+        assert mode in map_cm, f"Unsupported '{mode}' control mode"
+        return map_cm[mode]
+
+    @staticmethod
+    def _from_cpp_controlmode(mode) -> robot_joints.JointControlMode:
+        map_cm = {
+            bindings.JointControlMode_Position: robot_joints.JointControlMode.POSITION,
+            bindings.JointControlMode_PositionInterpolated:
+                robot_joints.JointControlMode.POSITION_INTERPOLATED,
+            bindings.JointControlMode_Velocity: robot_joints.JointControlMode.VELOCITY,
+            bindings.JointControlMode_Torque: robot_joints.JointControlMode.TORQUE,
+        }
+        assert mode in map_cm, f"Unsupported '{mode}' control mode"
+        return map_cm[mode]
+
     @property
     def gympp_robot(self) -> bindings.Robot:
         if self._gympp_robot:
@@ -135,12 +159,13 @@ class GazeboRobot(robot_abc.RobotABC,
         raise NotImplementedError
 
     def joint_control_mode(self, joint_name: str) -> robot_joints.JointControlMode:
-        raise NotImplementedError
+        return self._from_cpp_controlmode(self.gympp_robot.jointControlMode(joint_name))
 
     def set_joint_control_mode(self,
                                joint_name: str,
                                mode: robot_joints.JointControlMode) -> bool:
-        raise NotImplementedError
+        return self.gympp_robot.setJointControlMode(joint_name,
+                                                    self._to_cpp_controlmode(mode))
 
     def joint_position(self, joint_name: str) -> float:
         return self.gympp_robot.jointPosition(joint_name)

--- a/gym_ignition/robots/base/gazebo_robot.py
+++ b/gym_ignition/robots/base/gazebo_robot.py
@@ -180,7 +180,8 @@ class GazeboRobot(robot_abc.RobotABC,
         return self.gympp_robot.jointVelocities()
 
     def joint_pid(self, joint_name: str) -> Union[robot_joints.PID, None]:
-        return self.gympp_robot.jointPID()
+        gazebo_pid = self.gympp_robot.jointPID(joint_name)
+        return robot_joints.PID(p=gazebo_pid.p, i=gazebo_pid.i, d=gazebo_pid.d)
 
     def dt(self) -> float:
         return self.gympp_robot.dt()
@@ -201,7 +202,8 @@ class GazeboRobot(robot_abc.RobotABC,
         raise NotImplementedError
 
     def set_joint_pid(self, joint_name: str, pid: robot_joints.PID) -> bool:
-        return self.gympp_robot.setJointPID(joint_name, pid)
+        gazebo_pid = bindings.PID(pid.p, pid.i, pid.d)
+        return self.gympp_robot.setJointPID(joint_name, gazebo_pid)
 
     def reset_joint(self,
                     joint_name: str,

--- a/gympp/include/gympp/Robot.h
+++ b/gympp/include/gympp/Robot.h
@@ -20,6 +20,13 @@ namespace gympp {
     struct PID;
     struct BasePose;
     struct BaseVelocity;
+    enum class JointControlMode
+    {
+        Position,
+        PositionInterpolated,
+        Velocity,
+        Torque,
+    };
 } // namespace gympp
 
 struct gympp::PID
@@ -73,11 +80,13 @@ public:
     // GET METHODS
     // ===========
 
+    virtual size_t dofs() const = 0;
     virtual RobotName name() const = 0;
     virtual JointNames jointNames() const = 0;
 
     virtual double jointPosition(const JointName& jointName) const = 0;
     virtual double jointVelocity(const JointName& jointName) const = 0;
+    virtual JointControlMode jointControlMode(const JointName& jointName) const = 0;
 
     virtual JointPositions jointPositions() const = 0;
     virtual JointVelocities jointVelocities() const = 0;
@@ -100,6 +109,8 @@ public:
 
     virtual bool setJointPosition(const JointName& jointName, const double jointPosition) = 0;
     virtual bool setJointVelocity(const JointName& jointName, const double jointVelocity) = 0;
+    virtual bool setJointControlMode(const JointName& jointName,
+                                     const JointControlMode controlMode) = 0;
 
     virtual bool setJointPID(const JointName& jointName, const PID& pid) = 0;
 

--- a/ignition/include/gympp/gazebo/IgnitionRobot.h
+++ b/ignition/include/gympp/gazebo/IgnitionRobot.h
@@ -45,11 +45,14 @@ public:
     // GET METHODS
     // ===========
 
+    size_t dofs() const override;
+
     RobotName name() const override;
     JointNames jointNames() const override;
 
     double jointPosition(const JointName& jointName) const override;
     double jointVelocity(const JointName& jointName) const override;
+    JointControlMode jointControlMode(const JointName& jointName) const override;
 
     JointPositions jointPositions() const override;
     JointVelocities jointVelocities() const override;
@@ -71,6 +74,8 @@ public:
 
     bool setJointPosition(const JointName& jointName, const double jointPosition) override;
     bool setJointVelocity(const JointName& jointName, const double jointVelocity) override;
+    bool setJointControlMode(const JointName& jointName,
+                             const JointControlMode controlMode) override;
 
     bool setJointPID(const JointName& jointName, const PID& pid) override;
 

--- a/ignition/src/IgnitionRobot.cpp
+++ b/ignition/src/IgnitionRobot.cpp
@@ -46,33 +46,27 @@ using JointEntity = ignition::gazebo::Entity;
 const std::string World2BaseJoint = "world2base";
 const ignition::math::PID DefaultPID(1, 0.1, 0.01, 1, -1, 10000, -10000);
 
-enum class ControlType
-{
-    Position,
-    Velocity
-};
-
-struct PIDData
-{
-    ControlType type;
-    ignition::math::PID pid;
-};
-
-struct Buffers
-{
-    struct
-    {
-        gympp::Robot::JointPositions positions;
-        gympp::Robot::JointVelocities velocities;
-        std::map<JointName, double> references;
-        std::map<JointName, double> appliedForces;
-        std::map<JointName, PIDData> pidData;
-    } joints;
-};
-
 class IgnitionRobot::Impl
 {
 public:
+    struct PIDData
+    {
+        ignition::math::PID pid;
+        JointControlMode controlMode;
+    };
+
+    struct
+    {
+        struct
+        {
+            gympp::Robot::JointPositions positions;
+            gympp::Robot::JointVelocities velocities;
+            std::map<JointName, double> references;
+            std::map<JointName, Impl::PIDData> pidData;
+            std::map<JointName, double> appliedForces;
+        } joints;
+    } buffers;
+
     std::string name;
 
     ignition::gazebo::EventManager* eventManager = nullptr;
@@ -82,8 +76,6 @@ public:
 
     std::chrono::duration<double> dt;
     std::chrono::duration<double> prevUpdateTime = std::chrono::duration<double>(0.0);
-
-    Buffers buffers;
 
     bool floating = true;
     std::map<LinkName, LinkEntity> links;
@@ -333,6 +325,11 @@ bool IgnitionRobot::valid() const
     return true;
 }
 
+size_t IgnitionRobot::dofs() const
+{
+    return jointNames().size();
+}
+
 // ===========
 // GET METHODS
 // ===========
@@ -400,6 +397,13 @@ double IgnitionRobot::jointVelocity(const gympp::Robot::JointName& jointName) co
 
     assert(jointVelocityComponent->Data().size() == 1);
     return jointVelocityComponent->Data()[0];
+}
+
+gympp::JointControlMode
+IgnitionRobot::jointControlMode(const gympp::Robot::JointName& jointName) const
+{
+    // TODO
+    return JointControlMode::Position;
 }
 
 gympp::Robot::JointPositions IgnitionRobot::jointPositions() const
@@ -479,13 +483,13 @@ bool IgnitionRobot::setJointPositionTarget(const gympp::Robot::JointName& jointN
 
     // Create the PID if it does not exist
     if (!pImpl->pidExists(jointName)) {
-        pImpl->buffers.joints.pidData[jointName] = {ControlType::Position, DefaultPID};
+        pImpl->buffers.joints.pidData[jointName] = {DefaultPID, JointControlMode::Position};
     }
 
     // Check the control type and switch to position control if the joint was controlled differently
-    if (pImpl->buffers.joints.pidData[jointName].type != ControlType::Position) {
+    if (pImpl->buffers.joints.pidData[jointName].controlMode != JointControlMode::Position) {
         gymppDebug << "Switching joint '" << jointName << "' to Position control" << std::endl;
-        pImpl->buffers.joints.pidData[jointName].type = ControlType::Position;
+        pImpl->buffers.joints.pidData[jointName].controlMode = JointControlMode::Position;
 
         // Reset the PID
         assert(pImpl->pidExists(jointName));
@@ -513,13 +517,13 @@ bool IgnitionRobot::setJointVelocityTarget(const gympp::Robot::JointName& jointN
 
     // Create the PID if it does not exist
     if (!pImpl->pidExists(jointName)) {
-        pImpl->buffers.joints.pidData[jointName] = {ControlType::Velocity, DefaultPID};
+        pImpl->buffers.joints.pidData[jointName] = {DefaultPID, JointControlMode::Velocity};
     }
 
     // Check the control type and switch to velocity control if the joint was controlled differently
-    if (pImpl->buffers.joints.pidData[jointName].type != ControlType::Velocity) {
+    if (pImpl->buffers.joints.pidData[jointName].controlMode != JointControlMode::Velocity) {
         gymppDebug << "Switching joint '" << jointName << "' to Velocity control" << std::endl;
-        pImpl->buffers.joints.pidData[jointName].type = ControlType::Velocity;
+        pImpl->buffers.joints.pidData[jointName].controlMode = JointControlMode::Velocity;
 
         // Reset the PID
         assert(pImpl->pidExists(jointName));
@@ -546,7 +550,9 @@ bool IgnitionRobot::setJointPosition(const gympp::Robot::JointName& jointName,
 
     jointPosResetComponent = ignition::gazebo::components::JointPositionReset({jointPosition});
 
-    // Store the new position in the ECM
+    // Store the new position in the ECM.
+    // This is necessary because before the physics engine executes the step and resets the
+    // position, we might need to read the JointPosition component that might be uninitialized.
     auto& jointPosComponent =
         pImpl->getOrCreateComponent<ignition::gazebo::components::JointPosition>(jointEntity);
 
@@ -569,12 +575,21 @@ bool IgnitionRobot::setJointVelocity(const gympp::Robot::JointName& jointName,
 
     jointVelResetComponent = ignition::gazebo::components::JointVelocityReset({jointVelocity});
 
-    // Store the new velocity in the ECM
+    // Store the new velocity in the ECM.
+    // This is necessary because before the physics engine executes the step and resets the
+    // velocity, we might need to read the JointVelocity component that might be uninitialized.
     auto& jointVelComponent =
         pImpl->getOrCreateComponent<ignition::gazebo::components::JointVelocity>(jointEntity);
 
     jointVelComponent = ignition::gazebo::components::JointVelocity({jointVelocity});
 
+    return true;
+}
+
+bool IgnitionRobot::setJointControlMode(const gympp::Robot::JointName& jointName,
+                                        const JointControlMode controlMode)
+{
+    // TODO
     return true;
 }
 
@@ -587,7 +602,7 @@ bool IgnitionRobot::setJointPID(const gympp::Robot::JointName& jointName, const 
 
     if (!pImpl->pidExists(jointName)) {
         gymppDebug << "Creating new PID for joint " << jointName << std::endl;
-        pImpl->buffers.joints.pidData[jointName] = {ControlType::Position, DefaultPID};
+        pImpl->buffers.joints.pidData[jointName] = {DefaultPID, JointControlMode::Position};
     }
     else {
         pImpl->buffers.joints.pidData[jointName].pid.Reset();
@@ -627,7 +642,7 @@ bool IgnitionRobot::resetJoint(const gympp::Robot::JointName& jointName,
     // Reset the PID
     if (pImpl->pidExists(jointName)) {
         pImpl->buffers.joints.pidData[jointName].pid.Reset();
-        pImpl->buffers.joints.pidData[jointName].type = ControlType::Position;
+        pImpl->buffers.joints.pidData[jointName].controlMode = JointControlMode::Position;
     }
 
     // Clean the joint controlling storage
@@ -686,13 +701,18 @@ bool IgnitionRobot::update(const std::chrono::duration<double> time)
             auto& pid = pImpl->buffers.joints.pidData[jointName].pid;
 
             // Use the PID to get the reference
-            switch (pImpl->buffers.joints.pidData[jointName].type) {
-                case ControlType::Position:
+            switch (pImpl->buffers.joints.pidData[jointName].controlMode) {
+                case JointControlMode::Position:
                     force = pid.Update(jointPosition(jointName) - reference, stepTime);
                     break;
-                case ControlType::Velocity:
+                case JointControlMode::Velocity:
                     force = pid.Update(jointVelocity(jointName) - reference, stepTime);
                     break;
+                default:
+                    gymppError << "Joint control mode '"
+                               << int(pImpl->buffers.joints.pidData[jointName].controlMode)
+                               << "' not supported" << std::endl;
+                    return false;
             }
 
             // Store the force

--- a/tests/python/test_rates.py
+++ b/tests/python/test_rates.py
@@ -2,104 +2,14 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
-import gym
 import time
 import pytest
-import string
-import random
 import itertools
 import numpy as np
-import gym_ignition
+from . import utils
 from typing import List, Tuple
-from gym_ignition import gympp_bindings as bindings
-from gym_ignition.utils import logger, resource_finder
-
-# Set verbosity
-logger.set_level(gym.logger.ERROR)
-
-
-def get_gazebo_and_robot(rtf: float,
-                         physics_rate: float,
-                         agent_rate: float,
-                         # controller_rate: float = None,
-                         ) \
-        -> Tuple[bindings.GazeboWrapper, bindings.Robot]:
-
-    # ==========
-    # PARAMETERS
-    # ==========
-
-    model_sdf = "CartPole/CartPole.sdf"
-    world_sdf = "DefaultEmptyWorld.world"
-
-    plugin_data = bindings.PluginData()
-    plugin_data.setLibName("RobotController")
-    plugin_data.setClassName("gympp::plugins::RobotController")
-
-    # Find and load the model SDF file
-    model_sdf_file = resource_finder.find_resource(model_sdf)
-    with open(model_sdf_file, "r") as stream:
-        model_sdf_string = stream.read()
-
-    # Initialize the model data
-    model_data = bindings.ModelInitData()
-    model_data.setSdfString(model_sdf_string)
-
-    # Create a unique model name
-    letters_and_digits = string.ascii_letters + string.digits
-    prefix = ''.join(random.choice(letters_and_digits) for _ in range(6))
-
-    # Get the model name
-    model_name = bindings.GazeboWrapper.getModelNameFromSDF(model_sdf_string)
-    model_data.modelName = prefix + "::" + model_name
-    robot_name = model_data.modelName
-
-    num_of_iterations_per_gazebo_step = physics_rate / agent_rate
-    assert num_of_iterations_per_gazebo_step == int(num_of_iterations_per_gazebo_step)
-
-    # =============
-    # CONFIGURATION
-    # =============
-
-    # Create the gazebo wrapper
-    gazebo = bindings.GazeboWrapper(int(num_of_iterations_per_gazebo_step),
-                                    rtf,
-                                    physics_rate)
-    assert gazebo, "Failed to get the gazebo wrapper"
-
-    # Set verbosity
-    logger.set_level(gym.logger.DEBUG)
-
-    # Initialize the world
-    world_ok = gazebo.setupGazeboWorld(world_sdf)
-    assert world_ok, "Failed to initialize the gazebo world"
-
-    # Initialize the ignition gazebo wrapper (creates a paused simulation)
-    gazebo_initialized = gazebo.initialize()
-    assert gazebo_initialized, "Failed to initialize ignition gazebo"
-
-    # Insert the model
-    model_ok = gazebo.insertModel(model_data, plugin_data)
-    assert model_ok, "Failed to insert the model in the simulation"
-
-    assert bindings.RobotSingleton_get().exists(robot_name), \
-        "The robot interface was not registered in the singleton"
-
-    # Extract the robot interface from the singleton
-    robot_weak_ptr = bindings.RobotSingleton_get().getRobot(robot_name)
-    assert not robot_weak_ptr.expired(), "The Robot object has expired"
-    assert robot_weak_ptr.lock(), \
-        "The returned Robot object does not contain a valid interface"
-    assert robot_weak_ptr.lock().valid(), "The Robot object is not valid"
-
-    # Get the pointer to the robot interface
-    robot = robot_weak_ptr.lock()
-
-    # Set the joint controller period
-    robot.setdt(0.001 if physics_rate < 1000 else physics_rate)
-
-    # Return the simulator and the robot object
-    return gazebo, robot
+from gym_ignition.utils import logger
+from gym_ignition.base.robot.robot_joints import JointControlMode
 
 
 def almost_equal(first, second, epsilon=None) -> bool:
@@ -124,15 +34,22 @@ def almost_equal(first, second, epsilon=None) -> bool:
 def template_test(rtf: float,
                   physics_rate: float,
                   agent_rate: float,
-                  # controller_rate: float = None,
                   ) -> None:
 
-    # Get the simulator and the robot objects
-    gazebo, robot = get_gazebo_and_robot(rtf=rtf,
-                                         physics_rate=physics_rate,
-                                         agent_rate=agent_rate,
-                                         # controller_rate=None,  # Does not matter
-                                         )
+    # Get the simulator
+    iterations = int(physics_rate / agent_rate)
+    gazebo = utils.Gazebo(physics_rate=physics_rate, iterations=iterations, rtf=rtf)
+
+    # Get the cartpole robot
+    robot = utils.get_cartpole(gazebo)
+    assert robot.valid(), "The robot object is not valid"
+
+    # Configure the cartpole
+    ok_cm = robot.set_joint_control_mode("linear", JointControlMode.POSITION)
+    assert ok_cm, "Failed to set the control mode"
+
+    # Set the joint controller period
+    robot.set_dt(0.001 if physics_rate < 1000 else physics_rate)
 
     # Trajectory specifications
     trajectory_dt = 1 / agent_rate
@@ -151,12 +68,12 @@ def template_test(rtf: float,
     logger.debug(f"Simulating {cart_ref.size} steps")
     for i, ref in enumerate(cart_ref):
         # Set the references
-        ok_ref = robot.setJointPositionTarget("linear", ref)
+        ok_ref = robot.set_joint_position("linear", ref)
         assert ok_ref, "Failed to set joint references"
 
         # Step the simulator
         now = time.time()
-        gazebo.run()
+        gazebo.step()
         this_step = time.time() - now
         avg_time_per_step = avg_time_per_step + 0.1 * (this_step - avg_time_per_step)
 
@@ -164,7 +81,6 @@ def template_test(rtf: float,
     elapsed_time = stop - start
 
     # Compute useful quantities
-    # simulation_dt = 1 / simulation_rate
     number_of_actions = tot_simulated_seconds / trajectory_dt
     physics_iterations_per_run = physics_rate / agent_rate
     simulation_dt = 1 / (physics_rate * rtf)
@@ -192,7 +108,7 @@ def template_test(rtf: float,
     gazebo.close()
 
 
-def create_test_matrix() -> List[Tuple]:
+def create_test_matrix() -> List[Tuple[float, float, float]]:
     rtf_list = [0.5, 1, 2, 5, 10]
     agent_rate_list = [100, 500, 1000]
     physics_rate_list = [100, 500, 1000]
@@ -218,9 +134,8 @@ def create_test_matrix() -> List[Tuple]:
     return matrix
 
 
-# @pytest.mark.xfail
 @pytest.mark.parametrize("rtf, agent_rate, physics_rate", create_test_matrix())
-def test_rates(rtf, agent_rate, physics_rate):
+def test_rates(rtf: float, agent_rate: float, physics_rate: float):
 
     print("========")
     print("Testing:")

--- a/tests/python/test_robot_controller.py
+++ b/tests/python/test_robot_controller.py
@@ -75,6 +75,10 @@ def test_joint_controller():
     # Set the default update rate
     robot.setdt(1 / controller_rate)
 
+    # Control the cart joint in position
+    ok_cm = robot.setJointControlMode("linear", bindings.JointControlMode_Position)
+    assert ok_cm, "Failed to control the cart joint in position"
+
     # Set the PID of the cart joint
     pid = bindings.PID(10000, 1000, 1000)
     pid_ok = robot.setJointPID("linear", pid)

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -3,6 +3,7 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 import abc
+import numpy as np
 import pybullet_data
 import pybullet as p
 import gympp_bindings as bindings
@@ -27,9 +28,10 @@ class Simulator(abc.ABC):
 class Gazebo(Simulator):
     simulator_name = "gazebo"
 
-    def __init__(self, physics_rate: float):
-        rtf = 1.0
-        iterations = 1
+    def __init__(self,
+                 physics_rate: float,
+                 iterations: int = int(1),
+                 rtf=float(np.finfo(np.float32).max)):
         self.simulator = bindings.GazeboWrapper(iterations, rtf, physics_rate)
         assert self.simulator
 

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -1,0 +1,107 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import abc
+import pybullet_data
+import pybullet as p
+import gympp_bindings as bindings
+from gym_ignition.robots import sim
+from pybullet_utils import bullet_client
+from gym_ignition.utils import resource_finder
+
+
+class Simulator(abc.ABC):
+    simulator = None
+    simulator_name: str = ""
+
+    @abc.abstractmethod
+    def step(self):
+        pass
+
+    @abc.abstractmethod
+    def close(self):
+        pass
+
+
+class Gazebo(Simulator):
+    simulator_name = "gazebo"
+
+    def __init__(self, physics_rate: float):
+        rtf = 1.0
+        iterations = 1
+        self.simulator = bindings.GazeboWrapper(iterations, rtf, physics_rate)
+        assert self.simulator
+
+        self.simulator.setVerbosity(4)
+
+        empty_world = resource_finder.find_resource("DefaultEmptyWorld.world")
+        ok_world = self.simulator.setupGazeboWorld(worldFile=empty_world)
+        assert ok_world
+
+        ok_initialize = self.simulator.initialize()
+        assert ok_initialize
+
+    def step(self):
+        assert self.simulator.initialized()
+
+        ok_run = self.simulator.run()
+        assert ok_run
+
+    def close(self):
+        ok_close = self.simulator.close()
+        assert ok_close
+
+
+class PyBullet(Simulator):
+    simulator_name = "pybullet"
+
+    def __init__(self, physics_rate: float):
+        self.simulator = bullet_client.BulletClient(p.DIRECT)
+        assert self.simulator
+
+        self.simulator.setRealTimeSimulation(0)
+        self.simulator.setGravity(0, 0, -9.81)
+        self.simulator.setTimeStep(1.0 / physics_rate)
+
+        self.simulator.setAdditionalSearchPath(pybullet_data.getDataPath())
+        self.plane_id = self.simulator.loadURDF("plane_implicit.urdf")
+
+    def step(self):
+        self.simulator.stepSimulation()
+
+    def close(self):
+        pass
+
+
+# TODO: we need urdf for the controllers
+def get_pendulum(simulator: Simulator, **kwargs):
+    if simulator.simulator_name == "gazebo":
+        return sim.gazebo.pendulum.PendulumGazeboRobot(
+            model_file="Pendulum/Pendulum.urdf",
+            gazebo=simulator.simulator,
+            **kwargs)
+    elif simulator.simulator_name == "pybullet":
+        return sim.pybullet.pendulum.PendulumPyBulletRobot(
+            model_file="Pendulum/Pendulum.urdf",
+            p=simulator.simulator,
+            plane_id=simulator.plane_id,
+            **kwargs)
+    else:
+        raise Exception(f"Simulator {simulator.simulator_name} not recognized")
+
+
+def get_cartpole(simulator: Simulator, **kwargs):
+    if simulator.simulator_name == "gazebo":
+        return sim.gazebo.cartpole.CartPoleGazeboRobot(
+            model_file="CartPole/CartPole.urdf",
+            gazebo=simulator.simulator,
+            **kwargs)
+    elif simulator.simulator_name == "pybullet":
+        return sim.pybullet.cartpole.CartPolePyBulletRobot(
+            model_file="CartPole/CartPole.urdf",
+            p=simulator.simulator,
+            plane_id=simulator.plane_id,
+            **kwargs)
+    else:
+        raise Exception(f"Simulator {simulator.simulator_name} not recognized")


### PR DESCRIPTION
This PR adds the following capabilities to robots simulated in Ignition Gazebo:

- Gather the number of DoFs
- Set and get the control mode
- Refactor PID support based on the new control mode selection

Fixes partially #65 