### PR TITLE
Add contact support for Ignition Gazebo

### DIFF
--- a/bindings/gympp_bindings.i
+++ b/bindings/gympp_bindings.i
@@ -90,6 +90,7 @@
 %ignore gympp::Robot::dt;
 %ignore gympp::Robot::setdt(const StepSize&);
 %include "gympp/Robot.h"
+%template(Vector_contact) std::vector<gympp::ContactData>;
 
 %inline %{
     std::shared_ptr<gympp::gazebo::IgnitionEnvironment> envToIgnEnv(gympp::EnvironmentPtr env) {

--- a/gym_ignition/base/robot/robot_contacts.py
+++ b/gym_ignition/base/robot/robot_contacts.py
@@ -3,8 +3,17 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 import numpy as np
-from typing import List
+from typing import List, NamedTuple
 from abc import ABC, abstractmethod
+
+
+class ContactData(NamedTuple):
+    bodyA: str
+    bodyB: str
+    position: np.ndarray
+    depth: np.ndarray = None
+    normal: np.ndarray = None
+    wrench: np.ndarray = None
 
 
 class RobotContacts(ABC):
@@ -24,18 +33,15 @@ class RobotContacts(ABC):
         """
 
     @abstractmethod
-    def contact_data(self, contact_link_name: str):  # TODO
+    def contact_data(self, contact_link_name: str) -> List[ContactData]:
         """
-        Return data related to a contact.
+        Return contact data of a link. It might contain multiple contacts.
 
         Args:
             contact_link_name: The name of the link.
 
         Returns:
-            A Tuple with contact data with the following information:
-
-            # TODO ContactWrench idyntree
-
+            A list of NameTuple containing the contact data.
         """
 
     @abstractmethod

--- a/gym_ignition_data/worlds/DefaultEmptyWorld.world
+++ b/gym_ignition_data/worlds/DefaultEmptyWorld.world
@@ -16,11 +16,6 @@
                 name="ignition::gazebo::systems::SceneBroadcaster">
         </plugin>
         <plugin
-                filename="libignition-gazebo-contact-system.so"
-                name="ignition::gazebo::systems::Contact">
-        </plugin>
-
-        <plugin
                 filename="libECMProvider.so"
                 name="gympp::plugins::ECMProvider">
         </plugin>

--- a/gympp/include/gympp/Robot.h
+++ b/gympp/include/gympp/Robot.h
@@ -18,9 +18,11 @@
 namespace gympp {
     class Robot;
     using RobotPtr = std::shared_ptr<gympp::Robot>;
+
     struct PID;
     struct Limit;
     struct BasePose;
+    struct ContactData;
     struct BaseVelocity;
     enum class JointControlMode
     {
@@ -63,6 +65,16 @@ struct gympp::Limit
     double max = std::numeric_limits<double>::max();
 };
 
+struct gympp::ContactData
+{
+    std::string bodyA;
+    std::string bodyB;
+    std::array<double, 3> depth;
+    std::array<double, 6> wrench;
+    std::array<double, 3> normal;
+    std::array<double, 3> position;
+};
+
 class gympp::Robot
 {
 public:
@@ -71,6 +83,7 @@ public:
     using LinkName = std::string;
     using RobotName = std::string;
     using JointName = std::string;
+    using LinkNames = std::vector<JointName>;
     using JointNames = std::vector<JointName>;
 
     using JointPositions = VectorContainer;
@@ -105,6 +118,9 @@ public:
 
     virtual StepSize dt() const = 0;
     virtual PID jointPID(const JointName& jointName) const = 0;
+
+    virtual LinkNames linksInContact() const = 0;
+    virtual std::vector<ContactData> contactData(const LinkName& linkName) const = 0;
 
     // ===========
     // SET METHODS

--- a/ignition/include/gympp/gazebo/IgnitionRobot.h
+++ b/ignition/include/gympp/gazebo/IgnitionRobot.h
@@ -63,6 +63,9 @@ public:
     StepSize dt() const override;
     PID jointPID(const JointName& jointName) const override;
 
+    LinkNames linksInContact() const override;
+    std::vector<ContactData> contactData(const LinkName& linkName) const override;
+
     // ===========
     // SET METHODS
     // ===========

--- a/tests/python/test_contacts.py
+++ b/tests/python/test_contacts.py
@@ -1,0 +1,122 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import tempfile
+import numpy as np
+from . import utils
+from gym_ignition.robots import gazebo_robot
+
+
+def get_cube_urdf() -> str:
+    mass = 5.0
+    edge = 0.2
+    i = 1 / 12 * mass * (edge ** 2 + edge ** 2)
+    cube_urdf = f"""
+    <robot name="cube_robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+        <link name="cube">
+            <inertial>
+              <origin rpy="0 0 0" xyz="0 0 0"/>
+              <mass value="{mass}"/>
+              <inertia ixx="{i}" ixy="0" ixz="0" iyy="{i}" iyz="0" izz="{i}"/>
+            </inertial>
+            <visual>
+              <geometry>
+                <box size="{edge} {edge} {edge}"/>
+              </geometry>
+              <origin rpy="0 0 0" xyz="0 0 0"/>
+            </visual>
+            <collision>
+              <geometry>
+                <box size="{edge} {edge} {edge}"/>
+              </geometry>
+              <origin rpy="0 0 0" xyz="0 0 0"/>
+            </collision>
+        </link>
+    </robot>"""
+    return cube_urdf
+
+
+class CubeGazeboRobot(gazebo_robot.GazeboRobot):
+    def __init__(self, model_file: str, gazebo, initial_position: np.ndarray):
+        # Initialize base class
+        super().__init__(model_file=model_file,
+                         gazebo=gazebo)
+
+        ok_floating = self.set_as_floating_base(True)
+        assert ok_floating, "Failed to set the robot as floating base"
+
+        # Initial base position and orientation
+        base_position = np.array(initial_position)
+        base_orientation = np.array([1., 0., 0., 0.])
+        ok_base_pose = self.set_initial_base_pose(base_position, base_orientation)
+        assert ok_base_pose, "Failed to set base pose"
+
+        # Insert the model in the simulation
+        _ = self.gympp_robot
+
+
+def test_contacts():
+    # Get the simulator
+    gazebo = utils.Gazebo(physics_rate=1000, iterations=1, rtf=100)
+
+    # Serialize the cube urdf
+    handle, model_file = tempfile.mkstemp()
+    with open(handle, 'w') as f:
+        f.write(get_cube_urdf())
+
+    # Create the first cube and insert it in the simulation
+    cube1 = CubeGazeboRobot(model_file=model_file,
+                            gazebo=gazebo.simulator,
+                            initial_position=np.array([0, 0, 1.0]))
+
+    # Create the second cube and insert it in the simulation
+    cube2 = CubeGazeboRobot(model_file=model_file,
+                            gazebo=gazebo.simulator,
+                            initial_position=np.array([0, 0, 2.5]))
+
+    # Execute the first simulation step
+    gazebo.step()
+
+    # The cubes should be falling without contacts
+    assert len(cube1.links_in_contact()) == 0
+    assert len(cube2.links_in_contact()) == 0
+
+    # Perform 500 steps.
+    for _ in range(500):
+        gazebo.step()
+
+    # Cube1 should be touching ground
+    assert len(cube1.links_in_contact()) == 1
+    assert cube1.links_in_contact()[0] == 'cube'
+    contact_data1 = cube1.contact_data('cube')
+    assert len(contact_data1) > 0
+    assert contact_data1[0].bodyA == cube1.name() + "::cube_collision"
+    assert contact_data1[0].bodyB == "ground_plane::collision"
+
+    # Cube 2 should be still floating
+    assert len(cube2.links_in_contact()) == 0
+    assert len(cube2.contact_data('cube')) == 0
+
+    # Perform 500 steps.
+    for _ in range(500):
+        gazebo.step()
+
+    # Now cube2 should be in contact with cube1
+    assert len(cube2.links_in_contact()) == 1
+    assert cube2.links_in_contact()[0] == 'cube'
+    contact_data2 = cube2.contact_data('cube')
+    assert len(contact_data2) > 0
+    assert contact_data2[0].bodyA == cube2.name() + "::cube_collision"
+    assert contact_data2[0].bodyB == cube1.name() + "::cube_collision"
+
+    # And cube1 should be in contact with cube2 and ground_plane
+    assert len(cube1.links_in_contact()) == 1
+    assert cube1.links_in_contact()[0] == 'cube'
+    contact_data1 = cube1.contact_data('cube')
+    assert len(contact_data1) == 2
+
+    for contact in contact_data1:
+        assert contact.bodyA == cube1.name() + "::cube_collision"
+        assert contact.bodyB == cube2.name() + "::cube_collision" or \
+               contact.bodyB == "ground_plane::collision"


### PR DESCRIPTION
This PR enables robots simulated in Gazebo to provide information about contacts with other models.

Getting contact data from the simulator is not as straightforward in this moment. Contacts are exposed only if a _contact sensor_ is attached to a link. We can enable the sensors adding the contact sensor elements to each link of the SDF model.

Under the hood, this contact SDF element has to be associated to a collision element of the link (only one collision per link is currently supported). When the Physics system finds the `ContactSensorData` components, it will [fill them with contact information](https://github.com/robotology/gym-ignition/blob/86a77cc9ea02ec61a5f16ce44ba5d6fb83b9a11a/plugins/Physics/Physics.cpp#L1090-L1172).

The implementation of this PR bypasses the upstream [Contact system](https://bitbucket.org/ignitionrobotics/ign-gazebo/src/default/src/systems/contact/), moving its logic to the `GazeboWrapper` class. Instead of adding the contact sensors in the SDF, by default when inserting the model all links get their own contact sensor.

---

Note that self collision do no yet work. I tried to enable self collision in the SDF but they are not detected.

Note also that the exposed contact data is still limited ([ignitionrobotics/ign-physics#24](https://bitbucket.org/ignitionrobotics/ign-physics/issues/24/extend-contact-data)), and it does not yet include the magnitude and normal of the contact wrench.