### PR TITLE
Add links and base velocity support to Gazebo robots

### DIFF
--- a/gym_ignition/base/robot/robot_baseframe.py
+++ b/gym_ignition/base/robot/robot_baseframe.py
@@ -87,7 +87,7 @@ class RobotBaseFrame(ABC):
             A Tuple containing the linear and angular velocity of the base:
 
             - linear velocity: a 3D array in the [vx, vy, vz] form.
-            - angular velocity: a 3D array in the [wx, wy, wx] form.
+            - angular velocity: a 3D array in the [wx, wy, wz] form.
         """
 
     @abstractmethod

--- a/gym_ignition/base/robot/robot_links.py
+++ b/gym_ignition/base/robot/robot_links.py
@@ -34,7 +34,7 @@ class RobotLinks(ABC):
         both expressed in the the world frame.
 
         Args:
-            link_name: The name of the link
+            link_name: The name of the link.
 
         Returns:
             A Tuple containing the position and orientation of the link:
@@ -48,11 +48,14 @@ class RobotLinks(ABC):
         """
         Return the velocity of the specified link.
 
-        The velocity is composed of linear and angular velocities of the link frame,
-        both expressed in the world frame.
+        The velocity is composed of linear velocity (first three elements) and angular
+        velocity (last three elements) of the link frame.
+        The linear velocity is the time derivative of the position of the link frame
+        origin expressed in the world frame.
+        The angular velocity is expressed with the orientation of the world frame.
 
         Args:
-            link_name: The name of the link
+            link_name: The name of the link.
 
         Returns:
             A Tuple containing the linear and angular velocity of the link:
@@ -66,11 +69,14 @@ class RobotLinks(ABC):
         """
         Return the acceleration of the specified link.
 
-        The acceleration is composed of linear and angular accelerations of the link
-        frame, both expressed in the world frame.
+        The acceleration is composed of linear acceleration (first three elements) and
+        angular acceleration (last three elements) of the link frame.
+        The linear acceleration is the second time derivative of the position of the link
+        frame origin expressed in the world frame.
+        The angular acceleration is expressed with the orientation of the world frame.
 
         Args:
-            link_name: The name of the link
+            link_name: The name of the link.
 
         Returns:
             A Tuple containing the linear and angular acceleration of the link:

--- a/gym_ignition/base/robot/robot_links.py
+++ b/gym_ignition/base/robot/robot_links.py
@@ -3,7 +3,7 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 import numpy as np
-from typing import List
+from typing import List, Tuple
 from abc import ABC, abstractmethod
 
 
@@ -26,19 +26,55 @@ class RobotLinks(ABC):
         """
 
     @abstractmethod
-    def link_pose(self, link_name: str) -> np.ndarray:
+    def link_pose(self, link_name: str) -> Tuple[np.ndarray, np.ndarray]:
         """
         Return the pose of the specified link.
 
         The pose is composed of a position and a quaternion associated to the link frame,
-        both expressed in the the robot base frame.
+        both expressed in the the world frame.
 
         Args:
             link_name: The name of the link
 
         Returns:
-            A Tuple containing the position and orientation of the base:
+            A Tuple containing the position and orientation of the link:
 
             - position: 3D array in the [x, y, z] form.
             - orientation: a 4D array containing a quaternion in the [w, x, y, z] form.
+        """
+
+    @abstractmethod
+    def link_velocity(self, link_name: str) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Return the velocity of the specified link.
+
+        The velocity is composed of linear and angular velocities of the link frame,
+        both expressed in the world frame.
+
+        Args:
+            link_name: The name of the link
+
+        Returns:
+            A Tuple containing the linear and angular velocity of the link:
+
+            - linear velocity: a 3D array in the [vx, vy, vz] form.
+            - angular velocity: a 3D array in the [wx, wy, wz] form.
+        """
+
+    @abstractmethod
+    def link_acceleration(self, link_name: str) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Return the acceleration of the specified link.
+
+        The acceleration is composed of linear and angular accelerations of the link
+        frame, both expressed in the world frame.
+
+        Args:
+            link_name: The name of the link
+
+        Returns:
+            A Tuple containing the linear and angular acceleration of the link:
+
+            - linear acceleration: a 3D array in the [ax, ay, az] form.
+            - angular acceleration: a 3D array in the [wdotx, wdoty, wdotz] form.
         """

--- a/gym_ignition/robots/base/gazebo_robot.py
+++ b/gym_ignition/robots/base/gazebo_robot.py
@@ -6,13 +6,14 @@ import string
 import random
 import numpy as np
 from typing import List, Union, Tuple
-from gym_ignition.utils import logger, resource_finder
-from gym_ignition.base.robot import robot_abc, robot_joints
-from gym_ignition.base.robot import robot_baseframe, robot_initialstate, robot_contacts
 from gym_ignition import gympp_bindings as bindings
+from gym_ignition.utils import logger, resource_finder
+from gym_ignition.base.robot import robot_baseframe, robot_initialstate
+from gym_ignition.base.robot import robot_abc, robot_joints, robot_links, robot_contacts
 
 
 class GazeboRobot(robot_abc.RobotABC,
+                  robot_links.RobotLinks,
                   robot_joints.RobotJoints,
                   robot_contacts.RobotContacts,
                   robot_baseframe.RobotBaseFrame,
@@ -372,3 +373,22 @@ class GazeboRobot(robot_abc.RobotABC,
 
     def total_contact_wrench_on_link(self, contact_link_name: str) -> np.ndarray:
         raise NotImplementedError
+
+    # ==========
+    # RobotLinks
+    # ==========
+
+    def link_names(self) -> List[str]:
+        return self.gympp_robot.linkNames()
+
+    def link_pose(self, link_name: str) -> Tuple[np.ndarray, np.ndarray]:
+        link_pose_gympp = self.gympp_robot.linkPose(link_name)
+        return np.array(link_pose_gympp.position), np.array(link_pose_gympp.orientation)
+
+    def link_velocity(self, link_name: str) -> Tuple[np.ndarray, np.ndarray]:
+        link_velocity_gympp = self.gympp_robot.linkVelocity(link_name)
+        return np.array(link_velocity_gympp.linear), np.array(link_velocity_gympp.angular)
+
+    def link_acceleration(self, link_name: str) -> Tuple[np.ndarray, np.ndarray]:
+        link_acc_gympp = self.gympp_robot.linkAcceleration(link_name)
+        return np.array(link_acc_gympp.linear), np.array(link_acc_gympp.angular)

--- a/gympp/include/gympp/Robot.h
+++ b/gympp/include/gympp/Robot.h
@@ -21,9 +21,10 @@ namespace gympp {
 
     struct PID;
     struct Limit;
-    struct BasePose;
+    struct Pose;
+    struct Velocity6D;
     struct ContactData;
-    struct BaseVelocity;
+    struct Acceleration6D;
     enum class JointControlMode
     {
         Position,
@@ -47,13 +48,19 @@ struct gympp::PID
     double d;
 };
 
-struct gympp::BasePose
+struct gympp::Pose
 {
     std::array<double, 3> position;
     std::array<double, 4> orientation;
 };
 
-struct gympp::BaseVelocity
+struct gympp::Velocity6D
+{
+    std::array<double, 3> linear;
+    std::array<double, 3> angular;
+};
+
+struct gympp::Acceleration6D
 {
     std::array<double, 3> linear;
     std::array<double, 3> angular;
@@ -83,7 +90,7 @@ public:
     using LinkName = std::string;
     using RobotName = std::string;
     using JointName = std::string;
-    using LinkNames = std::vector<JointName>;
+    using LinkNames = std::vector<LinkName>;
     using JointNames = std::vector<JointName>;
 
     using JointPositions = VectorContainer;
@@ -122,6 +129,13 @@ public:
     virtual LinkNames linksInContact() const = 0;
     virtual std::vector<ContactData> contactData(const LinkName& linkName) const = 0;
 
+    virtual LinkNames linkNames() const = 0;
+    virtual Pose linkPose(const LinkName& linkName) const = 0;
+    virtual Velocity6D linkVelocity(const LinkName& linkName) const = 0;
+    virtual Acceleration6D linkAcceleration(const LinkName& linkName) const = 0;
+    virtual Velocity6D linkBodyFixedVelocity(const LinkName& linkName) const = 0;
+    virtual Acceleration6D linkBodyFixedAcceleration(const LinkName& linkName) const = 0;
+
     // ===========
     // SET METHODS
     // ===========
@@ -155,8 +169,8 @@ public:
     virtual LinkName baseFrame() = 0;
     virtual bool setBaseFrame(const LinkName& baseLink) = 0;
 
-    virtual BasePose basePose() = 0;
-    virtual BaseVelocity baseVelocity() = 0;
+    virtual Pose basePose() = 0;
+    virtual Velocity6D baseVelocity() = 0;
     virtual bool setAsFloatingBase(bool isFloating) = 0;
     virtual bool resetBasePose(const std::array<double, 3>& position,
                                const std::array<double, 4>& orientation) = 0;

--- a/ignition/CMakeLists.txt
+++ b/ignition/CMakeLists.txt
@@ -9,7 +9,8 @@
 add_library(ExtraComponents INTERFACE)
 target_sources(ExtraComponents INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/include/gympp/gazebo/components/JointPositionReset.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/gympp/gazebo/components/JointVelocityReset.h)
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/gympp/gazebo/components/JointVelocityReset.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/gympp/gazebo/components/WorldVelocityCmd.h)
 
 target_include_directories(ExtraComponents INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/ignition/include/gympp/gazebo/IgnitionRobot.h
+++ b/ignition/include/gympp/gazebo/IgnitionRobot.h
@@ -66,6 +66,13 @@ public:
     LinkNames linksInContact() const override;
     std::vector<ContactData> contactData(const LinkName& linkName) const override;
 
+    LinkNames linkNames() const override;
+    Pose linkPose(const LinkName& linkName) const override;
+    Velocity6D linkVelocity(const LinkName& linkName) const override;
+    Acceleration6D linkAcceleration(const LinkName& linkName) const override;
+    Velocity6D linkBodyFixedVelocity(const LinkName& linkName) const override;
+    Acceleration6D linkBodyFixedAcceleration(const LinkName& linkName) const override;
+
     // ===========
     // SET METHODS
     // ===========

--- a/ignition/include/gympp/gazebo/IgnitionRobot.h
+++ b/ignition/include/gympp/gazebo/IgnitionRobot.h
@@ -105,8 +105,8 @@ public:
     LinkName baseFrame() override;
     bool setBaseFrame(const LinkName& baseLink) override;
 
-    BasePose basePose() override;
-    BaseVelocity baseVelocity() override;
+    Pose basePose() override;
+    Velocity6D baseVelocity() override;
     bool setAsFloatingBase(bool isFloating) override;
     bool resetBasePose(const std::array<double, 3>& position,
                        const std::array<double, 4>& orientation) override;

--- a/ignition/include/gympp/gazebo/components/WorldVelocityCmd.h
+++ b/ignition/include/gympp/gazebo/components/WorldVelocityCmd.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ *
+ * ==================================================
+ *
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef IGNITION_GAZEBO_COMPONENTS_WORLDVELOCITYCMD_HH_
+#define IGNITION_GAZEBO_COMPONENTS_WORLDVELOCITYCMD_HH_
+
+#include <ignition/math/Vector3.hh>
+
+#include <ignition/gazebo/Export.hh>
+#include <ignition/gazebo/config.hh>
+
+#include "ignition/gazebo/components/Component.hh"
+#include <ignition/gazebo/components/Factory.hh>
+
+namespace ignition {
+    namespace gazebo {
+        // Inline bracket to help doxygen filtering.
+        inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
+            struct WorldVelocity {
+                math::Vector3d linear;
+                math::Vector3d angular;
+            };
+
+            namespace components {
+                /// \brief A component type that contains commanded velocity of an
+                /// entity in the world frame represented by ignition::math::Vector3d.
+                using WorldVelocityCmd =
+                    Component<WorldVelocity, class WorldVelocityCmdTag>;
+                IGN_GAZEBO_REGISTER_COMPONENT("ign_gazebo_components.WorldVelocityCmdTag",
+                                              WorldVelocityCmd)
+            } // namespace components
+        } // namespace IGNITION_GAZEBO_VERSION_NAMESPACE
+    } // namespace gazebo
+} // namespace ignition
+#endif // IGNITION_GAZEBO_COMPONENTS_WORLDVELOCITYCMD_HH_

--- a/ignition/src/IgnitionRobot.cpp
+++ b/ignition/src/IgnitionRobot.cpp
@@ -111,6 +111,20 @@ public:
 
     template <typename ComponentType>
     ComponentType& getOrCreateComponent(const ignition::gazebo::Entity entity);
+
+    static gympp::Pose fromIgnitionMath(const ignition::math::Pose3d& ignitionPose);
+    static ignition::math::Pose3d toIgnitionMath(const gympp::Pose& pose);
+
+    static inline std::array<double, 3>
+    fromIgnitionMath(const ignition::math::Vector3d& ignitionVector)
+    {
+        return {ignitionVector.X(), ignitionVector.Y(), ignitionVector.Z()};
+    }
+
+    static inline ignition::math::Vector3d toIgnitionMath(const std::array<double, 3>& vector)
+    {
+        return {vector[0], vector[1], vector[2]};
+    }
 };
 
 LinkEntity IgnitionRobot::Impl::getLinkEntity(const LinkName& linkName)
@@ -234,6 +248,29 @@ void IgnitionRobot::Impl::gatherLinksContactData()
 
             return true;
         });
+}
+
+gympp::Pose IgnitionRobot::Impl::fromIgnitionMath(const ignition::math::Pose3d& ignitionPose)
+{
+    gympp::Pose pose;
+    pose.position[0] = ignitionPose.Pos().X();
+    pose.position[1] = ignitionPose.Pos().Y();
+    pose.position[2] = ignitionPose.Pos().Z();
+    pose.orientation[0] = ignitionPose.Rot().W();
+    pose.orientation[1] = ignitionPose.Rot().X();
+    pose.orientation[2] = ignitionPose.Rot().Y();
+    pose.orientation[3] = ignitionPose.Rot().Z();
+    return pose;
+}
+
+ignition::math::Pose3d IgnitionRobot::Impl::toIgnitionMath(const gympp::Pose& pose)
+{
+    ignition::math::Pose3d ignitionPose;
+    ignitionPose.Pos() =
+        ignition::math::Vector3d(pose.position[0], pose.position[1], pose.position[2]);
+    ignitionPose.Rot() = ignition::math::Quaterniond(
+        pose.orientation[0], pose.orientation[1], pose.orientation[2], pose.orientation[3]);
+    return ignitionPose;
 }
 
 template <typename ComponentTypeT>

--- a/ignition/src/IgnitionRobot.cpp
+++ b/ignition/src/IgnitionRobot.cpp
@@ -662,6 +662,143 @@ IgnitionRobot::contactData(const gympp::Robot::LinkName& linkName) const
     return pImpl->buffers.links.contacts.at(linkName);
 }
 
+gympp::Robot::LinkNames IgnitionRobot::linkNames() const
+{
+    LinkNames names;
+    names.reserve(pImpl->links.size());
+
+    for (const auto& [linkName, _] : pImpl->links) {
+        names.push_back(linkName);
+    }
+
+    return names;
+}
+
+gympp::Pose IgnitionRobot::linkPose(const gympp::Robot::LinkName& linkName) const
+{
+    LinkEntity linkEntity = pImpl->getLinkEntity(linkName);
+    assert(linkEntity != ignition::gazebo::kNullEntity);
+
+    // Get the link world pose component expressed in the world frame
+    auto linkWorldPoseComponent =
+        pImpl->ecm->Component<ignition::gazebo::components::WorldPose>(linkEntity);
+    assert(linkWorldPoseComponent);
+
+    // Get the link pose
+    const ignition::math::Pose3d& linkWorldPoseGazebo = linkWorldPoseComponent->Data();
+
+    return Impl::fromIgnitionMath(linkWorldPoseGazebo);
+}
+
+gympp::Velocity6D IgnitionRobot::linkVelocity(const gympp::Robot::LinkName& linkName) const
+{
+    LinkEntity linkEntity = pImpl->getLinkEntity(linkName);
+    assert(linkEntity != ignition::gazebo::kNullEntity);
+
+    // Get the link linear velocity componenent expressed in the world frame.
+    auto linkWorldLinVelComponent =
+        pImpl->ecm->Component<ignition::gazebo::components::WorldLinearVelocity>(linkEntity);
+    assert(linkWorldLinVelComponent);
+
+    // Get the link angular velocity componenent expressed in the world frame.
+    auto linkWorldAngVelComponent =
+        pImpl->ecm->Component<ignition::gazebo::components::WorldAngularVelocity>(linkEntity);
+    assert(linkWorldAngVelComponent);
+
+    // Get the link velocities
+    const ignition::math::Vector3d& linkWorldLinVel = linkWorldLinVelComponent->Data();
+    const ignition::math::Vector3d& linkWorldAngVel = linkWorldAngVelComponent->Data();
+
+    // Fill the output data structure
+    gympp::Velocity6D linkWorldVelocity;
+    linkWorldVelocity.linear = Impl::fromIgnitionMath(linkWorldLinVel);
+    linkWorldVelocity.angular = Impl::fromIgnitionMath(linkWorldAngVel);
+
+    return linkWorldVelocity;
+}
+
+gympp::Acceleration6D IgnitionRobot::linkAcceleration(const gympp::Robot::LinkName& linkName) const
+{
+    LinkEntity linkEntity = pImpl->getLinkEntity(linkName);
+    assert(linkEntity != ignition::gazebo::kNullEntity);
+
+    // Get the link linear acceleration componenent expressed in the world frame.
+    auto linkWorldLinAccComponent =
+        pImpl->ecm->Component<ignition::gazebo::components::WorldLinearAcceleration>(linkEntity);
+    assert(linkWorldLinAccComponent);
+
+    // Get the link angular acceleration componenent expressed in the world frame.
+    auto linkWorldAngAccComponent =
+        pImpl->ecm->Component<ignition::gazebo::components::WorldAngularAcceleration>(linkEntity);
+    assert(linkWorldAngAccComponent);
+
+    // Get the link accelerations
+    const ignition::math::Vector3d& linkWorldLinAcc = linkWorldLinAccComponent->Data();
+    const ignition::math::Vector3d& linkWorldAngAcc = linkWorldAngAccComponent->Data();
+
+    // Fill the output data structure
+    gympp::Acceleration6D linkWorldAcceleration;
+    linkWorldAcceleration.linear = Impl::fromIgnitionMath(linkWorldLinAcc);
+    linkWorldAcceleration.angular = Impl::fromIgnitionMath(linkWorldAngAcc);
+
+    return linkWorldAcceleration;
+}
+
+gympp::Velocity6D IgnitionRobot::linkBodyFixedVelocity(const gympp::Robot::LinkName& linkName) const
+{
+    LinkEntity linkEntity = pImpl->getLinkEntity(linkName);
+    assert(linkEntity != ignition::gazebo::kNullEntity);
+
+    // Get the link linear velocity componenent expressed in the link frame.
+    auto linkBodyLinVelComponent =
+        pImpl->ecm->Component<ignition::gazebo::components::LinearVelocity>(linkEntity);
+    assert(linkBodyLinVelComponent);
+
+    // Get the link angular velocity componenent expressed in the link frame.
+    auto linkBodyAngVelComponent =
+        pImpl->ecm->Component<ignition::gazebo::components::AngularVelocity>(linkEntity);
+    assert(linkBodyAngVelComponent);
+
+    // Get the link velocities
+    const ignition::math::Vector3d& linkBodyLinVel = linkBodyLinVelComponent->Data();
+    const ignition::math::Vector3d& linkBodyAngVel = linkBodyAngVelComponent->Data();
+
+    // Fill the output data structure
+    gympp::Velocity6D linkBodyVelocity;
+    linkBodyVelocity.linear = Impl::fromIgnitionMath(linkBodyLinVel);
+    linkBodyVelocity.angular = Impl::fromIgnitionMath(linkBodyAngVel);
+
+    return linkBodyVelocity;
+}
+
+gympp::Acceleration6D
+IgnitionRobot::linkBodyFixedAcceleration(const gympp::Robot::LinkName& linkName) const
+{
+    LinkEntity linkEntity = pImpl->getLinkEntity(linkName);
+    assert(linkEntity != ignition::gazebo::kNullEntity);
+
+    // Get the link linear acceleration componenent expressed in the link frame.
+    auto linkBodyLinAccComponent =
+        pImpl->ecm->Component<ignition::gazebo::components::LinearAcceleration>(linkEntity);
+    assert(linkBodyLinAccComponent);
+
+    // Get the link angular acceleration componenent expressed in the link frame.
+    auto linkBodyAngAccComponent =
+        pImpl->ecm->Component<ignition::gazebo::components::AngularAcceleration>(linkEntity);
+    assert(linkBodyAngAccComponent);
+
+    // Get the link velocities
+    const ignition::math::Vector3d& linkBodyLinAcc = linkBodyLinAccComponent->Data();
+    const ignition::math::Vector3d& linkBodyAngAcc = linkBodyAngAccComponent->Data();
+
+    // Fill the output data structure
+    gympp::Acceleration6D linkBodyAcceleration;
+    linkBodyAcceleration.linear = Impl::fromIgnitionMath(linkBodyLinAcc);
+    linkBodyAcceleration.angular = Impl::fromIgnitionMath(linkBodyAngAcc);
+
+    return linkBodyAcceleration;
+}
+
 bool IgnitionRobot::setdt(const gympp::Robot::StepSize& stepSize)
 {
     pImpl->dt = stepSize;

--- a/ignition/src/IgnitionRobot.cpp
+++ b/ignition/src/IgnitionRobot.cpp
@@ -14,6 +14,8 @@
 
 #include <ignition/gazebo/Model.hh>
 #include <ignition/gazebo/SdfEntityCreator.hh>
+#include <ignition/gazebo/components/AngularAcceleration.hh>
+#include <ignition/gazebo/components/AngularVelocity.hh>
 #include <ignition/gazebo/components/CanonicalLink.hh>
 #include <ignition/gazebo/components/Collision.hh>
 #include <ignition/gazebo/components/ContactSensorData.hh>
@@ -23,6 +25,8 @@
 #include <ignition/gazebo/components/JointPosition.hh>
 #include <ignition/gazebo/components/JointType.hh>
 #include <ignition/gazebo/components/JointVelocity.hh>
+#include <ignition/gazebo/components/LinearAcceleration.hh>
+#include <ignition/gazebo/components/LinearVelocity.hh>
 #include <ignition/gazebo/components/Link.hh>
 #include <ignition/gazebo/components/Model.hh>
 #include <ignition/gazebo/components/Name.hh>
@@ -416,6 +420,20 @@ bool IgnitionRobot::configureECM(const ignition::gazebo::Entity& entity,
     // Initialize the contacts buffers for each link
     for (const auto& [linkName, LinkEntity] : pImpl->links) {
         pImpl->buffers.links.contacts[linkName] = {};
+    }
+
+    // Create the components to store link quantities.
+    // The Physics system fills the components during the simulation.
+    for (auto& [_, linkEntity] : pImpl->links) {
+        ecm->CreateComponent(linkEntity, ignition::gazebo::components::WorldPose());
+        ecm->CreateComponent(linkEntity, ignition::gazebo::components::WorldLinearVelocity());
+        ecm->CreateComponent(linkEntity, ignition::gazebo::components::WorldAngularVelocity());
+        ecm->CreateComponent(linkEntity, ignition::gazebo::components::WorldLinearAcceleration());
+        ecm->CreateComponent(linkEntity, ignition::gazebo::components::WorldAngularAcceleration());
+        ecm->CreateComponent(linkEntity, ignition::gazebo::components::LinearVelocity());
+        ecm->CreateComponent(linkEntity, ignition::gazebo::components::AngularVelocity());
+        ecm->CreateComponent(linkEntity, ignition::gazebo::components::LinearAcceleration());
+        ecm->CreateComponent(linkEntity, ignition::gazebo::components::AngularAcceleration());
     }
 
     // Check that the created object is valid

--- a/ignition/src/IgnitionRobot.cpp
+++ b/ignition/src/IgnitionRobot.cpp
@@ -320,10 +320,6 @@ bool IgnitionRobot::configureECM(const ignition::gazebo::Entity& entity,
 
     gymppDebug << "Processing model '" << pImpl->model.Name(*ecm) << "'" << std::endl;
 
-    // Modifying the ECM in a Each loop is dangerous.
-    // We store the joint entities we are interested in this vector and then we operate on them.
-    std::vector<ignition::gazebo::Entity> thisModelJointEntities;
-
     ecm->Each<ignition::gazebo::components::Joint,
               ignition::gazebo::components::Name,
               ignition::gazebo::components::JointType,
@@ -357,8 +353,6 @@ bool IgnitionRobot::configureECM(const ignition::gazebo::Entity& entity,
                 return true;
             }
 
-            thisModelJointEntities.push_back(entity);
-
             // Store the joint entity
             pImpl->joints[name->Data()] = jointEntity;
 
@@ -376,7 +370,7 @@ bool IgnitionRobot::configureECM(const ignition::gazebo::Entity& entity,
 
     // Create the joint position and velocity components.
     // In this way this data is stored in these components after the physics step.
-    for (auto& jointEntity : thisModelJointEntities) {
+    for (auto& [_, jointEntity] : pImpl->joints) {
         ecm->CreateComponent(jointEntity, ignition::gazebo::components::JointPosition());
         ecm->CreateComponent(jointEntity, ignition::gazebo::components::JointVelocity());
     }

--- a/plugins/Physics/Physics.cpp
+++ b/plugins/Physics/Physics.cpp
@@ -26,6 +26,7 @@
 #include "Physics.h"
 #include "gympp/gazebo/components/JointPositionReset.h"
 #include "gympp/gazebo/components/JointVelocityReset.h"
+#include "gympp/gazebo/components/WorldVelocityCmd.h"
 
 #include <ignition/common/MeshManager.hh>
 #include <ignition/gazebo/EntityComponentManager.hh>
@@ -115,6 +116,7 @@ public:
     using MinimumFeatureList = ignition::physics::FeatureList< //
         ignition::physics::FindFreeGroupFeature,
         ignition::physics::SetFreeGroupWorldPose,
+        ignition::physics::SetFreeGroupWorldVelocity,
         ignition::physics::AddLinkExternalForceTorque,
         ignition::physics::ForwardStep,
         ignition::physics::GetEntities,
@@ -738,6 +740,73 @@ void Physics::Impl::UpdatePhysics(EntityComponentManager& _ecm)
             return true;
         });
 
+    // Process WorldVelocityCmd
+    _ecm.Each<components::Model, components::WorldVelocityCmd>([&](const Entity& _entity,
+                                                                   const components::Model*,
+                                                                   components::WorldVelocityCmd*
+                                                                       _modelWorldVelocityCmd) {
+        auto modelIt = this->entityModelMap.find(_entity);
+        if (modelIt == this->entityModelMap.end())
+            return true;
+
+        // TODO(addisu) Store the free group instead of searching for it at
+        // every iteration
+        auto freeGroup = modelIt->second->FindFreeGroup();
+
+        // The FreeGroup is created only for floating-base object that do not have any defined
+        // joint between the world and their base
+        if (!freeGroup) {
+            ignwarn << "Failed to find FreeGroup. Linear and angular velocities commands ignored."
+                    << std::endl;
+            return true;
+        }
+
+        // Get canonical link offset
+        auto canonicalLink = _ecm.ChildrenByComponents(_entity, components::CanonicalLink());
+        if (canonicalLink.empty())
+            return true;
+
+        auto canonicalPoseComp = _ecm.Component<components::Pose>(canonicalLink[0]);
+        if (nullptr == canonicalPoseComp)
+            return true;
+
+        ignition::math::Vector3d& modelWorldLinearVelocity = _modelWorldVelocityCmd->Data().linear;
+        ignition::math::Vector3d& modelWorldAngularVelocity =
+            _modelWorldVelocityCmd->Data().angular;
+
+        ignition::math::Pose3d& M_H_B = canonicalPoseComp->Data();
+        ignition::math::Pose3d B_H_M = M_H_B.Inverse();
+        ignition::math::Vector3d& B_o_M = B_H_M.Pos();
+        ignition::math::Quaterniond& B_R_M = B_H_M.Rot();
+
+        {
+            // Express the angular velocity in the frame of the base link
+            ignition::math::Vector3d wBase = B_R_M * modelWorldAngularVelocity;
+            ignwarn << wBase << std::endl;
+
+            // Set the angular velocity of the canonical link
+            freeGroup->SetWorldAngularVelocity(math::eigen3::convert(wBase));
+        }
+
+        {
+            // Skew-symmetrix matrix from 3D vector
+            auto hat = [](const ignition::math::Vector3d& v) -> ignition::math::Matrix3d {
+                return ignition::math::Matrix3d(0, -v[2], v[1], v[2], 0, -v[0], -v[1], v[0], 0);
+            };
+
+            // Express the linear velocity in the frame of the base link
+            ignition::math::Vector3d vBase =
+                B_R_M * modelWorldLinearVelocity + hat(B_o_M) * (B_R_M * modelWorldAngularVelocity);
+            ignwarn << vBase << std::endl;
+
+            // Set the linear velocity of the canonical link
+            freeGroup->SetWorldLinearVelocity(math::eigen3::convert(vBase));
+        }
+
+        // TODO(diego): static models from above
+        return true;
+    });
+
     // Clear pending commands
     // Note: Removing components from inside an Each call can be dangerous.
     // Instead, we collect all the entities that have the desired components and
@@ -751,6 +820,18 @@ void Physics::Impl::UpdatePhysics(EntityComponentManager& _ecm)
 
     for (const Entity& entity : entitiesWorldCmd) {
         _ecm.RemoveComponent<components::WorldPoseCmd>(entity);
+    }
+
+    // Clear WorldVelocityCmd
+    entitiesWorldCmd.clear();
+    _ecm.Each<components::WorldVelocityCmd>(
+        [&](const Entity& _entity, components::WorldVelocityCmd*) -> bool {
+            entitiesWorldCmd.push_back(_entity);
+            return true;
+        });
+
+    for (const Entity& entity : entitiesWorldCmd) {
+        _ecm.RemoveComponent<components::WorldVelocityCmd>(entity);
     }
 }
 


### PR DESCRIPTION
The `IgnitionRobot` class now supports:

- Get link names
- Get link pose, velocity, acceleration, all expressed in the world frame
- Get link velocity and acceleration expressed in body-fixed frame
- Get the base velocity of a model (the base is the model frame, not the canonical link frame)
- Set the pose and velocity of the model

This PR also exposes these C++ methods to the `GazeboRobot` Python class.

Closes https://github.com/robotology/gym-ignition/issues/65.