### PR TITLE
Implement joint limits and initial joint position for Gazebo Robot

### DIFF
--- a/gym_ignition/robots/base/gazebo_robot.py
+++ b/gym_ignition/robots/base/gazebo_robot.py
@@ -289,7 +289,8 @@ class GazeboRobot(robot_abc.RobotABC,
 
     def initial_joint_positions(self) -> np.ndarray:
         if self._initial_joint_positions is None:
-            self._initial_joint_positions = np.zeros(self.dofs())
+            self._initial_joint_positions = \
+                np.array(self.gympp_robot.initialJointPositions())
 
         return self._initial_joint_positions
 

--- a/gym_ignition/robots/base/gazebo_robot.py
+++ b/gym_ignition/robots/base/gazebo_robot.py
@@ -214,7 +214,8 @@ class GazeboRobot(robot_abc.RobotABC,
         return self.gympp_robot.update(dt)
 
     def joint_position_limits(self, joint_name: str) -> Tuple[float, float]:
-        raise NotImplementedError
+        limit = self.gympp_robot.jointPositionLimits(joint_name)
+        return float(limit.min), float(limit.max)
 
     def joint_force_limit(self, joint_name: str) -> float:
         raise NotImplementedError

--- a/gym_ignition/robots/base/gazebo_robot.py
+++ b/gym_ignition/robots/base/gazebo_robot.py
@@ -130,6 +130,17 @@ class GazeboRobot(robot_abc.RobotABC,
             ok_dt = self._gympp_robot.setdt(1 / self._controller_rate)
             assert ok_dt, "Failed to set the robot controller period"
 
+        s0 = self.initial_joint_positions()
+        sdot0 = self.initial_joint_velocities()
+        joint_names = list(self._gympp_robot.jointNames())
+
+        assert s0.size == len(joint_names)
+        assert sdot0.size == len(joint_names)
+
+        for idx, name in enumerate(joint_names):
+            ok_reset = self._gympp_robot.resetJoint(name, s0[idx], sdot0[idx])
+            assert ok_reset, f"Failed to initialize the state of joint '{name}'"
+
         logger.debug(
             f"GazeboRobot '{self._gympp_robot.name()}' added to the simulation")
         return self._gympp_robot
@@ -257,7 +268,8 @@ class GazeboRobot(robot_abc.RobotABC,
         return position, orientation
 
     def base_velocity(self) -> Tuple[np.ndarray, np.ndarray]:
-        raise NotImplementedError
+        logger.warn("Interface not implemented!")
+        return np.zeros(3), np.zeros(3)
 
     def reset_base_pose(self,
                         position: np.ndarray,
@@ -296,21 +308,21 @@ class GazeboRobot(robot_abc.RobotABC,
         return self._initial_joint_positions
 
     def set_initial_joint_positions(self, positions: np.ndarray) -> bool:
-        if positions.size != self.dofs():
-            return False
+        if self._gympp_robot is not None:
+            raise Exception("The robot object has been already created")
 
         self._initial_joint_positions = positions
         return True
 
     def initial_joint_velocities(self) -> np.ndarray:
-        if not self._initial_joint_velocities:
-            return np.zeros(self.dofs())
-        else:
-            return self._initial_joint_velocities
+        if self._initial_joint_velocities is None:
+            self._initial_joint_velocities = np.zeros(self.dofs())
+
+        return self._initial_joint_velocities
 
     def set_initial_joint_velocities(self, velocities: np.ndarray) -> bool:
-        if velocities.size != self.dofs():
-            return False
+        if self._gympp_robot is not None:
+            raise Exception("The robot object has been already created")
 
         self._initial_joint_velocities = velocities
         return True

--- a/gympp/include/gympp/Robot.h
+++ b/gympp/include/gympp/Robot.h
@@ -91,6 +91,8 @@ public:
     virtual JointPositions jointPositions() const = 0;
     virtual JointVelocities jointVelocities() const = 0;
 
+    virtual JointPositions initialJointPositions() const = 0;
+
     virtual StepSize dt() const = 0;
     virtual PID jointPID(const JointName& jointName) const = 0;
 

--- a/gympp/include/gympp/Robot.h
+++ b/gympp/include/gympp/Robot.h
@@ -10,6 +10,7 @@
 #define GYMPP_ROBOT_H
 
 #include <chrono>
+#include <limits>
 #include <memory>
 #include <string>
 #include <vector>
@@ -18,6 +19,7 @@ namespace gympp {
     class Robot;
     using RobotPtr = std::shared_ptr<gympp::Robot>;
     struct PID;
+    struct Limit;
     struct BasePose;
     struct BaseVelocity;
     enum class JointControlMode
@@ -53,6 +55,12 @@ struct gympp::BaseVelocity
 {
     std::array<double, 3> linear;
     std::array<double, 3> angular;
+};
+
+struct gympp::Limit
+{
+    double min = std::numeric_limits<double>::lowest();
+    double max = std::numeric_limits<double>::max();
 };
 
 class gympp::Robot
@@ -92,6 +100,8 @@ public:
     virtual JointVelocities jointVelocities() const = 0;
 
     virtual JointPositions initialJointPositions() const = 0;
+
+    virtual Limit jointPositionLimits(const JointName& jointName) const = 0;
 
     virtual StepSize dt() const = 0;
     virtual PID jointPID(const JointName& jointName) const = 0;

--- a/ignition/include/gympp/gazebo/IgnitionRobot.h
+++ b/ignition/include/gympp/gazebo/IgnitionRobot.h
@@ -59,6 +59,8 @@ public:
 
     JointPositions initialJointPositions() const override;
 
+    Limit jointPositionLimits(const JointName& jointName) const override;
+
     StepSize dt() const override;
     PID jointPID(const JointName& jointName) const override;
 

--- a/ignition/include/gympp/gazebo/IgnitionRobot.h
+++ b/ignition/include/gympp/gazebo/IgnitionRobot.h
@@ -57,6 +57,8 @@ public:
     JointPositions jointPositions() const override;
     JointVelocities jointVelocities() const override;
 
+    JointPositions initialJointPositions() const override;
+
     StepSize dt() const override;
     PID jointPID(const JointName& jointName) const override;
 

--- a/ignition/src/IgnitionRobot.cpp
+++ b/ignition/src/IgnitionRobot.cpp
@@ -456,6 +456,28 @@ gympp::Robot::JointPositions IgnitionRobot::initialJointPositions() const
     return initialJointPositions;
 }
 
+gympp::Limit IgnitionRobot::jointPositionLimits(const gympp::Robot::JointName& jointName) const
+{
+    JointEntity jointEntity = pImpl->getJointEntity(jointName);
+    assert(jointEntity != ignition::gazebo::kNullEntity);
+
+    // Get the joint axis component
+    auto jointAxisComponent =
+        pImpl->ecm->Component<ignition::gazebo::components::JointAxis>(jointEntity);
+
+    if (!jointAxisComponent) {
+        gymppError << "JointAxis of joint '" << jointName << "' not found in the ecm" << std::endl;
+        assert(false);
+        return {};
+    }
+
+    gympp::Limit limit;
+    limit.min = jointAxisComponent->Data().Lower();
+    limit.max = jointAxisComponent->Data().Upper();
+
+    return limit;
+}
+
 gympp::Robot::StepSize IgnitionRobot::dt() const
 {
     return pImpl->dt;


### PR DESCRIPTION
This PR adds the following features to robots simulated in Ignition Gazebo:

- Get the joint limits
- Get the initial joint positions (as they are specified in the SDF model)

Fixes partially #65 
Requires #104 