### PR TITLE
Fix ECM lock during the first Gazebo step

### DIFF
--- a/ignition/src/GazeboWrapper.cpp
+++ b/ignition/src/GazeboWrapper.cpp
@@ -616,8 +616,10 @@ bool GazeboWrapper::insertModel(const gympp::gazebo::ModelInitData& modelData,
         // involved synchronization logic. This allows avoiding to use the UserCommands system
         // to create entities, giving us full power.
         assert(pImpl->gazebo.server->Paused().has_value());
-        if (pImpl->gazebo.server->Running() && pImpl->gazebo.server->Paused().value())
-            auto lock = ecmSingleton.waitPreUpdate(getWorldName());
+        std::unique_lock<std::mutex> lock;
+        if (pImpl->gazebo.server->Running() && pImpl->gazebo.server->Paused().value()) {
+            lock = ecmSingleton.waitPreUpdate(getWorldName());
+        }
 
         // Create the model entity. It will create a model with the name specified in the SDF.
         modelEntity = sdfEntityCreator->CreateEntities(modelSdfRoot.ModelByIndex(0));


### PR DESCRIPTION
This PR fixes the wrong lock of the mutex that assures that, when a model is inserted in a paused simulation, no other systems access in parallel the ECM.

Such behaviour is necessary to properly wait the creation of all the entities and component, in order to make them processed all together by the Physics system in the first subsequent (paused) simulation step.

The synchronization logic is quite convoluted, and it was first introduced in #50.