### PR TITLE
Apply external forces

### DIFF
--- a/gym_ignition/base/robot/robot_links.py
+++ b/gym_ignition/base/robot/robot_links.py
@@ -84,3 +84,27 @@ class RobotLinks(ABC):
             - linear acceleration: a 3D array in the [ax, ay, az] form.
             - angular acceleration: a 3D array in the [wdotx, wdoty, wdotz] form.
         """
+
+    def apply_external_force(self,
+                             link_name: str,
+                             force: np.ndarray,
+                             torque: np.ndarray) -> bool:
+        """
+        Apply external force and torque to the link.
+
+        The force and the torque are applied at the link origin.
+        The force is expressed in the world frame.
+        The torque is expressed with the orientation of the world frame.
+
+        The external force and torque are only applied for the next simulation step,
+        and then they are automatically reset to zero. To apply a force for more then one
+        step, call `apply_external_force` before each step.
+
+        Args:
+            link_name: The name of the link.
+            force: A 3D array containing the force vector.
+            torque: A 3D array containing the torque vector.
+
+        Returns:
+            True if successful, False otherwise.
+        """

--- a/gym_ignition/robots/base/gazebo_robot.py
+++ b/gym_ignition/robots/base/gazebo_robot.py
@@ -406,3 +406,15 @@ class GazeboRobot(robot_abc.RobotABC,
     def link_acceleration(self, link_name: str) -> Tuple[np.ndarray, np.ndarray]:
         link_acc_gympp = self.gympp_robot.linkAcceleration(link_name)
         return np.array(link_acc_gympp.linear), np.array(link_acc_gympp.angular)
+
+    def apply_external_force(self,
+                             link_name: str,
+                             force: np.ndarray,
+                             torque: np.ndarray) -> bool:
+        assert link_name in self.link_names(), "The link is not part of the model"
+
+        ok_wrench = self.gympp_robot.addExternalWrench(
+            link_name, list(force), list(torque))
+        assert ok_wrench, f"Failed to add external wrench to link '{link_name}'"
+
+        return True

--- a/gympp/include/gympp/Robot.h
+++ b/gympp/include/gympp/Robot.h
@@ -9,6 +9,7 @@
 #ifndef GYMPP_ROBOT_H
 #define GYMPP_ROBOT_H
 
+#include <array>
 #include <chrono>
 #include <limits>
 #include <memory>
@@ -160,6 +161,9 @@ public:
                             const double jointPosition = 0,
                             const double jointVelocity = 0) = 0;
 
+    virtual bool addExternalWrench(const LinkName& linkName,
+                                   const std::array<double, 3>& force,
+                                   const std::array<double, 3>& torque) = 0;
     virtual bool update(const std::chrono::duration<double> time) = 0;
 
     // ==============

--- a/ignition/include/gympp/gazebo/IgnitionRobot.h
+++ b/ignition/include/gympp/gazebo/IgnitionRobot.h
@@ -96,6 +96,9 @@ public:
                     const double jointPosition = 0,
                     const double jointVelocity = 0) override;
 
+    bool addExternalWrench(const LinkName& linkName,
+                           const std::array<double, 3>& force,
+                           const std::array<double, 3>& torque) override;
     bool update(const std::chrono::duration<double> time) override;
 
     // ==============

--- a/tests/python/test_contacts.py
+++ b/tests/python/test_contacts.py
@@ -5,55 +5,6 @@
 import tempfile
 import numpy as np
 from . import utils
-from gym_ignition.robots import gazebo_robot
-
-
-def get_cube_urdf() -> str:
-    mass = 5.0
-    edge = 0.2
-    i = 1 / 12 * mass * (edge ** 2 + edge ** 2)
-    cube_urdf = f"""
-    <robot name="cube_robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
-        <link name="cube">
-            <inertial>
-              <origin rpy="0 0 0" xyz="0 0 0"/>
-              <mass value="{mass}"/>
-              <inertia ixx="{i}" ixy="0" ixz="0" iyy="{i}" iyz="0" izz="{i}"/>
-            </inertial>
-            <visual>
-              <geometry>
-                <box size="{edge} {edge} {edge}"/>
-              </geometry>
-              <origin rpy="0 0 0" xyz="0 0 0"/>
-            </visual>
-            <collision>
-              <geometry>
-                <box size="{edge} {edge} {edge}"/>
-              </geometry>
-              <origin rpy="0 0 0" xyz="0 0 0"/>
-            </collision>
-        </link>
-    </robot>"""
-    return cube_urdf
-
-
-class CubeGazeboRobot(gazebo_robot.GazeboRobot):
-    def __init__(self, model_file: str, gazebo, initial_position: np.ndarray):
-        # Initialize base class
-        super().__init__(model_file=model_file,
-                         gazebo=gazebo)
-
-        ok_floating = self.set_as_floating_base(True)
-        assert ok_floating, "Failed to set the robot as floating base"
-
-        # Initial base position and orientation
-        base_position = np.array(initial_position)
-        base_orientation = np.array([1., 0., 0., 0.])
-        ok_base_pose = self.set_initial_base_pose(base_position, base_orientation)
-        assert ok_base_pose, "Failed to set base pose"
-
-        # Insert the model in the simulation
-        _ = self.gympp_robot
 
 
 def test_contacts():
@@ -63,17 +14,17 @@ def test_contacts():
     # Serialize the cube urdf
     handle, model_file = tempfile.mkstemp()
     with open(handle, 'w') as f:
-        f.write(get_cube_urdf())
+        f.write(utils.get_cube_urdf())
 
     # Create the first cube and insert it in the simulation
-    cube1 = CubeGazeboRobot(model_file=model_file,
-                            gazebo=gazebo.simulator,
-                            initial_position=np.array([0, 0, 1.0]))
+    cube1 = utils.CubeGazeboRobot(model_file=model_file,
+                                  gazebo=gazebo.simulator,
+                                  initial_position=np.array([0, 0, 1.0]))
 
     # Create the second cube and insert it in the simulation
-    cube2 = CubeGazeboRobot(model_file=model_file,
-                            gazebo=gazebo.simulator,
-                            initial_position=np.array([0, 0, 2.5]))
+    cube2 = utils.CubeGazeboRobot(model_file=model_file,
+                                  gazebo=gazebo.simulator,
+                                  initial_position=np.array([0, 0, 2.5]))
 
     # Execute the first simulation step
     gazebo.step()

--- a/tests/python/test_externalforce.py
+++ b/tests/python/test_externalforce.py
@@ -1,0 +1,50 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import tempfile
+import numpy as np
+from . import utils
+
+
+def test_external_force():
+    # Get the simulator
+    gazebo = utils.Gazebo(physics_rate=1000, iterations=1, rtf=100)
+
+    # Serialize the cube urdf
+    handle, model_file = tempfile.mkstemp()
+    with open(handle, 'w') as f:
+        f.write(utils.get_cube_urdf())
+
+    # Create the first cube and insert it in the simulation
+    cube = utils.CubeGazeboRobot(model_file=model_file,
+                                 gazebo=gazebo.simulator,
+                                 initial_position=np.array([0, 0, 1.0]))
+
+    # Execute the first simulation step
+    gazebo.step()
+
+    # Get the position of the cube
+    position, _ = cube.base_pose()
+    assert position[0] == 0.0
+    assert position[1] == 0.0
+
+    # Apply a force for 1 second
+    num_steps = 100
+    f_x = 50.0
+    f_y = - f_x / 10
+
+    for _ in range(num_steps):
+        ok_w = cube.apply_external_force(
+            "cube", np.array([f_x, f_y, 0]), np.array([0.0, 0, 0]))
+        assert ok_w
+
+        # Step the simulation
+        gazebo.step()
+
+    # Get the position of the cube
+    position, _ = cube.base_pose()
+    print(position)
+    assert position[0] > 0.0
+    assert position[1] < 0.0
+    assert np.allclose(-position[0], 10 * position[1])


### PR DESCRIPTION
This PR adds the support of applying external forces and torques to model's links. The component read by the Physics system unfortunately is a transport message, and due to this choice the way to fill the data handled by the component is not that clean.

Closes #121 