### PR TITLE
Experimental multi-world support

### DIFF
--- a/cpp/scenario/gazebo/include/scenario/gazebo/GazeboSimulator.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/GazeboSimulator.h
@@ -61,8 +61,10 @@ public:
     bool pause();
     bool running() const;
 
-    bool loadSdfWorld(const std::string& worldFile,
-                      const std::string& worldName = "");
+    bool insertWorldFromSDF(const std::string& worldFile = "",
+                            const std::string& worldName = "");
+    bool insertWorldsFromSDF(const std::string& worldFile,
+                             const std::vector<std::string>& worldNames = {});
 
     std::vector<std::string> worldNames() const;
     std::shared_ptr<scenario::gazebo::World>

--- a/cpp/scenario/gazebo/include/scenario/gazebo/helpers.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/helpers.h
@@ -134,9 +134,8 @@ namespace scenario::gazebo::utils {
     fromIgnitionContactsMsgs(ignition::gazebo::EntityComponentManager* ecm,
                              const ignition::msgs::Contacts& contactsMsg);
 
-    bool renameSDFWorld(sdf::Root& sdfRoot,
-                        const std::string& newWorldName,
-                        size_t worldIndex = 0);
+    sdf::World renameSDFWorld(const sdf::World& world,
+                              const std::string& newWorldName);
 
     bool renameSDFModel(sdf::Root& sdfRoot,
                         const std::string& newModelName,

--- a/cpp/scenario/gazebo/include/scenario/gazebo/helpers.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/helpers.h
@@ -29,6 +29,8 @@
 
 #include "scenario/gazebo/Joint.h"
 #include "scenario/gazebo/Link.h"
+#include "scenario/gazebo/Model.h"
+#include "scenario/gazebo/World.h"
 #include "scenario/gazebo/exceptions.h"
 
 #include <ignition/gazebo/Entity.hh>
@@ -164,6 +166,14 @@ namespace scenario::gazebo::utils {
                             const ignition::math::Vector3d& angBaseVelocity,
                             const ignition::math::Pose3d& M_H_B,
                             const ignition::math::Quaterniond& W_R_B);
+
+    WorldPtr getParentWorld(ignition::gazebo::EntityComponentManager* ecm,
+                            ignition::gazebo::EventManager* eventManager,
+                            const ignition::gazebo::Entity entity);
+
+    ModelPtr getParentModel(ignition::gazebo::EntityComponentManager* ecm,
+                            ignition::gazebo::EventManager* eventManager,
+                            const ignition::gazebo::Entity entity);
 
     template <typename ComponentType>
     ignition::gazebo::Entity getFirstParentEntityWithComponent(

--- a/cpp/scenario/gazebo/include/scenario/gazebo/utils.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/utils.h
@@ -44,6 +44,8 @@ namespace scenario {
             std::string getSdfString(const std::string& fileName);
             std::string getModelNameFromSdf(const std::string& fileName,
                                             const size_t modelIndex = 0);
+            std::string getWorldNameFromSdf(const std::string& fileName,
+                                            const size_t worldIndex = 0);
             std::string getEmptyWorld();
             std::string getModelFileFromFuel(const std::string& URI,
                                              const bool useCache = false);

--- a/cpp/scenario/gazebo/include/scenario/gazebo/utils.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/utils.h
@@ -49,6 +49,7 @@ namespace scenario {
             std::string getEmptyWorld();
             std::string getModelFileFromFuel(const std::string& URI,
                                              const bool useCache = false);
+            std::string getRandomString(const size_t length);
         } // namespace utils
     } // namespace gazebo
 } // namespace scenario

--- a/cpp/scenario/gazebo/src/Joint.cpp
+++ b/cpp/scenario/gazebo/src/Joint.cpp
@@ -27,6 +27,8 @@
 #include "scenario/gazebo/Joint.h"
 
 #include "scenario/gazebo/Log.h"
+#include "scenario/gazebo/Model.h"
+#include "scenario/gazebo/World.h"
 #include "scenario/gazebo/components/HistoryOfAppliedJointForces.h"
 #include "scenario/gazebo/components/JointAccelerationTarget.h"
 #include "scenario/gazebo/components/JointControlMode.h"
@@ -72,7 +74,22 @@ Joint::Joint()
 
 uint64_t Joint::id() const
 {
-    return pImpl->jointEntity;
+    // Get the parent world
+    WorldPtr parentWorld = utils::getParentWorld(
+        pImpl->ecm, pImpl->eventManager, pImpl->jointEntity);
+    assert(parentWorld);
+
+    // Get the parent model
+    ModelPtr parentModel = utils::getParentModel(
+        pImpl->ecm, pImpl->eventManager, pImpl->jointEntity);
+    assert(parentModel);
+
+    // Build a unique string identifier of this joint
+    std::string scopedJointName =
+        parentWorld->name() + "::" + parentModel->name() + "::" + this->name();
+
+    // Return the hashed string
+    return std::hash<std::string>{}(scopedJointName);
 }
 
 Joint::~Joint() = default;

--- a/cpp/scenario/gazebo/src/Link.cpp
+++ b/cpp/scenario/gazebo/src/Link.cpp
@@ -27,6 +27,8 @@
 #include "scenario/gazebo/Link.h"
 
 #include "scenario/gazebo/Log.h"
+#include "scenario/gazebo/Model.h"
+#include "scenario/gazebo/World.h"
 #include "scenario/gazebo/components/ExternalWorldWrenchCmdWithDuration.h"
 #include "scenario/gazebo/components/SimulatedTime.h"
 #include "scenario/gazebo/exceptions.h"
@@ -77,7 +79,22 @@ Link::Link()
 
 uint64_t Link::id() const
 {
-    return pImpl->linkEntity;
+    // Get the parent world
+    WorldPtr parentWorld = utils::getParentWorld(
+        pImpl->ecm, pImpl->eventManager, pImpl->linkEntity);
+    assert(parentWorld);
+
+    // Get the parent model
+    ModelPtr parentModel = utils::getParentModel(
+        pImpl->ecm, pImpl->eventManager, pImpl->linkEntity);
+    assert(parentModel);
+
+    // Build a unique string identifier of this joint
+    std::string scopedLinkName =
+        parentWorld->name() + "::" + parentModel->name() + "::" + this->name();
+
+    // Return the hashed string
+    return std::hash<std::string>{}(scopedLinkName);
 }
 
 Link::~Link() = default;

--- a/cpp/scenario/gazebo/src/Model.cpp
+++ b/cpp/scenario/gazebo/src/Model.cpp
@@ -29,6 +29,7 @@
 #include "scenario/gazebo/Joint.h"
 #include "scenario/gazebo/Link.h"
 #include "scenario/gazebo/Log.h"
+#include "scenario/gazebo/World.h"
 #include "scenario/gazebo/components/BasePoseTarget.h"
 #include "scenario/gazebo/components/BaseWorldAccelerationTarget.h"
 #include "scenario/gazebo/components/BaseWorldVelocityTarget.h"
@@ -94,7 +95,16 @@ Model::Model()
 
 uint64_t Model::id() const
 {
-    return pImpl->modelEntity;
+    // Get the parent world
+    WorldPtr parentWorld = utils::getParentWorld(
+        pImpl->ecm, pImpl->eventManager, pImpl->modelEntity);
+    assert(parentWorld);
+
+    // Build a unique string identifier of this model
+    std::string scopedModelName = parentWorld->name() + "::" + this->name();
+
+    // Return the hashed string
+    return std::hash<std::string>{}(scopedModelName);
 }
 
 Model::~Model() = default;

--- a/cpp/scenario/gazebo/src/World.cpp
+++ b/cpp/scenario/gazebo/src/World.cpp
@@ -48,6 +48,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <functional>
 #include <unordered_map>
 
 using namespace scenario::gazebo;
@@ -71,7 +72,7 @@ World::World()
 
 uint64_t World::id() const
 {
-    return pImpl->worldEntity;
+    return std::hash<std::string>{}(this->name());
 }
 
 World::~World() = default;

--- a/cpp/scenario/gazebo/src/helpers.cpp
+++ b/cpp/scenario/gazebo/src/helpers.cpp
@@ -29,7 +29,9 @@
 #include "scenario/gazebo/Log.h"
 
 #include <ignition/gazebo/components/Component.hh>
+#include <ignition/gazebo/components/Model.hh>
 #include <ignition/gazebo/components/Name.hh>
+#include <ignition/gazebo/components/World.hh>
 #include <ignition/msgs/contact.pb.h>
 #include <sdf/Error.hh>
 #include <sdf/Model.hh>
@@ -447,4 +449,38 @@ utils::fromBaseToModelVelocity(const ignition::math::Vector3d& linBaseVelocity,
 
     // Return the mixed velocity of the model
     return {linModelVelocity, angModelVelocity};
+}
+
+WorldPtr utils::getParentWorld(ignition::gazebo::EntityComponentManager* ecm,
+                               ignition::gazebo::EventManager* eventManager,
+                               const ignition::gazebo::Entity entity)
+{
+    auto worldEntity = getFirstParentEntityWithComponent< //
+        ignition::gazebo::components::World>(ecm, entity);
+
+    auto world = std::make_shared<World>();
+
+    if (!world->initialize(worldEntity, ecm, eventManager)) {
+        gymppError << "Failed to initialize world" << std::endl;
+        return nullptr;
+    }
+
+    return world;
+}
+
+ModelPtr utils::getParentModel(ignition::gazebo::EntityComponentManager* ecm,
+                               ignition::gazebo::EventManager* eventManager,
+                               const ignition::gazebo::Entity entity)
+{
+    auto modelEntity = getFirstParentEntityWithComponent< //
+        ignition::gazebo::components::World>(ecm, entity);
+
+    auto model = std::make_shared<Model>();
+
+    if (!model->initialize(modelEntity, ecm, eventManager)) {
+        gymppError << "Failed to initialize model" << std::endl;
+        return nullptr;
+    }
+
+    return model;
 }

--- a/cpp/scenario/gazebo/src/utils.cpp
+++ b/cpp/scenario/gazebo/src/utils.cpp
@@ -216,3 +216,18 @@ std::string utils::getModelFileFromFuel(const std::string& URI,
 
     return modelFile;
 }
+
+std::string utils::getRandomString(const size_t length)
+{
+    auto randchar = []() -> char {
+        static constexpr char charset[] = "0123456789"
+                                          "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                          "abcdefghijklmnopqrstuvwxyz";
+        const int max_index = (sizeof(charset) - 1);
+        return charset[rand() % max_index];
+    };
+
+    std::string str(length, 0);
+    std::generate_n(str.begin(), length, randchar);
+    return str;
+}

--- a/cpp/scenario/gazebo/src/utils.cpp
+++ b/cpp/scenario/gazebo/src/utils.cpp
@@ -40,6 +40,7 @@
 #include <sdf/Element.hh>
 #include <sdf/Model.hh>
 #include <sdf/Root.hh>
+#include <sdf/World.hh>
 
 #include <cassert>
 #include <memory>
@@ -125,6 +126,30 @@ std::string utils::getModelNameFromSdf(const std::string& fileName,
     }
 
     return root->ModelByIndex(modelIndex)->Name();
+}
+
+std::string utils::getWorldNameFromSdf(const std::string& fileName,
+                                       const size_t worldIndex)
+{
+    auto root = utils::getSdfRootFromFile(fileName);
+
+    if (!root) {
+        return {};
+    }
+
+    if (root->WorldCount() == 0) {
+        gymppError << "Didn't find any world in file " << fileName << std::endl;
+        return {};
+    }
+
+    if (worldIndex >= root->WorldCount()) {
+        gymppError << "Model with index " << worldIndex
+                   << " not found. The model has only " << root->WorldCount()
+                   << " model(s)" << std::endl;
+        return {};
+    }
+
+    return root->WorldByIndex(worldIndex)->Name();
 }
 
 std::string utils::getEmptyWorld()

--- a/cpp/scenario/plugins/ECMProvider/ECMSingleton.cpp
+++ b/cpp/scenario/plugins/ECMProvider/ECMSingleton.cpp
@@ -196,6 +196,6 @@ bool ECMSingleton::storePtrs(ignition::gazebo::EntityComponentManager* ecm,
         return false;
     }
 
-    pImpl->resources[worldName] = {ecm, eventMgr};
+    pImpl->resources.emplace(worldName, Impl::ResourcePtrs(ecm, eventMgr));
     return true;
 }

--- a/cpp/scenario/plugins/ECMProvider/ECMSingleton.cpp
+++ b/cpp/scenario/plugins/ECMProvider/ECMSingleton.cpp
@@ -27,22 +27,41 @@
 #include "scenario/plugins/gazebo/ECMSingleton.h"
 #include "scenario/gazebo/Log.h"
 
-#include <atomic>
+#include <mutex>
 #include <ostream>
 #include <string>
+#include <unordered_map>
+#include <utility>
 
 using namespace scenario::plugins::gazebo;
 
 class ECMSingleton::Impl
 {
 public:
-    std::atomic<ignition::gazebo::EventManager*> eventMgr = nullptr;
-    std::atomic<ignition::gazebo::EntityComponentManager*> ecm = nullptr;
+    struct ResourcePtrs
+    {
+        ResourcePtrs() = delete;
+        ResourcePtrs(ignition::gazebo::EntityComponentManager* _ecm,
+                     ignition::gazebo::EventManager* _eventMgr)
+            : ecm(_ecm)
+            , eventMgr(_eventMgr)
+        {}
+
+        ignition::gazebo::EntityComponentManager* ecm = nullptr;
+        ignition::gazebo::EventManager* eventMgr = nullptr;
+    };
+
+    mutable std::recursive_mutex mutex;
+
+    using WorldName = std::string;
+    std::unordered_map<WorldName, ResourcePtrs> resources;
 };
 
 ECMSingleton::ECMSingleton()
     : pImpl{new Impl()}
 {}
+
+ECMSingleton::~ECMSingleton() = default;
 
 ECMSingleton& ECMSingleton::Instance()
 {
@@ -50,23 +69,113 @@ ECMSingleton& ECMSingleton::Instance()
     return instance;
 }
 
-bool ECMSingleton::valid() const
+void ECMSingleton::clean(const std::string& worldName)
 {
-    return pImpl->ecm && pImpl->eventMgr;
+    std::unique_lock lock(pImpl->mutex);
+
+    if (worldName.empty()) {
+        pImpl->resources.clear();
+        return;
+    }
+
+    if (!this->hasWorld(worldName)) {
+        gymppError << "Resources of world " << worldName << " not found"
+                   << std::endl;
+        return;
+    }
+
+    pImpl->resources.erase(worldName);
 }
 
-ignition::gazebo::EventManager* ECMSingleton::getEventManager() const
+bool ECMSingleton::valid(const std::string& worldName) const
 {
-    if (!this->valid()) {
-        gymppError << "The pointers are not valid" << std::endl;
+    std::unique_lock lock(pImpl->mutex);
+
+    if (!this->hasWorld(worldName)) {
+        gymppDebug << "World" << worldName << " not found" << std::endl;
+        return false;
+    }
+
+    if (!worldName.empty()) {
+        const auto& ptrs = pImpl->resources.at(worldName);
+        return ptrs.ecm && ptrs.eventMgr;
+    }
+    else {
+        bool valid = true;
+        for (const auto& [_, resources] : pImpl->resources) {
+            valid = valid && resources.ecm && resources.eventMgr;
+        }
+
+        return valid;
+    }
+}
+
+bool ECMSingleton::hasWorld(const std::string& worldName) const
+{
+    std::unique_lock lock(pImpl->mutex);
+
+    if (worldName.empty()) {
+        return pImpl->resources.size() != 0;
+    }
+
+    return pImpl->resources.find(worldName) != pImpl->resources.end();
+}
+
+std::vector<std::string> ECMSingleton::worldNames() const
+{
+    std::unique_lock lock(pImpl->mutex);
+    std::vector<std::string> worldNames;
+
+    for (const auto& [key, _] : pImpl->resources) {
+        worldNames.emplace_back(key);
+    }
+
+    return worldNames;
+}
+
+ignition::gazebo::EventManager*
+ECMSingleton::getEventManager(const std::string& worldName) const
+{
+    std::unique_lock lock(pImpl->mutex);
+
+    if (!this->hasWorld(worldName)) {
+        gymppError << "Resources of world " << worldName << " not found"
+                   << std::endl;
         return nullptr;
     }
 
-    return pImpl->eventMgr;
+    if (!this->valid(worldName)) {
+        gymppError << "Resources of world " << worldName << " not valid"
+                   << std::endl;
+        return nullptr;
+    }
+
+    return pImpl->resources.at(worldName).eventMgr;
+}
+
+ignition::gazebo::EntityComponentManager*
+ECMSingleton::getECM(const std::string& worldName) const
+{
+    std::unique_lock lock(pImpl->mutex);
+
+    if (!this->hasWorld(worldName)) {
+        gymppError << "Resources of world " << worldName << " not found"
+                   << std::endl;
+        return nullptr;
+    }
+
+    if (!this->valid(worldName)) {
+        gymppError << "Resources of world " << worldName << " not valid"
+                   << std::endl;
+        return nullptr;
+    }
+
+    return pImpl->resources.at(worldName).ecm;
 }
 
 bool ECMSingleton::storePtrs(ignition::gazebo::EntityComponentManager* ecm,
-                             ignition::gazebo::EventManager* eventMgr)
+                             ignition::gazebo::EventManager* eventMgr,
+                             const std::string& worldName)
 {
     if (!ecm || !eventMgr) {
         gymppError << "The pointer to the ECM or EventManager is not valid"
@@ -74,25 +183,19 @@ bool ECMSingleton::storePtrs(ignition::gazebo::EntityComponentManager* ecm,
         return false;
     }
 
-    pImpl->ecm = ecm;
-    pImpl->eventMgr = eventMgr;
-
-    return true;
-}
-
-ignition::gazebo::EntityComponentManager* ECMSingleton::getECM() const
-{
-
-    if (!this->valid()) {
-        gymppError << "The pointers are not valid" << std::endl;
-        return nullptr;
+    if (worldName.empty()) {
+        gymppError << "The world name is empty" << std::endl;
+        return false;
     }
 
-    return pImpl->ecm;
-}
+    std::unique_lock lock(pImpl->mutex);
 
-void ECMSingleton::clean()
-{
-    pImpl->ecm = nullptr;
-    pImpl->eventMgr = nullptr;
+    if (this->hasWorld(worldName)) {
+        gymppError << "Resources of world " << worldName
+                   << " have been already stored" << std::endl;
+        return false;
+    }
+
+    pImpl->resources[worldName] = {ecm, eventMgr};
+    return true;
 }

--- a/cpp/scenario/plugins/ECMProvider/include/scenario/plugins/gazebo/ECMSingleton.h
+++ b/cpp/scenario/plugins/ECMProvider/include/scenario/plugins/gazebo/ECMSingleton.h
@@ -44,21 +44,26 @@ class scenario::plugins::gazebo::ECMSingleton
 {
 public:
     ECMSingleton();
-    ~ECMSingleton() = default;
+    ~ECMSingleton();
 
     ECMSingleton(ECMSingleton&) = delete;
     void operator=(const ECMSingleton&) = delete;
 
     static ECMSingleton& Instance();
 
-    void clean();
-    bool valid() const;
+    void clean(const std::string& worldName = {});
+    bool valid(const std::string& worldName = {}) const;
+    bool hasWorld(const std::string& worldName = {}) const;
 
-    ignition::gazebo::EventManager* getEventManager() const;
-    ignition::gazebo::EntityComponentManager* getECM() const;
+    std::vector<std::string> worldNames() const;
+    ignition::gazebo::EventManager*
+    getEventManager(const std::string& worldName) const;
+    ignition::gazebo::EntityComponentManager*
+    getECM(const std::string& worldName) const;
 
     bool storePtrs(ignition::gazebo::EntityComponentManager* ecm,
-                   ignition::gazebo::EventManager* eventMgr);
+                   ignition::gazebo::EventManager* eventMgr,
+                   const std::string& worldName);
 
 private:
     class Impl;

--- a/tests/scenario/test_multi_world.py
+++ b/tests/scenario/test_multi_world.py
@@ -15,7 +15,7 @@ bindings.setVerbosity(4)
                          [(0.001, 1.0, 1)],
                          indirect=True,
                          ids=utils.id_gazebo_fn)
-def _test_insert_multiple_worlds(gazebo: bindings.GazeboSimulator):
+def test_insert_multiple_worlds(gazebo: bindings.GazeboSimulator):
 
     empty_world_sdf = utils.get_empty_world_sdf()
     assert gazebo.insertWorldFromSDF(empty_world_sdf, "myWorld1")
@@ -39,7 +39,7 @@ def _test_insert_multiple_worlds(gazebo: bindings.GazeboSimulator):
                          [(0.001, 1.0, 1)],
                          indirect=True,
                          ids=utils.id_gazebo_fn)
-def _test_insert_multiple_world(gazebo: bindings.GazeboSimulator):
+def test_insert_multiple_world(gazebo: bindings.GazeboSimulator):
 
     multi_world_sdf = utils.get_multi_world_sdf_file()
 
@@ -62,7 +62,7 @@ def _test_insert_multiple_world(gazebo: bindings.GazeboSimulator):
                          [(0.001, 1.0, 1)],
                          indirect=True,
                          ids=utils.id_gazebo_fn)
-def _test_insert_multiple_world_rename(gazebo: bindings.GazeboSimulator):
+def test_insert_multiple_world_rename(gazebo: bindings.GazeboSimulator):
 
     multi_world_sdf = utils.get_multi_world_sdf_file()
 
@@ -86,7 +86,7 @@ def _test_insert_multiple_world_rename(gazebo: bindings.GazeboSimulator):
                          [(0.001, 1.0, 1)],
                          indirect=True,
                          ids=utils.id_gazebo_fn)
-def _test_insert_world_multiple_calls(gazebo: bindings.GazeboSimulator):
+def test_insert_world_multiple_calls(gazebo: bindings.GazeboSimulator):
 
     single_world_sdf = utils.get_empty_world_sdf()
 

--- a/tests/scenario/test_world.py
+++ b/tests/scenario/test_world.py
@@ -29,7 +29,7 @@ def test_load_default_world(gazebo: bindings.GazeboSimulator):
                          [(0.001, 1.0, 1)],
                          indirect=True,
                          ids=utils.id_gazebo_fn)
-def _test_load_default_world_from_file(gazebo: bindings.GazeboSimulator):
+def test_load_default_world_from_file(gazebo: bindings.GazeboSimulator):
 
     empty_world_sdf = utils.get_empty_world_sdf()
     print(empty_world_sdf)
@@ -47,7 +47,7 @@ def _test_load_default_world_from_file(gazebo: bindings.GazeboSimulator):
                          [(0.001, 1.0, 1)],
                          indirect=True,
                          ids=utils.id_gazebo_fn)
-def _test_rename_default_world(gazebo: bindings.GazeboSimulator):
+def test_rename_default_world(gazebo: bindings.GazeboSimulator):
 
     empty_world_sdf = utils.get_empty_world_sdf()
     assert gazebo.insertWorldFromSDF(empty_world_sdf, "myWorld")


### PR DESCRIPTION
This PR introduces the support to insert in the simulator multiple independent worlds.

What's interesting is that each world is simulated in the same process but in different threads. Each thread contains a `SimulationRunner` with one of the worlds. Worlds can have different physics and contain a different number of models, but all of them must share the same server configuration (step size, real-time factor, number of steps per run).

This architectures potentially enables gym-ignition to fully exploit the CPU resources of the machine for sampling from multiple world in parallel. I will push some Python code in another PR, but there are severe upstream limitations that prevent using the multi-world feature. In fact, upstream's multi-world setup has [few bugs](https://bitbucket.org/ignitionrobotics/ign-gazebo/issues/18/support-for-multiple-worlds) that haven't been solved yet.