### PR TITLE
Custom controllers: base interfaces, plugins, and fixed-base Computed Torque example

### DIFF
--- a/cpp/scenario/controllers/CMakeLists.txt
+++ b/cpp/scenario/controllers/CMakeLists.txt
@@ -42,12 +42,42 @@ target_include_directories(Controller INTERFACE
 
 set_target_properties(Controller PROPERTIES PUBLIC_HEADER "${CONTROLLER_HDRS}")
 
+# =======================
+# ComputedTorqueFixedBase
+# =======================
 
+add_library(ComputedTorqueFixedBase
+    include/scenario/controllers/ComputedTorqueFixedBase.h
+    src/ComputedTorqueFixedBase.cpp)
+
+target_link_libraries(ComputedTorqueFixedBase
+    PUBLIC
+    Controller
+    PRIVATE
+    ScenarioGazebo
+    Eigen3::Eigen
+    ignition-gazebo3::core
+    iDynTree::idyntree-core
+    iDynTree::idyntree-model
+    iDynTree::idyntree-modelio-urdf
+    iDynTree::idyntree-high-level)
+
+target_include_directories(ComputedTorqueFixedBase PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+set_target_properties(ComputedTorqueFixedBase PROPERTIES
+    PUBLIC_HEADER include/scenario/controllers/ComputedTorqueFixedBase.h)
+
+# ===================
+# Install the targets
+# ===================
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL "PyPI")
     install(
         TARGETS
         Controller
+        ComputedTorqueFixedBase
         EXPORT scenario
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/cpp/scenario/controllers/CMakeLists.txt
+++ b/cpp/scenario/controllers/CMakeLists.txt
@@ -1,0 +1,56 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#
+#  This project is dual licensed under LGPL v2.1+ or Apache License.
+#
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+#
+#  This software may be modified and distributed under the terms of the
+#  GNU Lesser General Public License v2.1 or any later version.
+#
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+find_package(iDynTree REQUIRED)
+find_package (Eigen3 3.3 REQUIRED NO_MODULE)
+
+# ==========
+# Controller
+# ==========
+
+set(CONTROLLER_HDRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/scenario/controllers/Controller.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/scenario/controllers/References.h)
+
+add_library(Controller INTERFACE)
+target_sources(Controller INTERFACE ${CONTROLLER_HDRS})
+
+target_include_directories(Controller INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+set_target_properties(Controller PROPERTIES PUBLIC_HEADER "${CONTROLLER_HDRS}")
+
+
+
+if(NOT CMAKE_BUILD_TYPE STREQUAL "PyPI")
+    install(
+        TARGETS
+        Controller
+        EXPORT scenario
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/scenario/controllers)
+endif()

--- a/cpp/scenario/controllers/include/scenario/controllers/ComputedTorqueFixedBase.h
+++ b/cpp/scenario/controllers/include/scenario/controllers/ComputedTorqueFixedBase.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This project is dual licensed under LGPL v2.1+ or Apache License.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SCENARIO_CONTROLLERS_COMPUTEDTORQUEFIXEDBASE_H
+#define SCENARIO_CONTROLLERS_COMPUTEDTORQUEFIXEDBASE_H
+
+#include "scenario/controllers/Controller.h"
+#include "scenario/controllers/References.h"
+
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace scenario {
+    namespace gazebo {
+        class Model;
+    } // namespace gazebo
+    namespace controllers {
+        class ControllersFactory;
+        class ComputedTorqueFixedBase;
+    } // namespace controllers
+} // namespace scenario
+
+class scenario::controllers::ComputedTorqueFixedBase final
+    : public scenario::controllers::Controller
+    , public scenario::controllers::UseScenarioModel
+    , public scenario::controllers::SetJointReferences
+{
+public:
+    ComputedTorqueFixedBase() = delete;
+    ComputedTorqueFixedBase(const std::string& urdfFile,
+                            std::shared_ptr<gazebo::Model> model,
+                            const std::vector<double>& kp,
+                            const std::vector<double>& kd,
+                            const std::vector<std::string>& controlledJoints,
+                            const std::array<double, 3> gravity = g);
+    ~ComputedTorqueFixedBase() override;
+
+    bool initialize() override;
+    bool step(const StepSize& dt) override;
+    bool terminate() override;
+
+    bool updateStateFromModel() override;
+
+    const std::vector<std::string>& controlledJoints() override;
+    bool setJointReferences(const JointReferences& jointReferences) override;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> pImpl;
+};
+
+#endif // SCENARIO_CONTROLLERS_COMPUTEDTORQUEFIXEDBASE_H

--- a/cpp/scenario/controllers/include/scenario/controllers/Controller.h
+++ b/cpp/scenario/controllers/include/scenario/controllers/Controller.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This project is dual licensed under LGPL v2.1+ or Apache License.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SCENARIO_CONTROLLERS_CONTROLLER_H
+#define SCENARIO_CONTROLLERS_CONTROLLER_H
+
+#include "scenario/controllers/References.h"
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace scenario {
+    namespace controllers {
+        class Controller;
+        class UseScenarioModel;
+        class SetBaseReferences;
+        class SetJointReferences;
+        using ControllerPtr = std::shared_ptr<Controller>;
+        constexpr std::array<double, 3> g = {0, 0, -9.80665};
+    } // namespace controllers
+    namespace gazebo {
+        class Model;
+        using ModelPtr = std::shared_ptr<Model>;
+    } // namespace gazebo
+} // namespace scenario
+
+class scenario::controllers::Controller
+    : public std::enable_shared_from_this<scenario::controllers::Controller>
+{
+public:
+    using StepSize = std::chrono::duration<double>;
+
+    Controller() = default;
+    virtual ~Controller() = default;
+
+    virtual bool initialize() = 0;
+    virtual bool step(const StepSize& dt) = 0;
+    virtual bool terminate() = 0;
+};
+
+class scenario::controllers::UseScenarioModel
+{
+public:
+    UseScenarioModel() = default;
+    virtual ~UseScenarioModel() = default;
+
+    virtual bool updateStateFromModel() = 0;
+
+protected:
+    gazebo::ModelPtr m_model;
+};
+
+class scenario::controllers::SetBaseReferences
+{
+public:
+    SetBaseReferences() = default;
+    virtual ~SetBaseReferences() = default;
+
+    virtual bool setBaseReferences(const BaseReferences& jointReferences) = 0;
+};
+
+class scenario::controllers::SetJointReferences
+{
+public:
+    SetJointReferences() = default;
+    virtual ~SetJointReferences() = default;
+
+    virtual const std::vector<std::string>& controlledJoints() = 0;
+    virtual bool setJointReferences(const JointReferences& jointReferences) = 0;
+
+protected:
+    std::vector<std::string> m_controlledJoints;
+};
+
+#endif // SCENARIO_CONTROLLERS_CONTROLLER_H

--- a/cpp/scenario/controllers/include/scenario/controllers/References.h
+++ b/cpp/scenario/controllers/include/scenario/controllers/References.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This project is dual licensed under LGPL v2.1+ or Apache License.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SCENARIO_CONTROLLERS_REFERENCES_H
+#define SCENARIO_CONTROLLERS_REFERENCES_H
+
+#include <array>
+#include <vector>
+
+namespace scenario {
+    namespace controllers {
+        struct BaseReferences;
+        struct JointReferences;
+    } // namespace controllers
+} // namespace scenario
+
+struct scenario::controllers::BaseReferences
+{
+    std::array<double, 3> position = {0, 0, 0};
+    std::array<double, 4> orientation = {1, 0, 0, 0};
+    std::array<double, 3> linearVelocity = {0, 0, 0};
+    std::array<double, 3> angularVelocity = {0, 0, 0};
+    std::array<double, 3> linearAcceleration = {0, 0, 0};
+    std::array<double, 3> angularAcceleration = {0, 0, 0};
+};
+
+struct scenario::controllers::JointReferences
+{
+    JointReferences(const size_t controlledDofs = 0)
+    {
+        position = std::vector<double>(controlledDofs, 0.0);
+        velocity = std::vector<double>(controlledDofs, 0.0);
+        acceleration = std::vector<double>(controlledDofs, 0.0);
+    }
+
+    inline bool valid() const
+    {
+        size_t dofs = position.size();
+        return dofs > 0 && velocity.size() == dofs
+               && acceleration.size() == dofs;
+    }
+
+    std::vector<double> position;
+    std::vector<double> velocity;
+    std::vector<double> acceleration;
+};
+
+#endif // SCENARIO_CONTROLLERS_REFERENCES_H

--- a/cpp/scenario/controllers/src/ComputedTorqueFixedBase.cpp
+++ b/cpp/scenario/controllers/src/ComputedTorqueFixedBase.cpp
@@ -1,0 +1,362 @@
+/*
+ * Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This project is dual licensed under LGPL v2.1+ or Apache License.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "scenario/controllers/ComputedTorqueFixedBase.h"
+#include "scenario/controllers/References.h"
+#include "scenario/gazebo/Joint.h"
+#include "scenario/gazebo/Log.h"
+#include "scenario/gazebo/Model.h"
+
+#include <Eigen/Dense>
+#include <iDynTree/Core/EigenHelpers.h>
+#include <iDynTree/Core/MatrixDynSize.h>
+#include <iDynTree/Core/VectorDynSize.h>
+#include <iDynTree/Core/VectorFixSize.h>
+#include <iDynTree/KinDynComputations.h>
+#include <iDynTree/Model/FreeFloatingState.h>
+#include <iDynTree/ModelIO/ModelLoader.h>
+
+#include <cassert>
+#include <unordered_map>
+
+using namespace scenario::controllers;
+
+class ComputedTorqueFixedBase::Impl
+{
+public:
+    class Buffers;
+
+    std::string urdfFile;
+
+    struct
+    {
+        std::vector<double> kp;
+        std::vector<double> kd;
+        std::array<double, 3> gravity;
+        std::unordered_map<std::string, base::JointControlMode> controlMode;
+    } initialValues;
+
+    JointReferences jointReferences;
+    std::unique_ptr<Buffers> buffers;
+    std::unique_ptr<iDynTree::KinDynComputations> kinDyn;
+
+    static Eigen::Map<Eigen::VectorXd> toEigen(std::vector<double>& vector)
+    {
+        return {vector.data(), Eigen::Index(vector.size())};
+    }
+};
+
+class ComputedTorqueFixedBase::Impl::Buffers
+{
+public:
+    Buffers(const unsigned controlledDofs = 0)
+    {
+        jointPositions.resize(controlledDofs);
+        jointVelocities.resize(controlledDofs);
+        massMatrix.resize(controlledDofs + 6, controlledDofs + 6);
+
+        kp = Eigen::ArrayXd(controlledDofs);
+        kd = Eigen::ArrayXd(controlledDofs);
+
+        torques = Eigen::VectorXd(controlledDofs);
+        dds_star = Eigen::VectorXd(controlledDofs);
+        positionError = Eigen::VectorXd(controlledDofs);
+        velocityError = Eigen::VectorXd(controlledDofs);
+
+        torquesVector.reserve(controlledDofs);
+    }
+
+    iDynTree::Vector3 gravity = {g.data(), 3};
+    iDynTree::MatrixDynSize massMatrix;
+    iDynTree::VectorDynSize jointPositions;
+    iDynTree::VectorDynSize jointVelocities;
+    iDynTree::FreeFloatingGeneralizedTorques biasForces;
+
+    Eigen::ArrayXd kp;
+    Eigen::ArrayXd kd;
+
+    Eigen::VectorXd torques;
+    Eigen::VectorXd dds_star;
+    Eigen::VectorXd positionError;
+    Eigen::VectorXd velocityError;
+
+    std::vector<double> torquesVector;
+};
+
+ComputedTorqueFixedBase::ComputedTorqueFixedBase(
+    const std::string& urdfFile,
+    std::shared_ptr<gazebo::Model> model,
+    const std::vector<double>& kp,
+    const std::vector<double>& kd,
+    const std::vector<std::string>& controlledJoints,
+    const std::array<double, 3> gravity)
+    : Controller()
+    , UseScenarioModel()
+    , SetJointReferences()
+    , pImpl{std::make_unique<Impl>()}
+{
+    m_model = model;
+    pImpl->urdfFile = urdfFile;
+    m_controlledJoints = controlledJoints;
+    assert(m_model->dofs() == controlledJoints.size()
+           || controlledJoints.empty());
+
+    pImpl->initialValues.gravity = gravity;
+
+    pImpl->initialValues.kp = kp;
+    pImpl->initialValues.kd = kd;
+    assert(m_model->dofs() == kp.size());
+    assert(kp.size() == kd.size());
+}
+
+ComputedTorqueFixedBase::~ComputedTorqueFixedBase() {}
+
+bool ComputedTorqueFixedBase::initialize()
+{
+    gymppDebug << "Initializing ComputedTorqueFixedBaseCpp" << std::endl;
+
+    if (pImpl->kinDyn) {
+        gymppWarning
+            << "The KinDynComputations object has been already initialized"
+            << std::endl;
+        return true;
+    }
+
+    if (!(m_model && m_model->valid())) {
+        gymppError << "Couldn't initialize controller. Model not valid."
+                   << std::endl;
+        return false;
+    }
+
+    if (m_controlledJoints.size() != m_model->dofs()
+        || m_controlledJoints.empty()) {
+        gymppError << "The list of controlled joints is not valid" << std::endl;
+        return false;
+    }
+
+    if (m_controlledJoints.empty()) {
+        gymppDebug << "No list of controlled joints. Controlling all the "
+                      "robots joints."
+                   << std::endl;
+
+        // Read the joint names from the robot object.
+        // This is useful to use the same joint serialization in the vectorized
+        // methods.
+        m_controlledJoints = m_model->jointNames();
+    }
+
+    for (auto& joint : m_model->joints(m_controlledJoints)) {
+        if (joint->dofs() != 1) {
+            gymppError << "Joint '" << joint->name()
+                       << "' does not have 1 DoF and is not supported"
+                       << std::endl;
+            return false;
+        }
+    }
+
+    iDynTree::ModelLoader loader;
+    if (!loader.loadReducedModelFromFile(pImpl->urdfFile, m_controlledJoints)) {
+        gymppError << "Failed to load reduced model from the urdf file"
+                   << std::endl;
+        return false;
+    }
+
+    pImpl->kinDyn = std::make_unique<iDynTree::KinDynComputations>();
+    pImpl->kinDyn->setFrameVelocityRepresentation(
+        iDynTree::MIXED_REPRESENTATION);
+
+    if (!pImpl->kinDyn->loadRobotModel(loader.model())) {
+        gymppError << "Failed to insert model in the KinDynComputations object"
+                   << std::endl;
+        return false;
+    }
+
+    // Set controlled joints in torque control mode
+    for (auto& joint : m_model->joints(m_controlledJoints)) {
+        pImpl->initialValues.controlMode[joint->name()] = joint->controlMode();
+
+        if (!joint->setControlMode(base::JointControlMode::Force)) {
+            gymppError << "Failed to control joint '" << joint->name()
+                       << "' in Force" << std::endl;
+            return false;
+        }
+    }
+
+    // Initialize buffers
+    gymppDebug << "Controlling " << m_controlledJoints.size() << " DoFs"
+               << std::endl;
+    pImpl->buffers = std::make_unique<Impl::Buffers>(m_controlledJoints.size());
+
+    pImpl->buffers->kp = Impl::toEigen(pImpl->initialValues.kp);
+    pImpl->buffers->kd = Impl::toEigen(pImpl->initialValues.kd);
+    pImpl->buffers->biasForces.resize(loader.model());
+
+    // Set the gravity
+    pImpl->buffers->gravity[0] = pImpl->initialValues.gravity[0];
+    pImpl->buffers->gravity[1] = pImpl->initialValues.gravity[1];
+    pImpl->buffers->gravity[2] = pImpl->initialValues.gravity[2];
+
+    return true;
+}
+
+bool ComputedTorqueFixedBase::step(const Controller::StepSize& /*dt*/)
+{
+    // ===================
+    // Intermediate Values
+    // ===================
+
+    const auto nrControlledDofs = pImpl->buffers->jointPositions.size();
+
+    auto Mfloating = iDynTree::toEigen(pImpl->buffers->massMatrix);
+
+    auto h = iDynTree::toEigen(pImpl->buffers->biasForces.jointTorques());
+    auto M = Mfloating.bottomRightCorner(nrControlledDofs, nrControlledDofs);
+    assert(h.size() == nrControlledDofs);
+    assert(M.size() == nrControlledDofs * nrControlledDofs);
+
+    auto s = iDynTree::toEigen(pImpl->buffers->jointPositions);
+    auto ds = iDynTree::toEigen(pImpl->buffers->jointVelocities);
+    assert(s.size() == nrControlledDofs);
+    assert(ds.size() == nrControlledDofs);
+
+    auto s_ref = Impl::toEigen(pImpl->jointReferences.position);
+    auto ds_ref = Impl::toEigen(pImpl->jointReferences.velocity);
+    auto dds_ref = Impl::toEigen(pImpl->jointReferences.acceleration);
+    assert(s_ref.size() == nrControlledDofs);
+    assert(ds_ref.size() == nrControlledDofs);
+    assert(dds_ref.size() == nrControlledDofs);
+
+    auto& kp = pImpl->buffers->kp;
+    auto& kd = pImpl->buffers->kd;
+    auto& s_tilde = pImpl->buffers->positionError;
+    auto& ds_tilde = pImpl->buffers->velocityError;
+    assert(kp.size() == nrControlledDofs);
+    assert(kd.size() == nrControlledDofs);
+    assert(s_tilde.size() == nrControlledDofs);
+    assert(ds_tilde.size() == nrControlledDofs);
+
+    auto& tau = pImpl->buffers->torques;
+    auto& dds_star = pImpl->buffers->dds_star;
+    assert(tau.size() == nrControlledDofs);
+    assert(dds_star.size() == nrControlledDofs);
+
+    // ===========
+    // Control Law
+    // ===========
+
+    // Compute errors
+    s_tilde = s - s_ref;
+    ds_tilde = ds - ds_ref;
+
+    // Compute the acceleration
+    dds_star = dds_ref.array() - kp * s_tilde.array() - kd * ds_tilde.array();
+
+    // Compute the torque
+    tau = M * dds_star + h;
+
+    pImpl->buffers->torquesVector = std::vector<double>(
+        pImpl->buffers->torques.data(),
+        pImpl->buffers->torques.data() + pImpl->buffers->torques.size());
+
+    if (!m_model->setJointGeneralizedForceTargets(pImpl->buffers->torquesVector,
+                                                  m_controlledJoints)) {
+        gymppError << "Failed to set joint forces" << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+bool ComputedTorqueFixedBase::terminate()
+{
+    bool ok = true;
+
+    for (const auto& [jointName, controlMode] :
+         pImpl->initialValues.controlMode) {
+
+        auto joint = m_model->getJoint(jointName);
+
+        if (!joint->setControlMode(controlMode)) {
+            gymppError << "Failed to restore original control mode of joint '"
+                       << jointName << "'" << std::endl;
+            ok = ok && false;
+        }
+    }
+
+    pImpl->kinDyn.reset();
+    pImpl->buffers.reset();
+    return ok;
+}
+
+bool ComputedTorqueFixedBase::updateStateFromModel()
+{
+    assert(m_model->jointPositions(m_controlledJoints).size()
+           == pImpl->buffers->jointPositions.size());
+    assert(m_model->jointVelocities(m_controlledJoints).size()
+           == pImpl->buffers->jointVelocities.size());
+
+    for (unsigned i = 0; i < m_controlledJoints.size(); ++i) {
+        // Get the joint
+        const auto& jointName = m_controlledJoints[i];
+        auto joint = m_model->getJoint(jointName);
+        assert(joint->dofs() == 1);
+
+        // Update the buffers
+        pImpl->buffers->jointPositions.setVal(i, joint->position());
+        pImpl->buffers->jointVelocities.setVal(i, joint->velocity());
+    }
+
+    if (!pImpl->kinDyn->setRobotState(pImpl->buffers->jointPositions,
+                                      pImpl->buffers->jointVelocities,
+                                      pImpl->buffers->gravity)) {
+        gymppError << "Failed to set the robot state" << std::endl;
+        return false;
+    }
+
+    if (!pImpl->kinDyn->getFreeFloatingMassMatrix(pImpl->buffers->massMatrix)) {
+        gymppError << "Failed to get the mass matrix" << std::endl;
+        return false;
+    }
+
+    if (!pImpl->kinDyn->generalizedBiasForces(pImpl->buffers->biasForces)) {
+        gymppError << "Failed to get the bias forces " << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+const std::vector<std::string>& ComputedTorqueFixedBase::controlledJoints()
+{
+    return m_controlledJoints;
+}
+
+bool ComputedTorqueFixedBase::setJointReferences(
+    const JointReferences& jointReferences)
+{
+    pImpl->jointReferences = jointReferences;
+    return pImpl->jointReferences.valid();
+};

--- a/cpp/scenario/plugins/CMakeLists.txt
+++ b/cpp/scenario/plugins/CMakeLists.txt
@@ -25,3 +25,4 @@
 add_subdirectory(Physics)
 add_subdirectory(ECMProvider)
 add_subdirectory(JointController)
+add_subdirectory(ControllerRunner)

--- a/cpp/scenario/plugins/ControllerRunner/CMakeLists.txt
+++ b/cpp/scenario/plugins/ControllerRunner/CMakeLists.txt
@@ -1,0 +1,72 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#
+#  This project is dual licensed under LGPL v2.1+ or Apache License.
+#
+# -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -
+#
+#  This software may be modified and distributed under the terms of the
+#  GNU Lesser General Public License v2.1 or any later version.
+#
+# -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ==================
+# ControllersFactory
+# ==================
+
+add_library(ControllersFactory STATIC
+    ControllersFactory.h
+    ControllersFactory.cpp)
+
+target_link_libraries(ControllersFactory
+    PUBLIC
+    Controller
+    PRIVATE
+    ScenarioGazebo
+    ignition-gazebo3::core
+    ComputedTorqueFixedBase)
+
+target_include_directories(ControllersFactory PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+
+# ================
+# ControllerRunner
+# ================
+
+add_library(ControllerRunner SHARED
+    ControllerRunner.h
+    ControllerRunner.cpp)
+
+target_link_libraries(ControllerRunner
+    PUBLIC
+    ignition-gazebo3::core
+    PRIVATE
+    Controller
+    ScenarioGazebo
+    ExtraComponents
+    ControllersFactory)
+
+target_include_directories(ControllerRunner PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+
+if(NOT CMAKE_BUILD_TYPE STREQUAL "PyPI")
+    install(
+        TARGETS
+        ControllerRunner
+        EXPORT scenario
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/scenario/plugins
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/scenario/plugins
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/scenario/plugins)
+endif()

--- a/cpp/scenario/plugins/ControllerRunner/ControllerRunner.cpp
+++ b/cpp/scenario/plugins/ControllerRunner/ControllerRunner.cpp
@@ -1,0 +1,388 @@
+/*
+ * Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This project is dual licensed under LGPL v2.1+ or Apache License.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ControllerRunner.h"
+#include "ControllersFactory.h"
+#include "scenario/controllers/Controller.h"
+#include "scenario/controllers/References.h"
+#include "scenario/gazebo/Link.h"
+#include "scenario/gazebo/Log.h"
+#include "scenario/gazebo/Model.h"
+#include "scenario/gazebo/components/BasePoseTarget.h"
+#include "scenario/gazebo/components/BaseWorldAccelerationTarget.h"
+#include "scenario/gazebo/components/BaseWorldVelocityTarget.h"
+#include "scenario/gazebo/exceptions.h"
+#include "scenario/gazebo/helpers.h"
+
+#include <ignition/math/Helpers.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Vector3.hh>
+#include <ignition/plugin/Register.hh>
+#include <sdf/Element.hh>
+
+#include <array>
+#include <cassert>
+#include <chrono>
+#include <limits>
+#include <ratio>
+#include <string>
+#include <vector>
+
+using namespace scenario::gazebo;
+using namespace scenario::plugins::gazebo;
+
+class ControllerRunner::Impl
+{
+public:
+    bool referencesHaveBeenSet = false;
+
+    scenario::gazebo::ModelPtr model;
+    ignition::gazebo::Entity modelEntity;
+    std::chrono::steady_clock::duration prevUpdateTime{0};
+
+    std::shared_ptr<controllers::Controller> controller;
+
+    controllers::BaseReferences baseReferences;
+    controllers::JointReferences jointReferences;
+
+    struct
+    {
+        controllers::SetBaseReferences* base = nullptr;
+        controllers::UseScenarioModel* useModel = nullptr;
+        controllers::SetJointReferences* joints = nullptr;
+    } controllerInterfaces;
+
+    bool
+    updateAllSupportedReferences(ignition::gazebo::EntityComponentManager& ecm);
+
+    bool
+    updateBaseReferencesfromECM(ignition::gazebo::EntityComponentManager& ecm);
+
+    bool
+    updateJointReferencesfromECM(ignition::gazebo::EntityComponentManager& ecm);
+
+    void printControllerContext(
+        const std::shared_ptr<const sdf::Element> context) const;
+};
+
+ControllerRunner::ControllerRunner()
+    : System()
+    , pImpl{std::make_unique<Impl>()}
+{}
+
+// NOTE: we should terminate the controller here, but plugins are not
+//       unloaded when the model is removed.
+//       All model plugins are deleted when the simulator is destroyed,
+//       and there's no more ECM -> we would get segfault.
+ControllerRunner::~ControllerRunner() = default;
+
+void ControllerRunner::Configure(const ignition::gazebo::Entity& entity,
+                                 const std::shared_ptr<const sdf::Element>& sdf,
+                                 ignition::gazebo::EntityComponentManager& ecm,
+                                 ignition::gazebo::EventManager& eventMgr)
+{
+
+    // Store the model entity
+    pImpl->modelEntity = entity;
+
+    // Create a model that will be given to the controller
+    pImpl->model = std::make_shared<Model>();
+
+    if (!pImpl->model->initialize(entity, &ecm, &eventMgr)) {
+        gymppError << "Failed to initialize model for controller" << std::endl;
+        return;
+    }
+
+    if (!pImpl->model->valid()) {
+        gymppError << "Failed to create a model from Entity [" << entity << "]"
+                   << std::endl;
+        return;
+    }
+
+    if (sdf->GetName() != "plugin") {
+        gymppError << "Received context does not contain the <plugin> element"
+                   << std::endl;
+        return;
+    }
+
+    // This is the <plugin> element (with extra options stored in its children)
+    sdf::ElementPtr pluginElement = sdf->Clone();
+
+    // Initialize the controller context
+    sdf::ElementPtr controllerContext;
+
+    // Check if it contains extra options stored in a <controller> child
+    if (pluginElement->HasElement("controller")) {
+        // Store the <controller> element
+        controllerContext = pluginElement->GetElement("controller");
+
+        if (utils::verboseFromEnvironment()) {
+            pImpl->printControllerContext(pluginElement);
+        }
+    }
+
+    pImpl->controller =
+        ControllersFactory::Instance().get(controllerContext, pImpl->model);
+
+    if (!pImpl->controller) {
+        gymppError << "Failed to find controller in the factory" << std::endl;
+        return;
+    }
+
+    if (!pImpl->controller->initialize()) {
+        gymppError << "Failed to initialize the controller" << std::endl;
+        pImpl->controller = nullptr;
+        return;
+    }
+
+    pImpl->controllerInterfaces.useModel = dynamic_cast< //
+        controllers::UseScenarioModel*>(pImpl->controller.get());
+
+    pImpl->controllerInterfaces.base = dynamic_cast< //
+        controllers::SetBaseReferences*>(pImpl->controller.get());
+
+    pImpl->controllerInterfaces.joints = dynamic_cast< //
+        controllers::SetJointReferences*>(pImpl->controller.get());
+
+    // Controller classes could inherit from various interfaces that specify the
+    // accepted references. This design allows developing generic controllers.
+    // Here we check if the controller inherits from the supported interfaces.
+    if (!(pImpl->controllerInterfaces.base
+          || pImpl->controllerInterfaces.joints)) {
+        gymppWarning << "Failed to find any of the supported interfaces to set "
+                     << "controller references" << std::endl;
+        return;
+    }
+
+    gymppDebug << "Controller successfully initialized" << std::endl;
+}
+
+void ControllerRunner::PreUpdate(const ignition::gazebo::UpdateInfo& info,
+                                 ignition::gazebo::EntityComponentManager& ecm)
+{
+    if (info.paused) {
+        return;
+    }
+
+    if (!pImpl->controller) {
+        gymppError << "The controller was not initialized successfully"
+                   << std::endl;
+        return;
+    }
+
+    using namespace std::chrono;
+
+    // Update the controller only if enough time is passed
+    duration<double> elapsedFromLastUpdate =
+        info.simTime - pImpl->prevUpdateTime;
+    assert(elapsedFromLastUpdate.count() > 0);
+
+    // Handle first iteration
+    if (pImpl->prevUpdateTime.count() == 0) {
+        elapsedFromLastUpdate =
+            duration<double>(pImpl->model->controllerPeriod());
+    }
+
+    // If enough time has passed, store the time of this actuation step. In this
+    // case the state of the robot is read and new force references are computed
+    // and actuated. Otherwise, the same force of the last step is actuated.
+    bool computeNewForce;
+
+    // Due to numerical floating point approximations, sometimes a comparison of
+    // chrono durations has an error in the 1e-18 order
+    auto greaterThan = [](const duration<double>& a,
+                          const duration<double>& b) -> bool {
+        return a.count() >= b.count() - std::numeric_limits<double>::epsilon();
+    };
+
+    if (greaterThan(elapsedFromLastUpdate,
+                    duration<double>(pImpl->model->controllerPeriod()))) {
+        // Store the current update time
+        pImpl->prevUpdateTime = info.simTime;
+
+        // Enable using the controller to compute the new force
+        computeNewForce = true;
+    }
+    else {
+        // Disable the controller and send the same force reference as last
+        // update
+        computeNewForce = false;
+    }
+
+    // Get and set the new references
+    if (computeNewForce) {
+
+        try {
+            if (!pImpl->updateAllSupportedReferences(ecm)) {
+                gymppError << "Failed to update supported references"
+                           << std::endl;
+                return;
+            }
+        }
+        catch (const exceptions::ComponentNotFound& e) {
+            gymppDebug << "Controller references not yet available"
+                       << std::endl;
+            gymppDebug << e.what();
+            gymppWarning << "[t="
+                         << utils::steadyClockDurationToDouble(info.simTime)
+                         << "] The controller is not stepping" << std::endl;
+            return;
+        }
+
+        if (pImpl->controllerInterfaces.useModel
+            && !pImpl->controllerInterfaces.useModel->updateStateFromModel()) {
+            gymppError
+                << "Failed to update controller state from internal model"
+                << std::endl;
+            return;
+        }
+
+        // The controller is stepped only when the references have been set
+        // at least once
+        pImpl->referencesHaveBeenSet = true;
+    }
+
+    // Step the controller
+    if (pImpl->referencesHaveBeenSet && !pImpl->controller->step(info.dt)) {
+        gymppError << "Failed to step the controller" << std::endl;
+        return;
+    }
+}
+
+bool ControllerRunner::Impl::updateAllSupportedReferences(
+    ignition::gazebo::EntityComponentManager& ecm)
+{
+    bool ok = true;
+
+    if (controllerInterfaces.base) {
+        if (!updateBaseReferencesfromECM(ecm)) {
+            gymppError << "Failed to update base references" << std::endl;
+            ok = false;
+        }
+        else {
+            if (!controllerInterfaces.base->setBaseReferences(baseReferences)) {
+                gymppError << "Failed to set base references" << std::endl;
+                ok = false;
+            }
+        }
+    }
+
+    if (controllerInterfaces.joints) {
+        if (!updateJointReferencesfromECM(ecm)) {
+            gymppError << "Failed to update joint references" << std::endl;
+            ok = false;
+        }
+        else {
+            if (!controllerInterfaces.joints->setJointReferences(
+                    jointReferences)) {
+                gymppError << "Failed to set joint references" << std::endl;
+                ok = false;
+            }
+        }
+    }
+
+    return ok;
+}
+
+bool ControllerRunner::Impl::updateBaseReferencesfromECM(
+    ignition::gazebo::EntityComponentManager& ecm)
+{
+    assert(controllerInterfaces.base);
+    using namespace ignition::math;
+    using namespace ignition::gazebo;
+
+    // =========
+    // Base Pose
+    // =========
+
+    Pose3d& basePoseTarget = utils::getExistingComponentData< //
+        components::BasePoseTarget>(&ecm, modelEntity);
+
+    base::Pose basePose = utils::fromIgnitionPose(basePoseTarget);
+    baseReferences.position = basePose.position;
+    baseReferences.orientation = basePose.orientation;
+
+    // =============
+    // Base Velocity
+    // =============
+
+    Vector3d baseLinearVelocityTarget = utils::getExistingComponentData< //
+        components::BaseWorldLinearVelocityTarget>(&ecm, modelEntity);
+
+    Vector3d baseAngularVelocityTarget = utils::getExistingComponentData< //
+
+        components::BaseWorldAngularVelocityTarget>(&ecm, modelEntity);
+
+    baseReferences.linearVelocity =
+        utils::fromIgnitionVector(baseLinearVelocityTarget);
+    baseReferences.angularVelocity =
+        utils::fromIgnitionVector(baseAngularVelocityTarget);
+
+    // =================
+    // Base Acceleration
+    // =================
+
+    Vector3d baseLinearAccelerationTarget = utils::getExistingComponentData< //
+        components::BaseWorldLinearAccelerationTarget>(&ecm, modelEntity);
+
+    Vector3d baseAngularAccelerationTarget = utils::getExistingComponentData< //
+        components::BaseWorldAngularAccelerationTarget>(&ecm, modelEntity);
+
+    baseReferences.linearAcceleration =
+        utils::fromIgnitionVector(baseLinearAccelerationTarget);
+    baseReferences.angularAcceleration =
+        utils::fromIgnitionVector(baseAngularAccelerationTarget);
+
+    return true;
+}
+
+bool ControllerRunner::Impl::updateJointReferencesfromECM(
+    ignition::gazebo::EntityComponentManager& /*ecm*/)
+{
+    assert(controllerInterfaces.joints);
+
+    auto& controlledJoints = controllerInterfaces.joints->controlledJoints();
+
+    jointReferences.position = model->jointPositionTargets(controlledJoints);
+    jointReferences.velocity = model->jointVelocityTargets(controlledJoints);
+    jointReferences.acceleration =
+        model->jointAccelerationTargets(controlledJoints);
+
+    return true;
+}
+
+void ControllerRunner::Impl::printControllerContext(
+    const std::shared_ptr<const sdf::Element> context) const
+{
+    gymppDebug << "SDF elements received by the controller:" << std::endl;
+    std::cout << context->ToString("") << std::endl;
+}
+
+IGNITION_ADD_PLUGIN(
+    scenario::plugins::gazebo::ControllerRunner,
+    scenario::plugins::gazebo::ControllerRunner::System,
+    scenario::plugins::gazebo::ControllerRunner::ISystemConfigure,
+    scenario::plugins::gazebo::ControllerRunner::ISystemPreUpdate)

--- a/cpp/scenario/plugins/ControllerRunner/ControllerRunner.h
+++ b/cpp/scenario/plugins/ControllerRunner/ControllerRunner.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This project is dual licensed under LGPL v2.1+ or Apache License.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SCENARIO_PLUGINS_GAZEBO_CONTROLLERRUNNER_H
+#define SCENARIO_PLUGINS_GAZEBO_CONTROLLERRUNNER_H
+
+#include <ignition/gazebo/Entity.hh>
+#include <ignition/gazebo/EntityComponentManager.hh>
+#include <ignition/gazebo/EventManager.hh>
+#include <ignition/gazebo/System.hh>
+#include <sdf/Element.hh>
+
+#include <memory>
+
+namespace scenario {
+    namespace plugins {
+        namespace gazebo {
+            class ControllerRunner;
+        } // namespace gazebo
+    } // namespace plugins
+} // namespace scenario
+
+class scenario::plugins::gazebo::ControllerRunner final
+    : public ignition::gazebo::System
+    , public ignition::gazebo::ISystemConfigure
+    , public ignition::gazebo::ISystemPreUpdate
+{
+public:
+    ControllerRunner();
+    ~ControllerRunner() override;
+
+    void Configure(const ignition::gazebo::Entity& entity,
+                   const std::shared_ptr<const sdf::Element>& sdf,
+                   ignition::gazebo::EntityComponentManager& ecm,
+                   ignition::gazebo::EventManager& eventMgr) override;
+
+    void PreUpdate(const ignition::gazebo::UpdateInfo& info,
+                   ignition::gazebo::EntityComponentManager& ecm) override;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> pImpl = nullptr;
+};
+
+#endif // SCENARIO_PLUGINS_GAZEBO_CONTROLLERRUNNER_H

--- a/cpp/scenario/plugins/ControllerRunner/ControllersFactory.cpp
+++ b/cpp/scenario/plugins/ControllerRunner/ControllersFactory.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This project is dual licensed under LGPL v2.1+ or Apache License.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ControllersFactory.h"
+#include "scenario/controllers/ComputedTorqueFixedBase.h"
+#include "scenario/gazebo/Log.h"
+
+#include <sdf/Param.hh>
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <istream>
+#include <locale>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace scenario::plugins::gazebo;
+
+class ControllersFactory::Impl
+{
+public:
+    static bool ContextValid(const sdf::ElementPtr context);
+
+    template <typename T>
+    static T GetElementValueAs(const std::string& elementName,
+                               const sdf::ElementPtr parentContext);
+
+    static void StringToStd(const std::string& string,
+                            std::vector<double>& out);
+
+    static void StringToStd(const std::string& string,
+                            std::vector<std::string>& out);
+
+    static void StringToStd(const std::string& string, std::string& out);
+};
+
+ControllersFactory::ControllersFactory()
+    : pImpl{std::make_unique<Impl>()}
+{}
+
+ControllersFactory::~ControllersFactory() = default;
+
+scenario::plugins::gazebo::ControllersFactory& ControllersFactory::Instance()
+{
+    static ControllersFactory instance;
+    return instance;
+}
+
+scenario::controllers::ControllerPtr
+ControllersFactory::get(const sdf::ElementPtr context,
+                        scenario::gazebo::ModelPtr model)
+{
+    if (!Impl::ContextValid(context)) {
+        gymppError << "Controller context not valid" << std::endl;
+        return nullptr;
+    }
+
+    std::string controllerName;
+    context->GetAttribute("name")->Get<std::string>(controllerName);
+    gymppDebug << "Found context for " << controllerName << std::endl;
+
+    if (controllerName == "ComputedTorqueFixedBase") {
+
+        bool ok = true;
+        ok = ok && context->HasElement("kp");
+        ok = ok && context->HasElement("kd");
+        ok = ok && context->HasElement("urdf");
+        ok = ok && context->HasElement("joints");
+        ok = ok && context->HasElement("gravity");
+
+        if (!ok) {
+            gymppError << "Controller context has missing elements"
+                       << std::endl;
+            return nullptr;
+        }
+
+        auto urdf = Impl::GetElementValueAs<std::string>("urdf", context);
+        auto kp = Impl::GetElementValueAs<std::vector<double>>("kp", context);
+        auto kd = Impl::GetElementValueAs<std::vector<double>>("kd", context);
+        auto gravity =
+            Impl::GetElementValueAs<std::vector<double>>("gravity", context);
+        auto joints = Impl::GetElementValueAs<std::vector<std::string>>(
+            "joints", context);
+
+        if (gravity.size() != 3) {
+            gymppError << "Parsed gravity does not have three elements";
+            return nullptr;
+        }
+
+        auto controller =
+            std::make_shared<controllers::ComputedTorqueFixedBase>(
+                urdf,
+                model,
+                kp,
+                kd,
+                joints,
+                std::array<double, 3>{gravity[0], gravity[1], gravity[2]});
+
+        return std::move(controller);
+    }
+
+    return nullptr;
+}
+
+bool ControllersFactory::Impl::ContextValid(const sdf::ElementPtr context)
+{
+    // Check that the context is a <controller> element
+    if (context->GetName() != "controller") {
+        gymppError << "The first element of the context must be <controller>"
+                   << std::endl;
+        return false;
+    }
+
+    // Check that there is only one <controller> element
+    if (context->GetNextElement("controller")) {
+        gymppError
+            << "Found multiple <controller> elements in controller context"
+            << std::endl;
+        return false;
+    }
+
+    // Check that there is a name attribute: <controller name="controller_name">
+    if (!context->HasAttribute("name")) {
+        gymppError << "Failed to find 'name' attribute in <controller> element"
+                   << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+template <typename T>
+T ControllersFactory::Impl::GetElementValueAs(
+    const std::string& elementName,
+    const sdf::ElementPtr parentContext)
+{
+    if (!parentContext->HasElement(elementName)) {
+        gymppError << "Failed to find element <" << elementName << ">"
+                   << std::endl;
+        return {};
+    }
+
+    sdf::ElementPtr element = parentContext->GetElement(elementName);
+    assert(element);
+
+    sdf::ParamPtr value = element->GetValue();
+
+    if (!value) {
+        gymppError << "Failed to get value of element <" << elementName << ">"
+                   << std::endl;
+        return {};
+    }
+
+    T output;
+    std::string valueString = value->GetAsString();
+
+    Impl::StringToStd(valueString, output);
+    return output;
+}
+
+void ControllersFactory::Impl::StringToStd(const std::string& string,
+                                           std::vector<double>& out)
+{
+    double value;
+    std::stringstream in(string);
+
+    // Locale independent floating point conversion
+    // Note: not yet supported by GCC8
+    //
+    //    auto toDouble = [](const std::string& s) -> double {
+    //        double output;
+    //        std::from_chars(s.data(), s.data() + s.size(), output);
+    //        return output;
+    //    };
+
+    // Manually set the locale
+    in.imbue(std::locale::classic());
+
+    out.clear();
+
+    while (in >> value) {
+        out.push_back(value);
+    }
+}
+
+void ControllersFactory::Impl::StringToStd(const std::string& string,
+                                           std::vector<std::string>& out)
+{
+    std::string value;
+    std::stringstream in(string);
+
+    out.clear();
+
+    while (in >> value) {
+        out.push_back(value);
+    }
+}
+
+void ControllersFactory::Impl::StringToStd(const std::string& string,
+                                           std::string& out)
+{
+    out = string;
+}

--- a/cpp/scenario/plugins/ControllerRunner/ControllersFactory.h
+++ b/cpp/scenario/plugins/ControllerRunner/ControllersFactory.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This project is dual licensed under LGPL v2.1+ or Apache License.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SCENARIO_PLUGINS_CONTROLLERSFACTORY_H
+#define SCENARIO_PLUGINS_CONTROLLERSFACTORY_H
+
+#include "scenario/controllers/Controller.h"
+#include "scenario/gazebo/Model.h"
+
+#include <sdf/Element.hh>
+
+#include <memory>
+
+namespace scenario {
+    namespace plugins {
+        namespace gazebo {
+            class ControllersFactory;
+        } // namespace gazebo
+    } // namespace plugins
+} // namespace scenario
+
+class scenario::plugins::gazebo::ControllersFactory
+{
+
+public:
+    ControllersFactory();
+    ~ControllersFactory();
+
+    static ControllersFactory& Instance();
+    controllers::ControllerPtr get(const sdf::ElementPtr context,
+                                   scenario::gazebo::ModelPtr model);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> pImpl;
+};
+
+#endif // SCENARIO_PLUGINS_CONTROLLERSFACTORY_H


### PR DESCRIPTION
This PR adds the initial support to insert custom controllers in the simulation as model plugins.

Controllers could inherit from the following interfaces:

- `scenario::controllers::Controller` Used to initialize / step / terminate a controller.
- `scenario::controllers::SetJointReferences` Used to set the joint references.
- `scenario::controllers::SetBaseReferences` Used to set the base references.
- `scenario::controllers::UseScenarioModel` Controllers could optionally use internally a `scenario::gazebo::Model` object to get / set data. This interface streamlines how the pointer to the model object is handled.

An example of a fixed-base controller implemented with some of these interfaces is `scenario::controllers::ComputedTorqueFixedBase`.

Then, there is a Gazebo plugin `scenario::plugins::gazebo::ControllerRunner` that can be inserted during runtime and executes controllers that implement those interfaces. The configuration of the controller is passed from the plugin as an XML configuration.

Right now we do not load the controller classes as plugins (since it would be a plugin loading a plugin). In order to keep things simple, I have implemented a controller factory that for the moment allows executing only the controllers part of the project.

Note that this design choice allows using the custom controllers also with ScenarI/O APIs implemented for a real robot (e.g. for YARP or ROS). In that case, a secondary thread / process will run the controller, and depending about how the ScenarI/O APIs will be implemented, it will read the references from either shared memory of pub-sub. After each call, the controller will send the command to the robot likely through a middleware.