### PR TITLE
Fix history of applied joint forces

### DIFF
--- a/cpp/scenario/gazebo/include/scenario/gazebo/Model.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/Model.h
@@ -86,7 +86,7 @@ public:
 
     bool valid() const;
 
-    size_t dofs() const;
+    size_t dofs(const std::vector<std::string>& jointNames = {}) const;
     std::string name() const;
 
     size_t nrOfLinks() const;

--- a/cpp/scenario/gazebo/include/scenario/gazebo/helpers.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/helpers.h
@@ -75,6 +75,10 @@ namespace scenario::gazebo::utils {
     double steadyClockDurationToDouble(
         const std::chrono::steady_clock::duration duration);
 
+    void rowMajorToColumnMajor(std::vector<double>& input,
+                               const long rows,
+                               const long cols);
+
     class FixedSizeQueue
     {
     public:

--- a/cpp/scenario/gazebo/include/scenario/gazebo/helpers.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/helpers.h
@@ -84,7 +84,7 @@ namespace scenario::gazebo::utils {
     public:
         FixedSizeQueue(const size_t size = 100)
             : m_size(size)
-            , m_deque(100, 0.0)
+            , m_deque(size, 0.0)
         {}
 
         void push(const double value)

--- a/cpp/scenario/gazebo/src/Model.cpp
+++ b/cpp/scenario/gazebo/src/Model.cpp
@@ -285,11 +285,14 @@ bool Model::valid() const
     return pImpl->model.Valid(*pImpl->ecm);
 }
 
-size_t Model::dofs() const
+size_t Model::dofs(const std::vector<std::string>& jointNames) const
 {
+    const std::vector<std::string>& jointSerialization =
+        jointNames.empty() ? this->jointNames() : jointNames;
+
     size_t dofs = 0;
 
-    for (const auto& jointName : jointNames()) {
+    for (const auto& jointName : jointSerialization) {
         dofs += this->getJoint(jointName)->dofs();
     }
 

--- a/cpp/scenario/gazebo/src/Model.cpp
+++ b/cpp/scenario/gazebo/src/Model.cpp
@@ -212,7 +212,7 @@ bool Model::insertModelPlugin(const std::string& libName,
 bool Model::historyOfAppliedJointForcesEnabled(
     const std::vector<std::string>& jointNames) const
 {
-    std::vector<std::string> jointSerialization =
+    const std::vector<std::string>& jointSerialization =
         jointNames.empty() ? this->jointNames() : jointNames;
 
     bool enabled = true;
@@ -229,7 +229,7 @@ bool Model::enableHistoryOfAppliedJointForces(
     const size_t maxHistorySizePerJoint,
     const std::vector<std::string>& jointNames)
 {
-    const std::vector<std::string> jointSerialization =
+    const std::vector<std::string>& jointSerialization =
         jointNames.empty() ? this->jointNames() : jointNames;
 
     bool ok = true;
@@ -246,7 +246,7 @@ bool Model::enableHistoryOfAppliedJointForces(
 std::vector<double> Model::historyOfAppliedJointForces(
     const std::vector<std::string>& jointNames) const
 {
-    const std::vector<std::string> jointSerialization =
+    const std::vector<std::string>& jointSerialization =
         jointNames.empty() ? this->jointNames() : jointNames;
 
     std::vector<double> history;
@@ -510,7 +510,7 @@ std::vector<std::string> Model::linksInContact() const
 std::vector<scenario::base::ContactData>
 Model::contacts(const std::vector<std::string>& linkNames) const
 {
-    std::vector<std::string> linkSerialization =
+    const std::vector<std::string>& linkSerialization =
         linkNames.empty() ? this->linkNames() : linkNames;
 
     std::vector<scenario::base::ContactData> allContacts;
@@ -548,7 +548,7 @@ Model::jointVelocities(const std::vector<std::string>& jointNames) const
 scenario::base::JointLimit
 Model::jointLimits(const std::vector<std::string>& jointNames) const
 {
-    const std::vector<std::string> jointSerialization =
+    const std::vector<std::string>& jointSerialization =
         jointNames.empty() ? this->jointNames() : jointNames;
 
     std::vector<double> low;
@@ -569,7 +569,7 @@ Model::jointLimits(const std::vector<std::string>& jointNames) const
 bool Model::setJointControlMode(const scenario::base::JointControlMode mode,
                                 const std::vector<std::string>& jointNames)
 {
-    std::vector<std::string> jointSerialization =
+    const std::vector<std::string>& jointSerialization =
         jointNames.empty() ? this->jointNames() : jointNames;
 
     bool ok = true;
@@ -584,7 +584,7 @@ bool Model::setJointControlMode(const scenario::base::JointControlMode mode,
 std::vector<LinkPtr>
 Model::links(const std::vector<std::string>& linkNames) const
 {
-    std::vector<std::string> linkSerialization =
+    const std::vector<std::string>& linkSerialization =
         linkNames.empty() ? this->linkNames() : linkNames;
 
     std::vector<LinkPtr> links;
@@ -599,7 +599,7 @@ Model::links(const std::vector<std::string>& linkNames) const
 std::vector<JointPtr>
 Model::joints(const std::vector<std::string>& jointNames) const
 {
-    const std::vector<std::string> jointSerialization =
+    const std::vector<std::string>& jointSerialization =
         jointNames.empty() ? this->jointNames() : jointNames;
 
     std::vector<JointPtr> joints;
@@ -1141,7 +1141,7 @@ std::vector<double> Model::Impl::getJointDataSerialized(
     const std::vector<std::string>& jointNames,
     std::function<double(JointPtr, const size_t)> getJointData)
 {
-    const std::vector<std::string> jointSerialization =
+    const std::vector<std::string>& jointSerialization =
         jointNames.empty() ? model->jointNames() : jointNames;
 
     std::vector<double> data;

--- a/cpp/scenario/gazebo/src/helpers.cpp
+++ b/cpp/scenario/gazebo/src/helpers.cpp
@@ -28,6 +28,7 @@
 #include "ignition/common/Util.hh"
 #include "scenario/gazebo/Log.h"
 
+#include <Eigen/Dense>
 #include <ignition/gazebo/components/Component.hh>
 #include <ignition/gazebo/components/Model.hh>
 #include <ignition/gazebo/components/Name.hh>
@@ -109,6 +110,20 @@ double utils::steadyClockDurationToDouble(
 {
     // This is the value in seconds
     return std::chrono::duration<double>(duration).count();
+}
+
+void utils::rowMajorToColumnMajor(std::vector<double>& input,
+                                  const long rows,
+                                  const long cols)
+{
+    using namespace Eigen;
+    using RowMajorMat = Matrix<double, Dynamic, Dynamic, RowMajor>;
+    using ColMajorMat = Matrix<double, Dynamic, Dynamic, ColMajor>;
+
+    Map<RowMajorMat> rowMajorView(input.data(), rows, cols);
+    Map<ColMajorMat> colMajorView(input.data(), rows, cols);
+
+    colMajorView = rowMajorView.eval();
 }
 
 scenario::base::Pose


### PR DESCRIPTION
Getting the total torques from the model had the wrong serialization. The serialization that is more useful for a model with N joint is to have the last N entries of the history vector containing the joint torques applied in the last simulated run. Before, instead there were the torques over the active window of the last selected joint.

What puzzles me more @traversaro is d4239ea, that handles multi-DoF joints. Would it be correct to sum the torques of the DoFs to get a single value?