### PR TITLE
Add support of setting the physics engine

### DIFF
--- a/cpp/scenario/gazebo/include/scenario/gazebo/World.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/World.h
@@ -42,6 +42,10 @@ namespace scenario {
     namespace gazebo {
         class World;
         class Model;
+        enum class PhysicsEngine
+        {
+            Dart,
+        };
         using ModelPtr = std::shared_ptr<Model>;
         using WorldPtr = std::shared_ptr<World>;
     } // namespace gazebo
@@ -67,6 +71,7 @@ public:
                            const std::string& className,
                            const std::string& context = {});
 
+    bool setPhysicsEngine(const PhysicsEngine engine);
     std::array<double, 3> gravity() const;
     bool setGravity(const std::array<double, 3>& gravity);
 

--- a/cpp/scenario/gazebo/src/World.cpp
+++ b/cpp/scenario/gazebo/src/World.cpp
@@ -147,6 +147,26 @@ bool World::insertWorldPlugin(const std::string& libName,
     return true;
 }
 
+bool World::setPhysicsEngine(const PhysicsEngine engine)
+{
+    std::string libName;
+    std::string className;
+
+    switch (engine) {
+        case PhysicsEngine::Dart:
+            libName = "libPhysicsSystem.so";
+            className = "scenario::plugins::gazebo::Physics";
+            break;
+    }
+
+    if (!this->insertWorldPlugin(libName, className)) {
+        gymppError << "Failed to insert the physics plugin" << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
 std::array<double, 3> World::gravity() const
 {
     auto gravity = utils::getExistingComponentData< //

--- a/python/gym_ignition/randomizers/physics/dart.py
+++ b/python/gym_ignition/randomizers/physics/dart.py
@@ -22,8 +22,7 @@ class DART(physics.PhysicsRandomizer):
     def randomize_physics(self, world: bindings.World) -> None:
 
         # Insert the physics
-        ok_physics = world.insertWorldPlugin("libPhysicsSystem.so",
-                                             "scenario::plugins::gazebo::Physics")
+        ok_physics = world.setPhysicsEngine(bindings.PhysicsEngine_Dart)
 
         if not ok_physics:
             raise RuntimeError("Failed to insert the physics plugin")

--- a/python/gym_ignition/utils/scenario.py
+++ b/python/gym_ignition/utils/scenario.py
@@ -94,9 +94,7 @@ def init_gazebo_sim(step_size: float = 0.001,
     if not ok_ground:
         raise RuntimeError("Failed to insert the ground plane")
 
-    # Insert the physics
-    ok_physics = world.insertWorldPlugin("libPhysicsSystem.so",
-                                         "scenario::plugins::gazebo::Physics")
+    ok_physics = world.setPhysicsEngine(bindings.PhysicsEngine_Dart)
 
     if not ok_physics:
         raise RuntimeError("Failed to insert the physics plugin")

--- a/python/gym_ignition_environments/randomizers/cartpole.py
+++ b/python/gym_ignition_environments/randomizers/cartpole.py
@@ -62,8 +62,7 @@ class CartpoleRandomizersMixin(randomizers.base.task.TaskRandomizer,
 
     def randomize_physics(self, world: bindings.World) -> None:
 
-        ok_physics = world.insertWorldPlugin("libPhysicsSystem.so",
-                                             "scenario::plugins::gazebo::Physics")
+        ok_physics = world.setPhysicsEngine(bindings.PhysicsEngine_Dart)
 
         if not ok_physics:
             raise RuntimeError("Failed to insert the physics plugin")

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -60,8 +60,7 @@ def default_world_fixture(request):
 
     world = gazebo.getWorld()
     assert world.insertModel(gym_ignition_models.get_model_file("ground_plane"))
-    assert world.insertWorldPlugin("libPhysicsSystem.so",
-                                   "scenario::plugins::gazebo::Physics")
+    assert world.setPhysicsEngine(bindings.PhysicsEngine_Dart)
 
     yield gazebo, world
 

--- a/tests/test_scenario/test_custom_controllers.py
+++ b/tests/test_scenario/test_custom_controllers.py
@@ -29,8 +29,7 @@ def test_computed_torque_fixed_base(gazebo: bindings.GazeboSimulator):
     world = gazebo.getWorld()
 
     # Insert the physics
-    assert world.insertWorldPlugin("libPhysicsSystem.so",
-                                   "scenario::plugins::gazebo::Physics")
+    assert world.setPhysicsEngine(bindings.PhysicsEngine_Dart)
 
     # Get the panda urdf
     panda_urdf = gym_ignition_models.get_model_file("panda")
@@ -60,9 +59,9 @@ def test_computed_torque_fixed_base(gazebo: bindings.GazeboSimulator):
         gravity=[0, 0, -9.81])
 
     # Insert the controller
-    panda.insertModelPlugin("libControllerRunner.so",
-                            "scenario::plugins::gazebo::ControllerRunner",
-                            controller_context.to_xml())
+    assert panda.insertModelPlugin("libControllerRunner.so",
+                                   "scenario::plugins::gazebo::ControllerRunner",
+                                   controller_context.to_xml())
 
     # Set the references
     assert panda.setJointPositionTargets([0.0] * panda.dofs())

--- a/tests/test_scenario/test_model.py
+++ b/tests/test_scenario/test_model.py
@@ -23,8 +23,7 @@ def get_model(gazebo: bindings.GazeboSimulator,
     world = gazebo.getWorld()
     # TODO: assert world
 
-    assert world.insertWorldPlugin("libPhysicsSystem.so",
-                                   "scenario::plugins::gazebo::Physics")
+    assert world.setPhysicsEngine(bindings.PhysicsEngine_Dart)
 
     model_urdf = gym_ignition_models.get_model_file(gym_ignition_model_name)
     assert world.insertModel(model_urdf,

--- a/tests/test_scenario/test_world.py
+++ b/tests/test_scenario/test_world.py
@@ -164,8 +164,7 @@ def test_world_physics_plugin(gazebo: bindings.GazeboSimulator):
     assert world.time() == 0
 
     # Insert the Physics system
-    assert world.insertWorldPlugin("libPhysicsSystem.so",
-                                   "scenario::plugins::gazebo::Physics")
+    assert world.setPhysicsEngine(bindings.PhysicsEngine_Dart)
 
     # After the first step, the physics catches up with time
     gazebo.run()
@@ -194,8 +193,7 @@ def test_sim_time_starts_from_zero(gazebo: bindings.GazeboSimulator):
     dt = gazebo.stepSize()
 
     assert world.time() == 0
-    assert world.insertWorldPlugin("libPhysicsSystem.so",
-                                   "scenario::plugins::gazebo::Physics")
+    assert world.setPhysicsEngine(bindings.PhysicsEngine_Dart)
     assert world.time() == 0
 
     gazebo.run(paused=True)


### PR DESCRIPTION
This PR simplifies inserting the Physics plugin during runtime, converting the following:

```python
world.insertWorldPlugin("libPhysicsSystem.so", "scenario::plugins::gazebo::Physics")
```

to:

```python
world.setPhysicsEngine(bindings.PhysicsEngine_Dart)
```

Having the `World::insertWorldPlugin` and `Model::insertModelPlugin` is a nice feature because it's completely generic, but for plugins that are commonly used, a specific method like `World::setPhysicsEngine` improves the user experience and hides under the hood the implementation (that, by the way it's Linux-specific at the moment).

This PR also introduces a new `PhysicsEngine` enum with the physics engine to select. Right now only DART is available, but there are interesting upstream contributions about Bullet3 (https://github.com/ignitionrobotics/ign-gazebo/pull/62).