### PR TITLE
Fix stepping PID controllers when physics and controllers rate are different

### DIFF
--- a/gympp/include/gympp/Robot.h
+++ b/gympp/include/gympp/Robot.h
@@ -172,7 +172,7 @@ public:
     virtual bool addExternalWrench(const LinkName& linkName,
                                    const std::array<double, 3>& force,
                                    const std::array<double, 3>& torque) = 0;
-    virtual bool update(const std::chrono::duration<double> time) = 0;
+    virtual bool update(const std::chrono::duration<double>& simTime) = 0;
 
     // ==============
     // RobotBaseFrame

--- a/ignition/include/gympp/gazebo/IgnitionRobot.h
+++ b/ignition/include/gympp/gazebo/IgnitionRobot.h
@@ -100,7 +100,7 @@ public:
     bool addExternalWrench(const LinkName& linkName,
                            const std::array<double, 3>& force,
                            const std::array<double, 3>& torque) override;
-    bool update(const std::chrono::duration<double> time) override;
+    bool update(const std::chrono::duration<double>& simTime) override;
 
     // ==============
     // RobotBaseFrame

--- a/ignition/src/IgnitionRobot.cpp
+++ b/ignition/src/IgnitionRobot.cpp
@@ -985,6 +985,10 @@ bool IgnitionRobot::setJointControlMode(const gympp::Robot::JointName& jointName
     // Clean up possible old references
     pImpl->buffers.joints.references.erase(jointName);
 
+    // Clean the buffer that stores the force
+    pImpl->buffers.joints.appliedForces.erase(jointName);
+
+    // Update the control mode
     pImpl->buffers.joints.controlMode[jointName] = controlMode;
     return true;
 }

--- a/ignition/src/IgnitionRobot.cpp
+++ b/ignition/src/IgnitionRobot.cpp
@@ -133,6 +133,11 @@ public:
     {
         return {vector[0], vector[1], vector[2]};
     }
+
+    static inline ignition::math::PID toIgnitionMath(const gympp::PID& pid)
+    {
+        return {pid.p, pid.i, pid.d};
+    }
 };
 
 LinkEntity IgnitionRobot::Impl::getLinkEntity(const LinkName& linkName)
@@ -991,19 +996,8 @@ bool IgnitionRobot::setJointPID(const gympp::Robot::JointName& jointName, const 
         return false;
     }
 
-    if (!pImpl->pidExists(jointName)) {
-        gymppDebug << "Creating new PID for joint " << jointName << std::endl;
-        pImpl->buffers.joints.pid[jointName] = DefaultPID;
-    }
-    else {
-        pImpl->buffers.joints.pid[jointName].Reset();
-    }
-
-    // Update the gains. The other PID parameters do not change.
-    pImpl->buffers.joints.pid[jointName].SetPGain(pid.p);
-    pImpl->buffers.joints.pid[jointName].SetIGain(pid.i);
-    pImpl->buffers.joints.pid[jointName].SetDGain(pid.d);
-
+    // Create a new PID
+    pImpl->buffers.joints.pid[jointName] = Impl::toIgnitionMath(pid);
     return true;
 }
 

--- a/ignition/src/IgnitionRobot.cpp
+++ b/ignition/src/IgnitionRobot.cpp
@@ -1145,11 +1145,8 @@ bool IgnitionRobot::update(const std::chrono::duration<double>& simTime)
             pImpl->buffers.joints.appliedForces[jointName] = force;
         }
 
-        // Break if there is no force to actuate for this joint
-        if (pImpl->buffers.joints.appliedForces.find(jointName)
-            == pImpl->buffers.joints.appliedForces.end()) {
-            break;
-        }
+        assert(pImpl->buffers.joints.appliedForces.find(jointName)
+               != pImpl->buffers.joints.appliedForces.end());
 
         // Get the force
         auto force = pImpl->buffers.joints.appliedForces[jointName];

--- a/ignition/src/IgnitionRobot.cpp
+++ b/ignition/src/IgnitionRobot.cpp
@@ -1071,7 +1071,7 @@ bool IgnitionRobot::addExternalWrench(const gympp::Robot::LinkName& linkName,
     return true;
 }
 
-bool IgnitionRobot::update(const std::chrono::duration<double> time)
+bool IgnitionRobot::update(const std::chrono::duration<double>& simTime)
 {
     // Return if there are no references to actuate
     if (pImpl->buffers.joints.references.empty()) {
@@ -1085,7 +1085,7 @@ bool IgnitionRobot::update(const std::chrono::duration<double> time)
     }
 
     // Update the controller only if enough time is passed
-    std::chrono::duration<double> stepTime = time - pImpl->prevUpdateTime;
+    std::chrono::duration<double> stepTime = simTime - pImpl->prevUpdateTime;
 
     // Handle first iteration
     if (pImpl->prevUpdateTime == std::chrono::duration<double>(0.0)) {
@@ -1106,7 +1106,7 @@ bool IgnitionRobot::update(const std::chrono::duration<double> time)
 
     if (greaterThen(stepTime, pImpl->dt)) {
         // Store the current update time
-        pImpl->prevUpdateTime = time;
+        pImpl->prevUpdateTime = simTime;
 
         // Enable using the PID to compute the new force
         computeNewForce = true;


### PR DESCRIPTION
I noticed by chance that sometimes the update of PID controllers were not triggered correctly in the case when the controller update rate differs from the physics rate.

For instance, if the physics run at 1000 Hz and the controller at 250 Hz, there are 4 physics step every controller update. This means that the PIDs in the first step get both measurements and references and generate a new torque output. In the last three steps, the PIDs is disabled and the physics engine receives the same torque computed in the first step.

Due to numerical errors of floating point numbers, the following if (that can be rewritten as `stepTime - pImpl->dt >= 0`) was failing because it assumed the value of `- Xe-18`:

https://github.com/robotology/gym-ignition/blob/86a77cc9ea02ec61a5f16ce44ba5d6fb83b9a11a/ignition/src/IgnitionRobot.cpp#L648-L658

Therefore, few update steps were skipped. It was fixed in 9bb70d0.

Then, this PR includes some other related minor fixes. 