### PR TITLE
Clone the entire git history before pushing to PyPI

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -40,7 +40,8 @@ jobs:
           apt update
           apt install -y git
 
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
+      - run: git fetch --prune --unshallow
 
       # The entrypoint is not called because it is overridden by GH Actions.
       # Even using the 'jobs.<job_id>.container.options' does not work because the
@@ -84,7 +85,8 @@ jobs:
           sudo apt update
           sudo apt install -y git
 
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
+      - run: git fetch --prune --unshallow
 
       # Workaround to export environment variables that persist in next steps
       # https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
@@ -154,7 +156,8 @@ jobs:
           apt update
           apt install -y git
 
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
+      - run: git fetch --prune --unshallow
 
       # Validate the last tag accordingly to PEP440
       # From https://stackoverflow.com/a/37972030/12150968


### PR DESCRIPTION
The [actions/checkout](https://github.com/actions/checkout) repository has been recently updated and it changed few things breaking our CD pipeline.

In particular, now it requires a newer git version as commented in https://github.com/robotology/gym-ignition/pull/104#issuecomment-566965481. Furthermore, the default checkout is without tags and with a depth of just one commit.

We use the entire git history to create the version the PyPI package. This PR updates the CD pipeline adapting the new checkout action to behave like the previous version.

Refer to [README.md@actions/checkout](https://github.com/actions/checkout/blob/c85684db76ba6ef08713c10cf4befe3318887415/README.md) for an extended documentation.