### PR TITLE
Fix Ignition Robot configuration

### DIFF
--- a/ignition/include/gympp/gazebo/IgnitionRobot.h
+++ b/ignition/include/gympp/gazebo/IgnitionRobot.h
@@ -36,9 +36,8 @@ public:
     ~IgnitionRobot() override;
 
     bool configureECM(const ignition::gazebo::Entity& entity,
-                      const std::shared_ptr<const sdf::Element>& sdf,
-                      ignition::gazebo::EntityComponentManager& ecm,
-                      ignition::gazebo::EventManager& eventManager);
+                      ignition::gazebo::EntityComponentManager* ecm,
+                      ignition::gazebo::EventManager* eventManager);
     bool valid() const override;
 
     // ===========

--- a/ignition/src/GazeboWrapper.cpp
+++ b/ignition/src/GazeboWrapper.cpp
@@ -658,7 +658,7 @@ bool GazeboWrapper::insertModel(const gympp::gazebo::ModelInitData& modelData,
 
         // Create an IgnitionRobot object from the ecm
         auto ignRobot = std::make_shared<gympp::gazebo::IgnitionRobot>();
-        if (!ignRobot->configureECM(modelEntity, modelSdfRoot.Element(), *ecm, *eventManager)) {
+        if (!ignRobot->configureECM(modelEntity, ecm, eventManager)) {
             gymppError << "Failed to configure the Robot interface" << std::endl;
             return false;
         }


### PR DESCRIPTION
This PR:

1. Fixes the process of adding new components to the ECM during the IgnitionRobot configuration. It is not safe editing the ECM in a `Each` call since it would alter the graph while it is being traversed, causing undefined behaviour. The fix is operating on the ECM outside the `Each` call.
2. Cleans the `configureECM` method removing the unused SDF information.