### PR TITLE
Always import Python bindings from the gym_ignition package

### DIFF
--- a/gym_ignition/__init__.py
+++ b/gym_ignition/__init__.py
@@ -2,13 +2,25 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
-# Import gympp bindings
+# Import SWIG bindings
 # See https://github.com/robotology/gym-ignition/issues/7
+#     https://stackoverflow.com/a/45473441/12150968
 import sys
 if sys.platform.startswith('linux') or sys.platform.startswith('darwin'):
-    import ctypes
-    sys.setdlopenflags(sys.getdlopenflags() | ctypes.RTLD_GLOBAL)
-import gympp_bindings
+    import os
+    dlopen_flags = sys.getdlopenflags()
+    if "gympp_bindings" not in sys.modules:
+        sys.setdlopenflags(dlopen_flags | os.RTLD_GLOBAL)
+    else:
+        sys.setdlopenflags(dlopen_flags | os.RTLD_LAZY | os.RTLD_NOLOAD | os.RTLD_GLOBAL)
+
+    import gympp_bindings
+
+    # Restore the flags
+    sys.setdlopenflags(dlopen_flags)
+else:
+    import gympp_bindings
+
 
 # Configure OS environment variables
 from gym_ignition.utils import gazebo_env_vars, resource_finder

--- a/tests/python/test_bindings.py
+++ b/tests/python/test_bindings.py
@@ -109,7 +109,7 @@ def test_box_space():
             "Wrong data type of the sample extracted from the box space"
         assert box.contains(sample), \
             "Sampled data is not contained in the box space object that created it"
-    
+
 
 def test_space_box_metadata(create_space_box_md):
     md = create_space_box_md

--- a/tests/python/test_robot_base.py
+++ b/tests/python/test_robot_base.py
@@ -7,9 +7,9 @@ import pytest
 import numpy as np
 import pybullet_data
 import pybullet as p
-import gympp_bindings as bindings
 from pybullet_utils import bullet_client
 from gym_ignition.utils import resource_finder
+from gym_ignition import gympp_bindings as bindings
 from gym_ignition.robots.sim import gazebo, pybullet
 
 

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -6,11 +6,11 @@ import abc
 import numpy as np
 import pybullet_data
 import pybullet as p
-import gympp_bindings as bindings
 from gym_ignition.robots import sim
 from pybullet_utils import bullet_client
 from gym_ignition.robots import gazebo_robot
 from gym_ignition.utils import resource_finder
+from gym_ignition import gympp_bindings as bindings
 
 
 class Simulator(abc.ABC):


### PR DESCRIPTION
In the past few months, our CI suffered by occasional segfaults and hanging-ups. Failure were non-deterministic and I never managed to catch any with the debugger.

I still couldn't isolate the problem, but I noticed that some tests were loading the bindings directly, not passing through the `gym_ignition` package. It could be problematic since we alter the dlopen flags to make singleton and plugins work nicely together (#7, #21). Let's see if this edit will help.