### PR TITLE
Expose the environment timestamp to the agent

### DIFF
--- a/gym_ignition/base/runtime.py
+++ b/gym_ignition/base/runtime.py
@@ -50,3 +50,16 @@ class Runtime(gym.Wrapper, abc.ABC):
             The gym.Env environment of the Runtime.
         """
         return self
+
+    @abc.abstractmethod
+    def timestamp(self) -> float:
+        """
+        Return the timestamp associated to the execution of the environment.
+
+        In real-time environments, the timestamp is the time read from the host system.
+        In simulated environments, the timestamp is the simulated time, which might not
+        match the real-time in the case of RTF different than 1.
+
+        Returns:
+            A float indicating the current environment timestamp
+        """

--- a/gym_ignition/runtimes/gazebo_runtime.py
+++ b/gym_ignition/runtimes/gazebo_runtime.py
@@ -144,6 +144,13 @@ class GazeboRuntime(runtime.Runtime):
 
         return robot
 
+    # =================
+    # Runtime interface
+    # =================
+
+    def timestamp(self) -> float:
+        return self.gazebo.getSimulatedTime()
+
     # ===============
     # gym.Env METHODS
     # ===============

--- a/gym_ignition/runtimes/pybullet_runtime.py
+++ b/gym_ignition/runtimes/pybullet_runtime.py
@@ -48,6 +48,7 @@ class PyBulletRuntime(base.runtime.Runtime):
         self._rtf = rtf
         self._now = None
         self._bias = 0.0
+        self._timestamp = 0.0
 
         self._physics_rate = physics_rate
 
@@ -206,6 +207,13 @@ class PyBulletRuntime(base.runtime.Runtime):
         # Update the time for the next cycle
         self._now = time.time()
 
+    # =================
+    # Runtime interface
+    # =================
+
+    def timestamp(self) -> float:
+        return self._timestamp
+
     # ===============
     # gym.Env METHODS
     # ===============
@@ -213,6 +221,9 @@ class PyBulletRuntime(base.runtime.Runtime):
     def step(self, action: Action) -> State:
         if not self.action_space.contains(action):
             logger.warn("The action does not belong to the action space")
+
+        # Update the timestamp
+        self._timestamp += 1.0 / self.agent_rate
 
         # Set the action
         ok_action = self.task.set_action(action)
@@ -263,6 +274,9 @@ class PyBulletRuntime(base.runtime.Runtime):
 
         if not self.observation_space.contains(observation):
             logger.warn("The observation does not belong to the observation space")
+
+        # Reset the timestamp
+        self._timestamp = 0.0
 
         return Observation(observation)
 

--- a/ignition/include/gympp/gazebo/GazeboWrapper.h
+++ b/ignition/include/gympp/gazebo/GazeboWrapper.h
@@ -85,6 +85,7 @@ public:
 
     bool initialized();
 
+    double getSimulatedTime() const;
     PhysicsData getPhysicsData() const;
     static void setVerbosity(int level = DEFAULT_VERBOSITY);
 

--- a/ignition/src/GazeboWrapper.cpp
+++ b/ignition/src/GazeboWrapper.cpp
@@ -384,6 +384,20 @@ bool GazeboWrapper::initialized()
     }
 }
 
+double GazeboWrapper::getSimulatedTime() const
+{
+    auto dt = pImpl->gazebo.physics.maxStepSize;
+    auto iterationCount = pImpl->gazebo.server->IterationCount();
+
+    if (!iterationCount || !pImpl->gazebo.server) {
+        gymppError << "Failed to get the simulated time" << std::endl;
+        return 0.0;
+    }
+
+    // TODO: this will no longer work if Gazebo changes the step dynamically
+    return dt * iterationCount.value();
+}
+
 PhysicsData GazeboWrapper::getPhysicsData() const
 {
     return pImpl->gazebo.physics;


### PR DESCRIPTION
This PR extends the interface of the environment exposed to the agent / user adding a `timestamp` method. It is useful e.g. for logging or plotting.