### PR TITLE
Extract extended contact data (force, normal, penetration depth)

### DIFF
--- a/bindings/scenario/scenario_bindings.i
+++ b/bindings/scenario/scenario_bindings.i
@@ -45,7 +45,8 @@
 %shared_ptr(scenario::gazebo::Link)
 %shared_ptr(scenario::gazebo::Model)
 %shared_ptr(scenario::gazebo::World)
-%template(Vector_contact) std::vector<scenario::base::ContactData>;
+%template(Vector_contact) std::vector<scenario::base::Contact>;
+%template(Vector_contact_point) std::vector<scenario::base::ContactPoint>;
 
 // Ignored methods
 %ignore scenario::gazebo::Joint::initialize;

--- a/cpp/scenario/gazebo/include/scenario/gazebo/Link.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/Link.h
@@ -40,7 +40,8 @@
 namespace scenario {
     namespace base {
         struct Pose;
-        struct ContactData;
+        struct Contact;
+        struct ContactPoint;
     } // namespace base
     namespace gazebo {
         class Link;
@@ -86,7 +87,8 @@ public:
     bool enableContactDetection(const bool enable);
 
     bool inContact() const;
-    std::vector<scenario::base::ContactData> contactData() const;
+    std::vector<base::Contact> contacts() const;
+    std::array<double, 6> contactWrench() const;
 
     bool applyWorldForce(const std::array<double, 3>& force,
                          const double duration = 0.0);
@@ -127,14 +129,20 @@ struct scenario::base::Pose
     std::array<double, 4> orientation = {1, 0, 0, 0};
 };
 
-struct scenario::base::ContactData
+struct scenario::base::ContactPoint
+{
+    double depth;
+    std::array<double, 3> force;
+    std::array<double, 3> torque;
+    std::array<double, 3> normal;
+    std::array<double, 3> position;
+};
+
+struct scenario::base::Contact
 {
     std::string bodyA;
     std::string bodyB;
-    std::array<double, 3> depth;
-    std::array<double, 6> wrench;
-    std::array<double, 3> normal;
-    std::array<double, 3> position;
+    std::vector<ContactPoint> points;
 };
 
 #endif // SCENARIO_GAZEBO_LINK_H

--- a/cpp/scenario/gazebo/include/scenario/gazebo/Model.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/Model.h
@@ -38,7 +38,7 @@
 
 namespace scenario {
     namespace base {
-        struct ContactData;
+        struct Contact;
         enum class JointControlMode;
     } // namespace base
     namespace gazebo {
@@ -113,7 +113,7 @@ public:
 
     std::vector<std::string> linksInContact() const;
 
-    std::vector<base::ContactData>
+    std::vector<base::Contact>
     contacts(const std::vector<std::string>& linkNames = {}) const;
 
     // ==================

--- a/cpp/scenario/gazebo/include/scenario/gazebo/helpers.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/helpers.h
@@ -132,7 +132,11 @@ namespace scenario::gazebo::utils {
 
     ignition::math::Pose3d toIgnitionPose(const scenario::base::Pose& pose);
 
-    std::vector<scenario::base::ContactData>
+    scenario::base::Contact
+    fromIgnitionContactMsgs(ignition::gazebo::EntityComponentManager* ecm,
+                            const ignition::msgs::Contact& contactMsg);
+
+    std::vector<scenario::base::Contact>
     fromIgnitionContactsMsgs(ignition::gazebo::EntityComponentManager* ecm,
                              const ignition::msgs::Contacts& contactsMsg);
 

--- a/cpp/scenario/gazebo/src/Link.cpp
+++ b/cpp/scenario/gazebo/src/Link.cpp
@@ -375,10 +375,10 @@ bool Link::enableContactDetection(const bool enable)
 
 bool Link::inContact() const
 {
-    return this->contactData().empty() ? false : true;
+    return this->contacts().empty() ? false : true;
 }
 
-std::vector<scenario::base::ContactData> Link::contactData() const
+std::vector<scenario::base::Contact> Link::contacts() const
 {
     std::vector<ignition::gazebo::Entity> collisionEntities;
 
@@ -391,7 +391,7 @@ std::vector<scenario::base::ContactData> Link::contactData() const
             ignition::gazebo::components::ContactSensorData*,
             ignition::gazebo::components::ParentEntity* parentEntityComponent)
             -> bool {
-            // Keep only the collision of this link
+            // Keep only the collisions of this link
             if (parentEntityComponent->Data() != pImpl->linkEntity) {
                 return true;
             }
@@ -404,27 +404,100 @@ std::vector<scenario::base::ContactData> Link::contactData() const
         return {};
     }
 
-    std::vector<base::ContactData> linkAllContacts;
+    using BodyNameA = std::string;
+    using BodyNameB = std::string;
+    using CollisionsInContact = std::pair<BodyNameA, BodyNameB>;
+    auto contactsMap = std::map<CollisionsInContact, base::Contact>();
 
     for (const auto collisionEntity : collisionEntities) {
 
         // Get the contact data for the selected collision entity
-        ignition::msgs::Contacts contactSensorData =
+        const ignition::msgs::Contacts& contactSensorData =
             utils::getExistingComponentData< //
                 ignition::gazebo::components::ContactSensorData>(
                 pImpl->ecm, collisionEntity);
 
         // Convert the ignition msg
-        std::vector<base::ContactData> collisionContacts =
+        std::vector<base::Contact> collisionContacts =
             utils::fromIgnitionContactsMsgs(pImpl->ecm, contactSensorData);
+        //        assert(collisionContacts.size() <= 1);
 
-        // Insert the collision contact data to the link's buffer
-        linkAllContacts.insert(linkAllContacts.end(),
-                               collisionContacts.begin(),
-                               collisionContacts.end());
+        for (const auto& contact : collisionContacts) {
+
+            assert(!contact.bodyA.empty());
+            assert(!contact.bodyB.empty());
+
+            auto key = std::make_pair(contact.bodyA, contact.bodyB);
+
+            if (contactsMap.find(key) != contactsMap.end()) {
+                contactsMap.at(key).points.insert(
+                    contactsMap.at(key).points.end(),
+                    contact.points.begin(),
+                    contact.points.end());
+            }
+            else {
+                contactsMap[key] = contact;
+            }
+        }
     }
 
-    return linkAllContacts;
+    // Move data from the map to the output vector
+    std::vector<base::Contact> allContacts;
+    allContacts.reserve(contactsMap.size());
+
+    for (auto& [_, contact] : contactsMap) {
+        allContacts.push_back(std::move(contact));
+    }
+
+    return allContacts;
+}
+
+std::array<double, 6> Link::contactWrench() const
+{
+    auto totalForce = ignition::math::Vector3d::Zero;
+    auto totalTorque = ignition::math::Vector3d::Zero;
+
+    const auto& contacts = this->contacts();
+
+    for (const auto& contact : contacts) {
+        // Each contact wrench is expressed with respect to the contact point
+        // and with the orientation of the world frame. We need to translate it
+        // to the link frame.
+
+        for (const auto& contactPoint : contact.points) {
+            // The contact points extracted from the physics do not have torque
+            constexpr std::array<double, 3> zero = {0, 0, 0};
+            assert(contactPoint.torque == zero);
+
+            // Link position
+            const auto& o_L = utils::toIgnitionVector3(this->position());
+
+            // Contact position
+            const auto& o_P = utils::toIgnitionVector3(contactPoint.position);
+
+            // Relative position
+            const auto L_o_P = o_P - o_L;
+
+            // The contact force and the total link force are both expressed
+            // with the orientation of the world frame. This simplifies the
+            // conversion since we have to take into account only the
+            // displacement.
+            auto force = utils::toIgnitionVector3(contactPoint.force);
+
+            // The force does not have to be changed
+            totalForce += force;
+
+            // There is however a torque that balances out the resulting moment
+            totalTorque += L_o_P.Cross(force);
+        }
+    }
+
+    return {totalForce[0],
+            totalForce[1],
+            totalForce[2],
+            totalTorque[0],
+            totalTorque[1],
+            totalTorque[2]};
 }
 
 bool Link::applyWorldForce(const std::array<double, 3>& force,

--- a/cpp/scenario/gazebo/src/Model.cpp
+++ b/cpp/scenario/gazebo/src/Model.cpp
@@ -487,16 +487,16 @@ std::vector<std::string> Model::linksInContact() const
     return linksInContact;
 }
 
-std::vector<scenario::base::ContactData>
+std::vector<scenario::base::Contact>
 Model::contacts(const std::vector<std::string>& linkNames) const
 {
     std::vector<std::string> linkSerialization =
         linkNames.empty() ? this->linkNames() : linkNames;
 
-    std::vector<scenario::base::ContactData> allContacts;
+    std::vector<scenario::base::Contact> allContacts;
 
     for (const auto& linkName : linkSerialization) {
-        auto contacts = this->getLink(linkName)->contactData();
+        auto contacts = this->getLink(linkName)->contacts();
         std::move(contacts.begin(), //
                   contacts.end(),
                   std::back_inserter(allContacts));

--- a/cpp/scenario/gazebo/src/helpers.cpp
+++ b/cpp/scenario/gazebo/src/helpers.cpp
@@ -143,9 +143,9 @@ ignition::math::Pose3d utils::toIgnitionPose(const scenario::base::Pose& pose)
     return ignitionPose;
 }
 
-std::vector<scenario::base::ContactData>
-utils::fromIgnitionContactsMsgs(ignition::gazebo::EntityComponentManager* ecm,
-                                const ignition::msgs::Contacts& contactsMsg)
+scenario::base::Contact
+utils::fromIgnitionContactMsgs(ignition::gazebo::EntityComponentManager* ecm,
+                               const ignition::msgs::Contact& contactMsg)
 {
     auto getEntityName =
         [&](const ignition::gazebo::Entity entity) -> std::string {
@@ -155,43 +155,77 @@ utils::fromIgnitionContactsMsgs(ignition::gazebo::EntityComponentManager* ecm,
         return nameComponent->Data();
     };
 
-    std::vector<base::ContactData> contacts;
+    // Get the names of the links in contact following:
+    // collision entity -> collision link -> link name
+    auto collisionEntityA = contactMsg.collision1().id();
+    auto collisionEntityB = contactMsg.collision2().id();
 
-    for (int i = 0; i < contactsMsg.contact_size(); ++i) {
-        // Extract the contact object
-        const ignition::msgs::Contact& contactData = contactsMsg.contact(i);
+    auto linkEntityA = ecm->ParentEntity(collisionEntityA);
+    auto linkEntityB = ecm->ParentEntity(collisionEntityB);
+    std::string linkNameA = getEntityName(linkEntityA);
+    std::string linkNameB = getEntityName(linkEntityB);
 
-        auto collisionEntityA = contactData.collision1().id();
-        auto collisionEntityB = contactData.collision2().id();
+    // Return the link names scoped with the model name
+    auto modelEntityA = ecm->ParentEntity(linkEntityA);
+    auto modelEntityB = ecm->ParentEntity(linkEntityB);
+    std::string modelNameA = getEntityName(modelEntityA);
+    std::string modelNameB = getEntityName(modelEntityB);
 
-        auto linkEntityA = ecm->ParentEntity(collisionEntityA);
-        auto linkEntityB = ecm->ParentEntity(collisionEntityB);
-        std::string linkNameA = getEntityName(linkEntityA);
-        std::string linkNameB = getEntityName(linkEntityB);
+    std::string scopedBodyA = modelNameA + "::" + linkNameA;
+    std::string scopedBodyB = modelNameB + "::" + linkNameB;
 
-        auto modelEntityA = ecm->ParentEntity(linkEntityA);
-        auto modelEntityB = ecm->ParentEntity(linkEntityB);
-        std::string modelNameA = getEntityName(modelEntityA);
-        std::string modelNameB = getEntityName(modelEntityB);
+    // Returned data structure
+    scenario::base::Contact contact;
+    contact.bodyA = scopedBodyA;
+    contact.bodyB = scopedBodyB;
 
-        std::string scopedBodyA = modelNameA + "::" + linkNameA;
-        std::string scopedBodyB = modelNameB + "::" + linkNameB;
+    // Dimensions of contact points data must match
+    auto numOfDepths = contactMsg.depth_size();
+    auto numOfNormals = contactMsg.normal_size();
+    auto numOfWrenches = contactMsg.wrench_size();
+    auto numOfPositions = contactMsg.position_size();
 
-        // Fill the contact data
-        base::ContactData contact;
-        contact.bodyA = scopedBodyA;
-        contact.bodyB = scopedBodyB;
-        contact.position[0] = contactData.position(i).x();
-        contact.position[1] = contactData.position(i).y();
-        contact.position[2] = contactData.position(i).z();
+    int numOfPoints = numOfDepths;
+    assert(numOfPoints == numOfNormals);
+    assert(numOfPoints == numOfWrenches);
+    assert(numOfPoints == numOfPositions);
 
-        // TODO: fill the normal, contacty depth, wrench magnitude
-        assert(contactData.depth_size() == 0);
-        assert(contactData.normal_size() == 0);
-        assert(contactData.wrench_size() == 0);
+    auto fromIgnMsg =
+        [](const ignition::msgs::Vector3d& vec) -> std::array<double, 3> {
+        return {vec.x(), vec.y(), vec.z()};
+    };
 
-        // Add the new contact data to the contacts vector
-        contacts.push_back(contact);
+    // Get all the contact points data
+    for (int pointIdx = 0; pointIdx < numOfPoints; ++pointIdx) {
+        // Create a contact point
+        scenario::base::ContactPoint contactPoint;
+        contactPoint.depth = contactMsg.depth(pointIdx);
+        contactPoint.normal = fromIgnMsg(contactMsg.normal(pointIdx));
+        contactPoint.position = fromIgnMsg(contactMsg.position(pointIdx));
+
+        // Get the wrench acting on bodyA
+        const ignition::msgs::JointWrench wrench = contactMsg.wrench(pointIdx);
+        const auto& wrench1 = wrench.body_1_wrench();
+        contactPoint.force = fromIgnMsg(wrench1.force());
+        contactPoint.torque = fromIgnMsg(wrench1.torque());
+
+        // Store the contact point
+        contact.points.push_back(contactPoint);
+    }
+
+    return contact;
+}
+
+std::vector<scenario::base::Contact>
+utils::fromIgnitionContactsMsgs(ignition::gazebo::EntityComponentManager* ecm,
+                                const ignition::msgs::Contacts& contactsMsg)
+{
+    std::vector<base::Contact> contacts;
+
+    for (int contactIdx = 0; contactIdx < contactsMsg.contact_size();
+         ++contactIdx) {
+        contacts.push_back(
+            fromIgnitionContactMsgs(ecm, contactsMsg.contact(contactIdx)));
     }
 
     return contacts;

--- a/tests/test_scenario/test_contacts.py
+++ b/tests/test_scenario/test_contacts.py
@@ -1,0 +1,226 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import pytest
+pytestmark = pytest.mark.scenario
+
+import numpy as np
+from ..common import utils
+import gym_ignition_models
+from typing import Callable
+from gym_ignition.utils import misc
+from ..common.utils import gazebo_fixture as gazebo
+from gym_ignition import scenario_bindings as bindings
+
+
+def get_cube_urdf_string_double_collision() -> str:
+
+    mass = 5.0
+    edge = 0.2
+    i = 1 / 12 * mass * (edge ** 2 + edge ** 2)
+    cube_urdf = f"""
+    <robot name="cube_robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+        <link name="cube">
+            <inertial>
+              <origin rpy="0 0 0" xyz="0 0 0"/>
+              <mass value="{mass}"/>
+              <inertia ixx="{i}" ixy="0" ixz="0" iyy="{i}" iyz="0" izz="{i}"/>
+            </inertial>
+            <visual>
+              <geometry>
+                <box size="{edge} {edge} {edge}"/>
+              </geometry>
+              <origin rpy="0 0 0" xyz="0 0 0"/>
+            </visual>
+            <collision>
+              <geometry>
+                <box size="{edge} {edge / 2} {edge}"/>
+              </geometry>
+              <origin rpy="0 0 0" xyz="0 -{edge / 4} 0"/>
+            </collision>
+            <collision>
+              <geometry>
+                <box size="{edge} {edge / 2} {edge}"/>
+              </geometry>
+              <origin rpy="0 0 0" xyz="0 {edge / 4} 0"/>
+            </collision>
+        </link>
+    </robot>"""
+
+    return cube_urdf
+
+
+@pytest.mark.parametrize("gazebo, get_model_str",
+                         [((0.001, 1.0, 1), utils.get_cube_urdf_string),
+                          ((0.001, 1.0, 1), get_cube_urdf_string_double_collision)],
+                         indirect=["gazebo"],
+                         ids=utils.id_gazebo_fn)
+def test_cube_contact(gazebo: bindings.GazeboSimulator,
+                      get_model_str: Callable):
+
+    assert gazebo.initialize()
+    world = gazebo.getWorld()
+
+    # Insert the Physics system
+    assert world.insertWorldPlugin("libPhysicsSystem.so",
+                                   "scenario::plugins::gazebo::Physics")
+
+    # Insert the ground plane
+    assert world.insertModel(gym_ignition_models.get_model_file("ground_plane"))
+    assert len(world.modelNames()) == 1
+
+    # Insert the cube
+    cube_urdf = misc.string_to_file(get_model_str())
+    assert world.insertModel(cube_urdf,
+                             bindings.Pose([0, 0, 0.15], [1., 0, 0, 0]),
+                             "cube")
+    assert len(world.modelNames()) == 2
+
+    # Get the cube
+    cube = world.getModel("cube")
+
+    # Enable contact detection
+    assert not cube.contactsEnabled()
+    assert cube.enableContacts()
+    assert cube.contactsEnabled()
+
+    # The cube was inserted floating in the air with a 5cm gap wrt to ground.
+    # There should be no contacts.
+    gazebo.run(paused=True)
+    assert not cube.getLink("cube").inContact()
+    assert len(cube.contacts()) == 0
+
+    # Make the cube fall for 150ms
+    for _ in range(150):
+        gazebo.run()
+
+    # There should be only one contact, between ground and the cube
+    assert cube.getLink("cube").inContact()
+    assert len(cube.contacts()) == 1
+
+    # Get the contact
+    contact_with_ground = cube.contacts()[0]
+
+    assert contact_with_ground.bodyA == "cube::cube"
+    assert contact_with_ground.bodyB == "ground_plane::link"
+
+    # Check contact points
+    for point in contact_with_ground.points:
+
+        assert point.normal == pytest.approx([0, 0, 1])
+
+    # Check that the contact force matches the weight of the cube
+    z_forces = [point.force[2] for point in contact_with_ground.points]
+    assert np.sum(z_forces) == pytest.approx(50, abs=1.0)
+
+    # Forces of all contact points are combined by the following method
+    assert cube.getLink("cube").contactWrench() == pytest.approx([0, 0, np.sum(z_forces),
+                                                                  0, 0, 0])
+
+
+@pytest.mark.parametrize("gazebo, get_model_str",
+                         [((0.001, 1.0, 1), utils.get_cube_urdf_string),
+                          ((0.001, 1.0, 1), get_cube_urdf_string_double_collision)],
+                         indirect=["gazebo"],
+                         ids=utils.id_gazebo_fn)
+def test_cube_multiple_contacts(gazebo: bindings.GazeboSimulator,
+                                get_model_str: Callable):
+
+    assert gazebo.initialize()
+    world = gazebo.getWorld()
+
+    # Insert the Physics system
+    assert world.insertWorldPlugin("libPhysicsSystem.so",
+                                   "scenario::plugins::gazebo::Physics")
+
+    # Insert the ground plane
+    assert world.insertModel(gym_ignition_models.get_model_file("ground_plane"))
+    assert len(world.modelNames()) == 1
+
+    # Insert two cubes side to side with a 10cm gap
+    cube_urdf = misc.string_to_file(get_model_str())
+    assert world.insertModel(cube_urdf,
+                             bindings.Pose([0, -0.15, 0.101], [1., 0, 0, 0]),
+                             "cube1")
+    assert world.insertModel(cube_urdf,
+                             bindings.Pose([0, 0.15, 0.101], [1., 0, 0, 0]),
+                             "cube2")
+    assert len(world.modelNames()) == 3
+
+    # Get the cubes
+    cube1 = world.getModel("cube1")
+    cube2 = world.getModel("cube2")
+
+    # Enable contact detection
+    assert cube1.enableContacts()
+    assert cube2.enableContacts()
+
+    # The cubes were inserted floating in the air with a 1mm gap wrt to ground.
+    # There should be no contacts.
+    gazebo.run(paused=True)
+    assert not cube1.getLink("cube").inContact()
+    assert not cube2.getLink("cube").inContact()
+    assert len(cube1.contacts()) == 0
+    assert len(cube2.contacts()) == 0
+
+    # Make the cubes fall for 50ms
+    for _ in range(50):
+        gazebo.run()
+
+    assert cube1.getLink("cube").inContact()
+    assert cube2.getLink("cube").inContact()
+    assert len(cube1.contacts()) == 1
+    assert len(cube2.contacts()) == 1
+
+    # Now we make another cube fall above the gap. It will touch both cubes.
+    assert world.insertModel(cube_urdf,
+                             bindings.Pose([0, 0, 0.301], [1., 0, 0, 0]),
+                             "cube3")
+    assert len(world.modelNames()) == 4
+
+    cube3 = world.getModel("cube3")
+    assert cube3.enableContacts()
+
+    gazebo.run(paused=True)
+    assert not cube3.getLink("cube").inContact()
+    assert len(cube3.contacts()) == 0
+
+    # Make the cube fall for 50ms
+    for _ in range(50):
+        gazebo.run()
+
+    # There will be two contacts, respectively with cube1 and cube2.
+    # Contacts are related to the link, not the collision elements. In the case of two
+    # collisions elements associated to the same link, contacts are merged together.
+    assert cube3.getLink("cube").inContact()
+    assert len(cube3.contacts()) == 2
+
+    contact1 = cube3.contacts()[0]
+    contact2 = cube3.contacts()[1]
+
+    assert contact1.bodyA == "cube3::cube"
+    assert contact2.bodyA == "cube3::cube"
+
+    assert contact1.bodyB == "cube1::cube"
+    assert contact2.bodyB == "cube2::cube"
+
+    # Calculate the total contact wrench of cube3
+    assert cube3.getLink("cube").contactWrench() == pytest.approx([0, 0, 50, 0, 0, 0],
+                                                                  abs=1.1)
+
+    # Calculate the total contact force of the cubes below.
+    # They will have 1.5 their weight from below and -0.5 from above.
+    assert cube1.getLink("cube").contactWrench()[2] == pytest.approx(50, abs=1.1)
+    assert cube1.getLink("cube").contactWrench()[2] == pytest.approx(50, abs=1.1)
+
+    # Check the normals and the sign of the forces
+    for contact in cube2.contacts():
+        if contact.bodyB == "cube3::cube":
+            for point in contact.points:
+                assert point.force[2] < 0
+                assert point.normal == pytest.approx([0, 0, -1], abs=0.001)
+        if contact.bodyB == "ground_plane::link":
+            for point in contact.points:
+                assert point.force[2] > 0
+                assert point.normal == pytest.approx([0, 0, 1], abs=0.001)


### PR DESCRIPTION
This PR shows how https://github.com/ignitionrobotics/ign-physics/pull/40 could be used to extract data provided by the DART ign-physics plugin.

Still in WIP state waiting to receive feedback from upstream.