### PR TITLE
Update link / base velocities and accelerations

### DIFF
--- a/cpp/scenario/gazebo/include/scenario/gazebo/Model.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/Model.h
@@ -27,6 +27,8 @@
 #ifndef SCENARIO_GAZEBO_MODEL_H
 #define SCENARIO_GAZEBO_MODEL_H
 
+#include "scenario/gazebo/Joint.h"
+
 #include <ignition/gazebo/Entity.hh>
 #include <ignition/gazebo/EntityComponentManager.hh>
 #include <ignition/gazebo/EventManager.hh>
@@ -39,11 +41,9 @@
 namespace scenario {
     namespace base {
         struct ContactData;
-        enum class JointControlMode;
     } // namespace base
     namespace gazebo {
         class Link;
-        class Joint;
         class Model;
         using LinkPtr = std::shared_ptr<Link>;
         using JointPtr = std::shared_ptr<Joint>;
@@ -123,6 +123,9 @@ public:
     std::vector<double> jointPositions( //
         const std::vector<std::string>& jointNames = {}) const;
     std::vector<double> jointVelocities( //
+        const std::vector<std::string>& jointNames = {}) const;
+
+    base::JointLimit jointLimits( //
         const std::vector<std::string>& jointNames = {}) const;
 
     bool setJointControlMode(const base::JointControlMode mode,

--- a/cpp/scenario/gazebo/include/scenario/gazebo/Model.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/Model.h
@@ -178,15 +178,18 @@ public:
 
     std::array<double, 3> basePosition() const;
     std::array<double, 4> baseOrientation() const;
-    std::array<double, 3> baseLinearVelocity() const;
-    std::array<double, 3> baseAngularVelocity() const;
+    std::array<double, 3> baseBodyLinearVelocity() const;
+    std::array<double, 3> baseBodyAngularVelocity() const;
+    std::array<double, 3> baseWorldLinearVelocity() const;
+    std::array<double, 3> baseWorldAngularVelocity() const;
 
-    bool
-    resetBaseLinearVelocity(const std::array<double, 3>& linear = {0, 0, 0});
-    bool
-    resetBaseAngularVelocity(const std::array<double, 3>& angular = {0, 0, 0});
-    bool resetBaseVelocity(const std::array<double, 3>& linear = {0, 0, 0},
-                           const std::array<double, 3>& angular = {0, 0, 0});
+    bool resetBaseWorldLinearVelocity(
+        const std::array<double, 3>& linear = {0, 0, 0});
+    bool resetBaseWorldAngularVelocity(
+        const std::array<double, 3>& angular = {0, 0, 0});
+    bool resetBaseWorldVelocity( //
+        const std::array<double, 3>& linear = {0, 0, 0},
+        const std::array<double, 3>& angular = {0, 0, 0});
 
     bool resetBasePose(const std::array<double, 3>& position = {0, 0, 0},
                        const std::array<double, 4>& orientation = {0, 0, 0, 0});
@@ -203,19 +206,22 @@ public:
     bool setBasePositionTarget(const std::array<double, 3>& position);
     bool setBaseOrientationTarget(const std::array<double, 4>& orientation);
 
-    bool setBaseVelocityTarget(const std::array<double, 3>& linear,
-                               const std::array<double, 3>& angular);
-    bool setBaseLinearVelocityTarget(const std::array<double, 3>& linear);
-    bool setBaseAngularVelocityTarget(const std::array<double, 3>& angular);
-    bool setBaseLinearAccelerationTarget(const std::array<double, 3>& linear);
-    bool setBaseAngularAccelerationTarget(const std::array<double, 3>& angular);
+    bool setBaseWorldVelocityTarget(const std::array<double, 3>& linear,
+                                    const std::array<double, 3>& angular);
+    bool setBaseWorldLinearVelocityTarget(const std::array<double, 3>& linear);
+    bool setBaseWorldAngularVelocityTarget( //
+        const std::array<double, 3>& angular);
+    bool setBaseWorldLinearAccelerationTarget( //
+        const std::array<double, 3>& linear);
+    bool setBaseWorldAngularAccelerationTarget( //
+        const std::array<double, 3>& angular);
 
     std::array<double, 3> basePositionTarget() const;
     std::array<double, 4> baseOrientationTarget() const;
-    std::array<double, 3> baseLinearVelocityTarget() const;
-    std::array<double, 3> baseAngularVelocityTarget() const;
-    std::array<double, 3> baseLinearAccelerationTarget() const;
-    std::array<double, 3> baseAngularAccelerationTarget() const;
+    std::array<double, 3> baseWorldLinearVelocityTarget() const;
+    std::array<double, 3> baseWorldAngularVelocityTarget() const;
+    std::array<double, 3> baseWorldLinearAccelerationTarget() const;
+    std::array<double, 3> baseWorldAngularAccelerationTarget() const;
 
 private:
     class Impl;

--- a/cpp/scenario/gazebo/src/Link.cpp
+++ b/cpp/scenario/gazebo/src/Link.cpp
@@ -255,8 +255,8 @@ std::array<double, 3> Link::worldAngularVelocity() const
 std::array<double, 3> Link::bodyLinearVelocity() const
 {
     auto linkBodyLinVel = utils::getComponentData< //
-        ignition::gazebo::components::AngularAcceleration>(pImpl->ecm,
-                                                           pImpl->linkEntity);
+        ignition::gazebo::components::LinearVelocity>(pImpl->ecm,
+                                                      pImpl->linkEntity);
 
     return utils::fromIgnitionVector(linkBodyLinVel);
 }
@@ -264,8 +264,8 @@ std::array<double, 3> Link::bodyLinearVelocity() const
 std::array<double, 3> Link::bodyAngularVelocity() const
 {
     auto linkBodyAngVel = utils::getComponentData< //
-        ignition::gazebo::components::AngularAcceleration>(pImpl->ecm,
-                                                           pImpl->linkEntity);
+        ignition::gazebo::components::AngularVelocity>(pImpl->ecm,
+                                                       pImpl->linkEntity);
 
     return utils::fromIgnitionVector(linkBodyAngVel);
 }

--- a/cpp/scenario/gazebo/src/Model.cpp
+++ b/cpp/scenario/gazebo/src/Model.cpp
@@ -525,6 +525,27 @@ Model::jointVelocities(const std::vector<std::string>& jointNames) const
     return Impl::getJointDataSerialized(this, jointNames, lambda);
 }
 
+scenario::base::JointLimit
+Model::jointLimits(const std::vector<std::string>& jointNames) const
+{
+    const std::vector<std::string> jointSerialization =
+        jointNames.empty() ? this->jointNames() : jointNames;
+
+    std::vector<double> low;
+    std::vector<double> high;
+
+    low.reserve(jointSerialization.size());
+    high.reserve(jointSerialization.size());
+
+    for (const auto& joint : this->joints(jointSerialization)) {
+        auto limit = joint->jointPositionLimit();
+        std::move(limit.min.begin(), limit.min.end(), std::back_inserter(low));
+        std::move(limit.max.begin(), limit.max.end(), std::back_inserter(high));
+    }
+
+    return base::JointLimit(low, high);
+}
+
 bool Model::setJointControlMode(const scenario::base::JointControlMode mode,
                                 const std::vector<std::string>& jointNames)
 {

--- a/cpp/scenario/gazebo/src/Model.cpp
+++ b/cpp/scenario/gazebo/src/Model.cpp
@@ -753,7 +753,33 @@ std::array<double, 4> Model::baseOrientation() const
     return utils::fromIgnitionPose(world_H_model).orientation;
 }
 
-std::array<double, 3> Model::baseLinearVelocity() const
+std::array<double, 3> Model::baseBodyLinearVelocity() const
+{
+    auto baseWorldLinearVelocity =
+        utils::toIgnitionVector3(this->baseWorldLinearVelocity());
+
+    // Get the model pose
+    ignition::math::Pose3d world_H_model = utils::getExistingComponentData< //
+        ignition::gazebo::components::Pose>(pImpl->ecm, pImpl->modelEntity);
+
+    return utils::fromIgnitionVector( //
+        world_H_model.Inverse().Rot() * baseWorldLinearVelocity);
+}
+
+std::array<double, 3> Model::baseBodyAngularVelocity() const
+{
+    auto baseWorldAngularVelocity =
+        utils::toIgnitionVector3(this->baseWorldAngularVelocity());
+
+    // Get the model pose
+    ignition::math::Pose3d world_H_model = utils::getExistingComponentData< //
+        ignition::gazebo::components::Pose>(pImpl->ecm, pImpl->modelEntity);
+
+    return utils::fromIgnitionVector( //
+        world_H_model.Inverse().Rot() * baseWorldAngularVelocity);
+}
+
+std::array<double, 3> Model::baseWorldLinearVelocity() const
 {
     // Get the entity of the canonical link
     auto canonicalLinkEntity = pImpl->ecm->EntityByComponents(
@@ -792,7 +818,7 @@ std::array<double, 3> Model::baseLinearVelocity() const
     return utils::fromIgnitionVector(modelLinearVelocity);
 }
 
-std::array<double, 3> Model::baseAngularVelocity() const
+std::array<double, 3> Model::baseWorldAngularVelocity() const
 {
     // We could use the helper to convert the base link velocity to the model
     // mixed velocity. However, since there's only a rigid transformation
@@ -853,18 +879,20 @@ bool Model::resetBaseOrientation(const std::array<double, 4>& orientation)
     return this->resetBasePose(this->basePosition(), orientation);
 }
 
-bool Model::resetBaseLinearVelocity(const std::array<double, 3>& linear)
+bool Model::resetBaseWorldLinearVelocity(const std::array<double, 3>& linear)
 {
-    return this->resetBaseVelocity(linear, this->baseAngularVelocity());
+    return this->resetBaseWorldVelocity(linear,
+                                        this->baseWorldAngularVelocity());
 }
 
-bool Model::resetBaseAngularVelocity(const std::array<double, 3>& angular)
+bool Model::resetBaseWorldAngularVelocity(const std::array<double, 3>& angular)
 {
-    return this->resetBaseVelocity(this->baseLinearVelocity(), angular);
+    return this->resetBaseWorldVelocity(this->baseWorldLinearVelocity(),
+                                        angular);
 }
 
-bool Model::resetBaseVelocity(const std::array<double, 3>& linear,
-                              const std::array<double, 3>& angular)
+bool Model::resetBaseWorldVelocity(const std::array<double, 3>& linear,
+                                   const std::array<double, 3>& angular)
 {
     // Get the entity of the canonical (base) link
     auto canonicalLinkEntity = pImpl->ecm->EntityByComponents(
@@ -944,16 +972,17 @@ bool Model::setBaseOrientationTarget(const std::array<double, 4>& orientation)
     return true;
 }
 
-bool Model::setBaseVelocityTarget(const std::array<double, 3>& linear,
-                                  const std::array<double, 3>& angular)
+bool Model::setBaseWorldVelocityTarget(const std::array<double, 3>& linear,
+                                       const std::array<double, 3>& angular)
 {
     // TODO: the velocity target is not used by Gazebo.
     //       Should we compute the base velocity from the inputs?
-    return this->setBaseLinearVelocityTarget(linear)
-           && this->setBaseAngularVelocityTarget(angular);
+    return this->setBaseWorldLinearVelocityTarget(linear)
+           && this->setBaseWorldAngularVelocityTarget(angular);
 }
 
-bool Model::setBaseLinearVelocityTarget(const std::array<double, 3>& linear)
+bool Model::setBaseWorldLinearVelocityTarget(
+    const std::array<double, 3>& linear)
 {
     ignition::math::Vector3d baseWorldLinearVelocity =
         utils::toIgnitionVector3(linear);
@@ -965,7 +994,8 @@ bool Model::setBaseLinearVelocityTarget(const std::array<double, 3>& linear)
     return true;
 }
 
-bool Model::setBaseAngularVelocityTarget(const std::array<double, 3>& angular)
+bool Model::setBaseWorldAngularVelocityTarget(
+    const std::array<double, 3>& angular)
 {
     ignition::math::Vector3d baseWorldAngularVelocity =
         utils::toIgnitionVector3(angular);
@@ -977,7 +1007,8 @@ bool Model::setBaseAngularVelocityTarget(const std::array<double, 3>& angular)
     return true;
 }
 
-bool Model::setBaseLinearAccelerationTarget(const std::array<double, 3>& linear)
+bool Model::setBaseWorldLinearAccelerationTarget(
+    const std::array<double, 3>& linear)
 {
     ignition::math::Vector3d baseWorldLinearAcceleration =
         utils::toIgnitionVector3(linear);
@@ -993,7 +1024,7 @@ bool Model::setBaseLinearAccelerationTarget(const std::array<double, 3>& linear)
     return true;
 }
 
-bool Model::setBaseAngularAccelerationTarget(
+bool Model::setBaseWorldAngularAccelerationTarget(
     const std::array<double, 3>& angular)
 {
     ignition::math::Vector3d baseWorldAngularAcceleration =
@@ -1024,7 +1055,7 @@ std::array<double, 4> Model::baseOrientationTarget() const
     return utils::fromIgnitionPose(basePoseTarget).orientation;
 }
 
-std::array<double, 3> Model::baseLinearVelocityTarget() const
+std::array<double, 3> Model::baseWorldLinearVelocityTarget() const
 {
     ignition::math::Vector3d& baseLinTarget = utils::getExistingComponentData<
         ignition::gazebo::components::BaseWorldLinearVelocityTarget>(
@@ -1033,7 +1064,7 @@ std::array<double, 3> Model::baseLinearVelocityTarget() const
     return utils::fromIgnitionVector(baseLinTarget);
 }
 
-std::array<double, 3> Model::baseAngularVelocityTarget() const
+std::array<double, 3> Model::baseWorldAngularVelocityTarget() const
 {
     ignition::math::Vector3d& baseAngTarget = utils::getExistingComponentData<
         ignition::gazebo::components::BaseWorldAngularVelocityTarget>(
@@ -1042,7 +1073,7 @@ std::array<double, 3> Model::baseAngularVelocityTarget() const
     return utils::fromIgnitionVector(baseAngTarget);
 }
 
-std::array<double, 3> Model::baseLinearAccelerationTarget() const
+std::array<double, 3> Model::baseWorldLinearAccelerationTarget() const
 {
     ignition::math::Vector3d& baseLinTarget = utils::getExistingComponentData<
         ignition::gazebo::components::BaseWorldLinearAccelerationTarget>(
@@ -1051,7 +1082,7 @@ std::array<double, 3> Model::baseLinearAccelerationTarget() const
     return utils::fromIgnitionVector(baseLinTarget);
 }
 
-std::array<double, 3> Model::baseAngularAccelerationTarget() const
+std::array<double, 3> Model::baseWorldAngularAccelerationTarget() const
 {
     ignition::math::Vector3d& baseAngTarget = utils::getExistingComponentData<
         ignition::gazebo::components::BaseWorldAngularAccelerationTarget>(

--- a/python/gym_ignition/utils/scenario.py
+++ b/python/gym_ignition/utils/scenario.py
@@ -2,8 +2,10 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
-from typing import Tuple
+import gym.spaces
+import numpy as np
 import gym_ignition_models
+from typing import List, Tuple
 from gym_ignition import scenario_bindings as bindings
 
 
@@ -100,3 +102,30 @@ def init_gazebo_sim(step_size: float = 0.001,
         raise RuntimeError("Failed to insert the physics plugin")
 
     return gazebo, world
+
+
+def get_joint_positions_space(model: bindings.Model,
+                              considered_joints: List[str] = None) -> gym.spaces.Box:
+    """
+    Build a Box space from the joint position limits.
+
+    Args:
+        model: The model from which generating the joint space.
+        considered_joints: List of considered joints. It is helpful to restrict the set
+            of joints and to enforce a custom joint serialization.
+
+    Returns:
+        A box space created from the model's joint position limits.
+    """
+
+    if considered_joints is None:
+        considered_joints = model.jointNames()
+
+    # Get the joint limits
+    joint_limits = model.jointLimits(considered_joints)
+
+    # Build the space
+    space = gym.spaces.Box(low=np.array(joint_limits.min),
+                           high=np.array(joint_limits.max))
+
+    return space

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -4,6 +4,7 @@
 
 import pytest
 from typing import Tuple
+import gym_ignition_models
 from gym_ignition.utils import misc
 from gym_ignition import scenario_bindings as bindings
 
@@ -43,6 +44,26 @@ def gazebo_fixture(request):
     gazebo = bindings.GazeboSimulator(step_size, rtf, iterations)
 
     yield gazebo
+
+    gazebo.close()
+
+
+@pytest.fixture(scope="function")
+def default_world_fixture(request):
+    """
+    """
+
+    step_size, rtf, iterations = request.param
+    gazebo = bindings.GazeboSimulator(step_size, rtf, iterations)
+
+    assert gazebo.initialize()
+
+    world = gazebo.getWorld()
+    assert world.insertModel(gym_ignition_models.get_model_file("ground_plane"))
+    assert world.insertWorldPlugin("libPhysicsSystem.so",
+                                   "scenario::plugins::gazebo::Physics")
+
+    yield gazebo, world
 
     gazebo.close()
 

--- a/tests/test_scenario/test_link_velocities.py
+++ b/tests/test_scenario/test_link_velocities.py
@@ -1,0 +1,314 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import pytest
+pytestmark = pytest.mark.scenario
+
+import numpy as np
+from ..common import utils
+import gym_ignition_models
+from typing import Callable, List, Tuple
+from scipy.spatial.transform import Rotation
+from gym_ignition import scenario_bindings as bindings
+from ..common.utils import default_world_fixture as default_world
+from gym_ignition.utils.scenario import get_joint_positions_space
+
+
+def to_wxyz(xyzw: np.ndarray) -> np.ndarray:
+
+    if xyzw.shape != (4,):
+        raise ValueError(xyzw)
+
+    return xyzw[[3, 0, 1, 2]]
+
+
+def to_xyzw(wxyz: np.ndarray) -> np.ndarray:
+
+    if wxyz.shape != (4,):
+        raise ValueError(wxyz)
+
+    return wxyz[[1, 2, 3, 0]]
+
+
+def to_matrix(quaternion: List[float]) -> np.ndarray:
+
+    quaternion_xyzw = to_xyzw(np.array(quaternion))
+    return Rotation.from_quat(quaternion_xyzw).as_matrix()
+
+
+def get_random_panda(gazebo: bindings.GazeboSimulator,
+                     world: bindings.World) -> bindings.Model:
+
+    panda_urdf = gym_ignition_models.get_model_file("panda")
+    assert world.insertModel(panda_urdf)
+    assert "panda" in world.modelNames()
+
+    panda = world.getModel("panda")
+
+    joint_space = get_joint_positions_space(model=panda)
+    joint_space.seed(10)
+
+    q = joint_space.sample()
+    dq = joint_space.np_random.uniform(low=-1.0, high=1.0, size=q.shape)
+
+    assert panda.resetJointPositions(q.tolist())
+    assert panda.resetJointVelocities(dq.tolist())
+
+    assert gazebo.run(paused=True)
+    return panda
+
+
+def get_cube(gazebo: bindings.GazeboSimulator,
+             world: bindings.World) -> bindings.Model:
+
+    quaternion = to_wxyz(Rotation.from_euler('x', 45, degrees=True).as_quat())
+    initial_pose = bindings.Pose([0, 0, 0.5], quaternion.tolist())
+
+    cube_urdf = utils.get_cube_urdf()
+    assert world.insertModel(cube_urdf, initial_pose)
+    assert "cube_robot" in world.modelNames()
+
+    cube = world.getModel("cube_robot")
+
+    assert cube.resetBaseWorldLinearVelocity([0.1, -0.2, -0.3])
+    assert cube.resetBaseWorldAngularVelocity([-0.1, 2.0, 0.3])
+
+    assert gazebo.run(paused=True)
+    return cube
+
+
+# 1. VELOCITY LINEAR
+@pytest.mark.parametrize("default_world, get_model, link_name", [
+                          ((1.0 / 10_000, 1.0, 1), get_random_panda, "panda_link7"),
+                          ((1.0 / 10_000, 1.0, 1), get_cube, "cube"),
+                          ],
+                         indirect=["default_world"])
+def test_linear_velocity(
+        default_world: Tuple[bindings.GazeboSimulator, bindings.World],
+        get_model: Callable[[bindings.GazeboSimulator, bindings.World], bindings.Model],
+        link_name: str):
+
+    # Get the simulator and the world
+    gazebo, world = default_world
+    dt = gazebo.stepSize()
+
+    # Get the model
+    model = get_model(gazebo, world)
+
+    # Get the link.
+    # If the link is the base link, get the data through the base methods.
+    link = model.getLink(link_name)
+
+    if link.name() != model.baseFrame():
+
+        position = link.position
+        orientation = link.orientation
+        bodyLinearVelocity = link.bodyLinearVelocity
+        worldLinearVelocity = link.worldLinearVelocity
+
+    else:
+
+        position = model.basePosition
+        orientation = model.baseOrientation
+        bodyLinearVelocity = model.baseBodyLinearVelocity
+        worldLinearVelocity = model.baseWorldLinearVelocity
+
+    # 0.5 seconds of simulation
+    for _ in range(int(0.5 / dt)):
+
+        position_old = np.array(position())
+        assert gazebo.run()
+        position_new = np.array(position())
+
+        world_velocity = (position_new - position_old) / dt
+
+        # Test the world velocity (MIXED)
+        assert world_velocity == pytest.approx(worldLinearVelocity(), abs=1E-2)
+
+        # Eq 18
+        # Test the BODY velocity
+        W_R_L = to_matrix(orientation())
+        body_velocity = W_R_L.transpose() @ np.array(worldLinearVelocity())
+        assert body_velocity == pytest.approx(bodyLinearVelocity())
+
+    gazebo.close()
+
+
+# 2. VELOCITY ANGULAR
+@pytest.mark.parametrize("default_world, get_model, link_name", [
+                          ((1.0 / 10_000, 1.0, 1), get_random_panda, "panda_link7"),
+                          ((1.0 / 10_000, 1.0, 1), get_cube, "cube"),
+                          ],
+                         indirect=["default_world"])
+def test_angular_velocity(
+        default_world: Tuple[bindings.GazeboSimulator, bindings.World],
+        get_model: Callable[[bindings.GazeboSimulator, bindings.World], bindings.Model],
+        link_name: str):
+
+    # Get the simulator and the world
+    gazebo, world = default_world
+    dt = gazebo.stepSize()
+
+    # Get the model
+    model = get_model(gazebo, world)
+
+    # Get the link.
+    # If the link is the base link, get the data through the base methods.
+    link = model.getLink(link_name)
+
+    if link.name() != model.baseFrame():
+
+        orientation = link.orientation
+        bodyAngularVelocity = link.bodyAngularVelocity
+        worldAngularVelocity = link.worldAngularVelocity
+
+    else:
+
+        orientation = model.baseOrientation
+        bodyAngularVelocity = model.baseBodyAngularVelocity
+        worldAngularVelocity = model.baseWorldAngularVelocity
+
+    skew = lambda matrix: (matrix - matrix.transpose()) / 2
+    vee = lambda matrix: [matrix[2, 1], matrix[0,2], matrix[1, 0]]
+
+    for _ in range(int(0.5 / dt)):
+
+        W_R_L_old = to_matrix(orientation())
+        assert gazebo.run()
+        W_R_L_new = to_matrix(orientation())
+
+        dot_rotation_matrix = (W_R_L_new - W_R_L_old) / dt
+        world_velocity = dot_rotation_matrix @ W_R_L_new.transpose()
+
+        # Test the world velocity (MIXED)
+        assert vee(skew(world_velocity)) == pytest.approx(worldAngularVelocity(),
+                                                          abs=0.005)
+
+        # Test the BODY velocity
+        body_velocity = W_R_L_new.transpose() @ dot_rotation_matrix
+        assert vee(skew(body_velocity)) == pytest.approx(bodyAngularVelocity(),
+                                                         abs=0.005)
+
+
+# 3. ACCELERATION LINEAR
+@pytest.mark.parametrize("default_world, get_model, link_name", [
+                          ((1.0 / 10_000, 1.0, 1), get_random_panda, "panda_link7"),
+                          # ((1.0 / 10_000, 1.0, 1), get_cube, "cube"),  # TODO
+                          ],
+                         indirect=["default_world"])
+def test_linear_acceleration(
+        default_world: Tuple[bindings.GazeboSimulator, bindings.World],
+        get_model: Callable[[bindings.GazeboSimulator, bindings.World], bindings.Model],
+        link_name: str):
+
+    # Get the simulator and the world
+    gazebo, world = default_world
+    dt = gazebo.stepSize()
+
+    # Get the model
+    model = get_model(gazebo, world)
+
+    # Get the link.
+    # If the link is the base link, get the data through the base methods.
+    link = model.getLink(link_name)
+
+    if link.name() != model.baseFrame():
+
+        orientation = link.orientation
+        worldLinearVelocity = link.worldLinearVelocity
+        bodyLinearAcceleration = link.bodyLinearAcceleration
+        worldLinearAcceleration = link.worldLinearAcceleration
+
+    else:
+
+        orientation = model.baseOrientation
+        worldLinearVelocity = model.baseWorldLinearVelocity
+        bodyLinearAcceleration = model.baseBodyLinearAcceleration
+        worldLinearAcceleration = model.baseWordLinearAcceleration
+
+    # 0.5 seconds of simulation
+    for _ in range(int(0.5 / dt)):
+
+        velocity_old = np.array(worldLinearVelocity())
+        assert gazebo.run()
+        velocity_new = np.array(worldLinearVelocity())
+
+        world_acceleration = (velocity_new - velocity_old) / dt
+
+        # By time to time there are steps where the acceleration becomes extremely high,
+        # like 1000 m/s/s when the average is never exceeds 4 m/s/s.
+        # We exclude those points. We should understand why this happens.
+        if (np.array(worldLinearAcceleration()) > 100.0).any():
+            continue
+
+        # Test the world acceleration (MIXED)
+        assert worldLinearAcceleration() == pytest.approx(world_acceleration, abs=0.5)
+
+        # Test the BODY acceleration
+        # Note: https://github.com/ignitionrobotics/ign-gazebo/issues/87
+        W_R_L = to_matrix(orientation())
+        body_acceleration = W_R_L.transpose() @ np.array(worldLinearAcceleration())
+        assert body_acceleration == pytest.approx(bodyLinearAcceleration())
+
+    gazebo.close()
+
+
+# 2. ACCELERATION ANGULAR
+@pytest.mark.parametrize("default_world, get_model, link_name", [
+                          ((1.0 / 10_000, 1.0, 1), get_random_panda, "panda_link7"),
+                          # ((1.0 / 10_000, 1.0, 1), get_cube, "cube"),  # TODO
+                          ],
+                         indirect=["default_world"])
+def test_angular_acceleration(
+        default_world: Tuple[bindings.GazeboSimulator, bindings.World],
+        get_model: Callable[[bindings.GazeboSimulator, bindings.World], bindings.Model],
+        link_name: str):
+
+    # Get the simulator and the world
+    gazebo, world = default_world
+    dt = gazebo.stepSize()
+
+    # Get the model
+    model = get_model(gazebo, world)
+
+    # Get the link.
+    # If the link is the base link, get the data through the base methods.
+    link = model.getLink(link_name)
+
+    if link.name() != model.baseFrame():
+
+        orientation = link.orientation
+        worldAngularVelocity = link.worldAngularVelocity
+        bodyAngularAcceleration = link.bodyAngularAcceleration
+        worldAngularAcceleration = link.worldAngularAcceleration
+
+    else:
+
+        orientation = model.baseOrientation
+        worldAngularVelocity = model.baseWorldAngularVelocity
+        bodyAngularAcceleration = model.baseBodyAngularAcceleration
+        worldAngularAcceleration = model.baseWordAngularAcceleration
+
+    for _ in range(int(0.5 / dt)):
+
+        world_velocity_old = np.array(worldAngularVelocity())
+        assert gazebo.run()
+        world_velocity_new = np.array(worldAngularVelocity())
+
+        world_acceleration = (world_velocity_new - world_velocity_old) / dt
+
+        # By time to time there are steps where the acceleration becomes extremely high,
+        # like 1000 rad/s/s when the average is never exceeds 20 rad/s/s.
+        # We exclude those points. We should understand why this happens.
+        if (np.array(worldAngularAcceleration()) > 100.0).any():
+            continue
+
+        # Test the world acceleration (MIXED)
+        assert world_acceleration == pytest.approx(worldAngularAcceleration(),
+                                                   abs=0.2)
+
+        # Note: https://github.com/ignitionrobotics/ign-gazebo/issues/87
+        W_R_L = to_matrix(orientation())
+        body_acceleration = W_R_L.transpose() @ np.array(worldAngularAcceleration())
+        assert body_acceleration == pytest.approx(bodyAngularAcceleration())

--- a/tests/test_scenario/test_model.py
+++ b/tests/test_scenario/test_model.py
@@ -138,10 +138,10 @@ def test_model_base(gazebo: bindings.GazeboSimulator):
 
     # Reset the linear velocity
     lin_velocity = [0, 0, 5.0]
-    assert model.resetBaseLinearVelocity(lin_velocity)
-    assert model.baseLinearVelocity() == pytest.approx([0, 0, 0])
+    assert model.resetBaseWorldLinearVelocity(lin_velocity)
+    assert model.baseWorldLinearVelocity() == pytest.approx([0, 0, 0])
     gazebo.run()
-    assert model.baseLinearVelocity() == pytest.approx(lin_velocity, abs=0.01)
+    assert model.baseWorldLinearVelocity() == pytest.approx(lin_velocity, abs=0.01)
 
     # The linear velocity of the support must be the same
     assert "support" in model.linkNames()
@@ -150,10 +150,10 @@ def test_model_base(gazebo: bindings.GazeboSimulator):
 
     # Reset the angular velocity
     ang_velocity = [0.1, 0.5, -3.0]
-    assert model.resetBaseAngularVelocity(ang_velocity)
-    assert model.baseAngularVelocity() == pytest.approx([0, 0, 0])
+    assert model.resetBaseWorldAngularVelocity(ang_velocity)
+    assert model.baseWorldAngularVelocity() == pytest.approx([0, 0, 0])
     gazebo.run()
-    assert model.baseAngularVelocity() == pytest.approx(ang_velocity, abs=0.01)
+    assert model.baseWorldAngularVelocity() == pytest.approx(ang_velocity, abs=0.01)
 
     # The angular velocity of the support must be the same
     assert "support" in model.linkNames()
@@ -196,12 +196,12 @@ def test_model_references(gazebo: bindings.GazeboSimulator):
     assert model.basePositionTarget() == pytest.approx([0, 0, 5])
     assert model.baseOrientationTarget() == pytest.approx([0, 0, 1.0, 0])
 
-    assert model.setBaseLinearVelocityTarget([1, 2, 3])
-    assert model.setBaseAngularVelocityTarget([4, 5, 6])
-    assert model.setBaseAngularAccelerationTarget([-1, -2, -3])
-    assert model.baseLinearVelocityTarget() == pytest.approx([1, 2, 3])
-    assert model.baseAngularVelocityTarget() == pytest.approx([4, 5, 6])
-    assert model.baseAngularAccelerationTarget() == pytest.approx([-1, -2, -3])
+    assert model.setBaseWorldLinearVelocityTarget([1, 2, 3])
+    assert model.setBaseWorldAngularVelocityTarget([4, 5, 6])
+    assert model.setBaseWorldAngularAccelerationTarget([-1, -2, -3])
+    assert model.baseWorldLinearVelocityTarget() == pytest.approx([1, 2, 3])
+    assert model.baseWorldAngularVelocityTarget() == pytest.approx([4, 5, 6])
+    assert model.baseWorldAngularAccelerationTarget() == pytest.approx([-1, -2, -3])
 
 
 # def test_model_contacts():


### PR DESCRIPTION
- Fix a copy-and-paste bug ea0d34f 
- Improve the base link APIs clarifying the velocity representation e7b9b1e 
- Get the body base velocity e7b9b1e 
- Add new test that check the link and base APIs for velocity and accelerations against numerically differentiated values 830b30a

Referring to [Multibody Dynamics Notation](https://pure.tue.nl/ws/portalfiles/portal/139293126/A_Multibody_Dynamics_Notation_Revision_2_.pdf), the `World` methods use the _mixed velocity_ representation [Section 5.2] and the `Body` methods the _left trivialized_ representation (body fixed frame) [Section 5].

Related to https://github.com/ignitionrobotics/ign-gazebo/issues/87.