### PR TITLE
Extract last applied joint forces

### DIFF
--- a/gym_ignition/base/robot/robot_joints.py
+++ b/gym_ignition/base/robot/robot_joints.py
@@ -117,6 +117,28 @@ class RobotJoints(ABC):
         """
 
     @abstractmethod
+    def joint_force(self, joint_name: str) -> float:
+        """
+        Return the joint force applied to the specified joint in the last physics step.
+
+        The returned value is the effort or torque of the joint, since currently only
+        1 DoF joints are supported.
+
+        Note that the returned value depends on the rate of the enabled controllers.
+        For example, the JointControlMode.POSITION allows to specify a controller rate
+        different than the physics rate. In this case, this method will return only the
+        last applied force reference. If the PIDs are running faster than the code
+        that calls this `joint_force` method, the PIDs are generating forces that
+        are not returned.
+
+        Args:
+            joint_name: The name of the joint.
+
+        Returns:
+            The generalized joint force reference applied in the last physics step.
+        """
+
+    @abstractmethod
     def joint_positions(self) -> np.ndarray:
         """
         Return the generalized positions of the joints.

--- a/gym_ignition/robots/base/gazebo_robot.py
+++ b/gym_ignition/robots/base/gazebo_robot.py
@@ -203,6 +203,9 @@ class GazeboRobot(robot_abc.RobotABC,
     def joint_velocity(self, joint_name: str) -> float:
         return self.gympp_robot.jointVelocity(joint_name)
 
+    def joint_force(self, joint_name: str) -> float:
+        return self.gympp_robot.jointForce(joint_name)
+
     def joint_positions(self) -> List[float]:
         return self.gympp_robot.jointPositions()
 

--- a/gym_ignition/robots/base/pybullet_robot.py
+++ b/gym_ignition/robots/base/pybullet_robot.py
@@ -340,6 +340,9 @@ class PyBulletRobot(robot.robot_abc.RobotABC,
         joint_idx = self._joints_name2index[joint_name]
         return self._pybullet.getJointState(self._robot_id, joint_idx)[1]
 
+    def joint_force(self, joint_name: str) -> float:
+        raise NotImplementedError
+
     def joint_positions(self) -> List[float]:
         joint_states = self._pybullet.getJointStates(self._robot_id, range(self.dofs()))
         joint_positions = [state[0] for state in joint_states]

--- a/gympp/include/gympp/Robot.h
+++ b/gympp/include/gympp/Robot.h
@@ -121,6 +121,7 @@ public:
     virtual JointNames jointNames() const = 0;
 
     virtual JointType jointType(const JointName& jointName) const = 0;
+    virtual double jointForce(const JointName& jointName) const = 0;
     virtual double jointPosition(const JointName& jointName) const = 0;
     virtual double jointVelocity(const JointName& jointName) const = 0;
     virtual JointControlMode jointControlMode(const JointName& jointName) const = 0;

--- a/ignition/include/gympp/gazebo/IgnitionRobot.h
+++ b/ignition/include/gympp/gazebo/IgnitionRobot.h
@@ -50,6 +50,7 @@ public:
     JointNames jointNames() const override;
 
     JointType jointType(const JointName& jointName) const override;
+    double jointForce(const JointName& jointName) const override;
     double jointPosition(const JointName& jointName) const override;
     double jointVelocity(const JointName& jointName) const override;
     JointControlMode jointControlMode(const JointName& jointName) const override;

--- a/tests/python/test_joint_force.py
+++ b/tests/python/test_joint_force.py
@@ -1,0 +1,81 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+from . import utils
+from gym_ignition.base.robot.robot_joints import JointControlMode
+
+
+def test_joint_force():
+    # Get the simulator
+    gazebo = utils.Gazebo(physics_rate=1000, iterations=1)
+
+    # Insert the robot
+    pendulum = utils.get_pendulum(simulator=gazebo)
+
+    # Configure the robot
+    ok_mode = pendulum.set_joint_control_mode("pivot", JointControlMode.TORQUE)
+    assert ok_mode
+
+    # Step the simulator
+    gazebo.step()
+
+    # No references set
+    assert pendulum.joint_force("pivot") == 0.0
+
+    # Step the simulator
+    gazebo.step()
+
+    # Set a reference. No force reference yet applied.
+    torque = 42.42
+    pendulum.set_joint_force("pivot", torque)
+    assert pendulum.joint_force("pivot") == 0.0
+
+    # Step the simulator. Now the force reference should have been actuated and after
+    # the physics step it should be returned by the method.
+    gazebo.step()
+    assert pendulum.joint_force("pivot") == torque
+
+    # Step again the simulator. No force reference has been specified and the method
+    # should return zero.
+    gazebo.step()
+    assert pendulum.joint_force("pivot") == 0.0
+
+    # Close the simulator
+    gazebo.close()
+
+
+def test_joint_force_multiple_iterations():
+    # Get the simulator
+    gazebo = utils.Gazebo(physics_rate=1000, iterations=2)
+
+    # Insert the robot
+    pendulum = utils.get_pendulum(simulator=gazebo)
+    pendulum.set_joint_control_mode("pivot", JointControlMode.TORQUE)
+
+    # Step the simulator
+    gazebo.step()
+
+    # No references set
+    assert pendulum.joint_force("pivot") == 0.0
+
+    # Step the simulator
+    gazebo.step()
+
+    # Set a reference. No force reference yet applied.
+    torque = 42.42
+    pendulum.set_joint_force("pivot", torque)
+    assert pendulum.joint_force("pivot") == 0.0
+
+    # Step the simulator.
+    # Note that since gazebo was configured with multiple iterations,
+    # the force is applied only in the first one and we still read zero!
+    gazebo.step()
+    assert pendulum.joint_force("pivot") == 0.0
+
+    # Step again the simulator
+    gazebo.step()
+    assert pendulum.joint_force("pivot") == 0.0
+
+    # Close the simulator
+    gazebo.close()


### PR DESCRIPTION
This PR introduces the support of extracting the last-applied generalized force of joints.

There are few caveats. For instance if physics rate = agent rate = controller rate, everything work as expected. Though, if these rates are different, the extracted force reference could not be what expected. In fact, this method will **always return the force reference applied in the _last step_**.

Users should be aware of this behaviour when using this method.

This PR depends on #140.