### PR TITLE
Update fixed-base robots and update Python tests

### DIFF
--- a/gym_ignition/base/gympp_env.py
+++ b/gym_ignition/base/gympp_env.py
@@ -155,12 +155,15 @@ class GymppEnv(gym.Env):
         assert observation_vector, "Failed to get the observation buffer"
         assert observation_vector.size() > 0, "The observation does not contain elements"
 
+        # Convert the SWIG type to a list
+        observation_list = list(observation_vector)
+
         # Convert the observation to a numpy array (this is the only required copy)
         if isinstance(self.observation_space, gym.spaces.Box):
-            observation = np.array(observation_vector)
+            observation = np.array(observation_list)
         elif isinstance(self.observation_space, gym.spaces.Discrete):
             assert observation_vector.size() == 1, "The buffer has the wrong dimension"
-            observation = observation_vector[0]
+            observation = observation_list[0]
         else:
             assert False, "Space not supported"
 
@@ -186,16 +189,19 @@ class GymppEnv(gym.Env):
         assert observation_vector, "Failed to get the observation buffer"
         assert observation_vector.size() > 0, "The observation does not contain elements"
 
+        # Convert the SWIG type to a list
+        observation_list = list(observation_vector)
+
         # Convert the observation to a numpy array (this is the only required copy)
         if isinstance(self.observation_space, gym.spaces.Box):
-            observation = np.array(observation_vector)
+            observation = np.array(observation_list)
         elif isinstance(self.observation_space, gym.spaces.Discrete):
             assert observation_vector.size() == 1, "The buffer has the wrong dimension"
-            observation = observation_vector[0]
+            observation = observation_list[0]
         else:
             assert False, "Space not supported"
 
-        assert self.observation_space.contains(observation),\
+        assert self.observation_space.contains(observation), \
             "The returned observation does not belong to the space"
 
         # Return the list

--- a/gym_ignition/robots/base/gazebo_robot.py
+++ b/gym_ignition/robots/base/gazebo_robot.py
@@ -104,19 +104,19 @@ class GazeboRobot(robot_abc.RobotABC,
 
         # Initialize the model data
         model_data = bindings.ModelInitData()
-        model_data.setModelName(self._robot_name)
-        model_data.setSdfString(sdf_string)
-        model_data.setFixedPose(not self.is_floating_base())
-        model_data.setPosition(initial_base_pose.tolist())
-        model_data.setOrientation(initial_base_orientation.tolist())
+        model_data.modelName = self._robot_name
+        model_data.sdfString = sdf_string
+        model_data.fixedPose = not self.is_floating_base()
+        model_data.position =initial_base_pose.tolist()
+        model_data.orientation = initial_base_orientation.tolist()
 
         if self._base_frame is not None:
             model_data.setBaseLink(self._base_frame)
 
         # Initialize robot controller plugin
         plugin_data = bindings.PluginData()
-        plugin_data.setLibName("RobotController")
-        plugin_data.setClassName("gympp::plugins::RobotController")
+        plugin_data.libName = "RobotController"
+        plugin_data.className = "gympp::plugins::RobotController"
 
         # Insert the model
         ok_model = self._gazebo.insertModel(model_data, plugin_data)

--- a/gym_ignition/robots/sim/gazebo/cartpole.py
+++ b/gym_ignition/robots/sim/gazebo/cartpole.py
@@ -20,10 +20,6 @@ class CartPoleGazeboRobot(gazebo_robot.GazeboRobot):
                          gazebo=gazebo,
                          controller_rate=kwargs.get("controller_rate"))
 
-        # Configure the cartpole as fixed-base robot
-        ok_floating = self.set_as_floating_base(False)
-        assert ok_floating, "Failed to set the robot as fixed base"
-
         # Initial base position
         base_position = np.array([0., 0., 0.]) \
             if "base_position" not in kwargs else kwargs["base_position"]

--- a/gym_ignition/robots/sim/gazebo/panda.py
+++ b/gym_ignition/robots/sim/gazebo/panda.py
@@ -20,9 +20,6 @@ class PandaRobot(gazebo_robot.GazeboRobot):
                          gazebo=gazebo,
                          controller_rate=kwargs.get("controller_rate"))
 
-        ok_floating = self.set_as_floating_base(False)
-        assert ok_floating, "Failed to set the robot as fixed base"
-
         base_position = np.array([0., 0., 0.]) \
             if "base_position" not in kwargs else kwargs["base_position"]
 

--- a/ignition/include/gympp/gazebo/GazeboWrapper.h
+++ b/ignition/include/gympp/gazebo/GazeboWrapper.h
@@ -45,22 +45,12 @@ struct gympp::gazebo::ModelInitData
     std::string modelName = "";
     std::array<double, 3> position = {0, 0, 0};
     std::array<double, 4> orientation = {1, 0, 0, 0};
-
-    inline void setFixedPose(const bool f) { fixedPose = f; }
-    inline void setBaseLink(const std::string& b) { baseLink = b; }
-    inline void setSdfString(const std::string& s) { sdfString = s; }
-    inline void setModelName(const std::string& m) { modelName = m; }
-    inline void setPosition(const std::array<double, 3> p) { position = p; }
-    inline void setOrientation(const std::array<double, 4> o) { orientation = o; }
 };
 
 struct gympp::gazebo::PluginData
 {
     std::string libName;
     std::string className;
-
-    inline void setLibName(const std::string& l) { libName = l; }
-    inline void setClassName(const std::string& c) { className = c; }
 };
 
 class gympp::gazebo::GazeboWrapper

--- a/tests/python/test_environments_gympp.py
+++ b/tests/python/test_environments_gympp.py
@@ -13,6 +13,8 @@ def test_create_cpp_environment():
     env = gym.make("CartPoleDiscrete-Gympp-v0")
     assert env, "Failed to create 'CartPoleDiscrete-Gympp-v0' environment"
 
+    env.seed(42)
+
     action = env.action_space.sample()
     assert isinstance(action, int), "The sampled action is empty"
 

--- a/tests/python/test_robot_controller.py
+++ b/tests/python/test_robot_controller.py
@@ -18,8 +18,8 @@ def test_joint_controller():
     controller_rate = 500.0
 
     plugin_data = bindings.PluginData()
-    plugin_data.setLibName("RobotController")
-    plugin_data.setClassName("gympp::plugins::RobotController")
+    plugin_data.libName = "RobotController"
+    plugin_data.className = "gympp::plugins::RobotController"
 
     # Find and load the model SDF file
     model_sdf_file = resource_finder.find_resource("CartPole/CartPole.urdf")
@@ -28,7 +28,7 @@ def test_joint_controller():
 
     # Initialize the model data
     model_data = bindings.ModelInitData()
-    model_data.setSdfString(model_sdf_string)
+    model_data.sdfString = model_sdf_string
 
     # Get the model name
     model_name = bindings.GazeboWrapper.getModelNameFromSDF(model_sdf_string)


### PR DESCRIPTION
If the model is already anchored to the world (as the panda manipulator and the cartpole), setting the robot as fixed-base in Python will create another joint to fix the robot to the world, generating the following `ign-physics` error:

```
[Err] [SDFFeatures.cc:710] Asked to create a joint between links
```