### PR TITLE
Get tests from the right branch in PyPI bdist Github Action 

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Python tests
         run: |
           cd tests/python
-          pytest
+          pytest -v
 
   # ========================
   # TEST BDIST_WHEEL PACKAGE
@@ -115,6 +115,7 @@ jobs:
           docker run \
             -d -i --name test -e PYTHON_VERSION=$PYTHON_VERSION \
             -v $(pwd)/dist:/dist \
+            -v $(pwd)/tests:/tests \
             diegoferigo/gym-ignition:ci-master bash
           sleep 15
 
@@ -122,9 +123,7 @@ jobs:
         run: docker exec -i -w /dist test sh -c 'pip install *.whl'
 
       - name: Python tests
-        run: |
-          docker exec -i test sh -c "git clone https://github.com/robotology/gym-ignition"
-          docker exec -i test sh -c "cd gym-ignition/tests/python && pytest -v"
+        run: docker exec -i -w /tests/python test sh -c 'pytest -v'
 
   # =============
   # PUSH PACKAGES


### PR DESCRIPTION
The failures in the PyPI pipeline of these last few days are caused by the fact that the bdist job was cloning the `master` branch instead of the current commit.

This PR fixes the problem and instead of cloning the repository, it just mounts the test repo of the git folder in the clean docker image where tests are executed.

The CD pipeline is triggered only on the `master` and `devel` branches, so this PR does no have the job running. To get the GHA output, check the outcome of [my fork's branch](https://github.com/diegoferigo/gym-ignition/commit/88cb351507e391c676237ff22ab4b3005f7d9e83/checks?check_suite_id=368546592).