### PR TITLE
Add self-collisions support

### DIFF
--- a/cpp/scenario/gazebo/include/scenario/gazebo/Model.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/Model.h
@@ -110,7 +110,7 @@ public:
     bool contactsEnabled() const;
     bool enableContacts(const bool enable = true);
 
-    bool selfCollisions() const;
+    bool selfCollisionsEnabled() const;
     bool enableSelfCollisions(const bool enable = true);
 
     std::vector<std::string> linksInContact() const;

--- a/tests/test_scenario/test_custom_controllers.py
+++ b/tests/test_scenario/test_custom_controllers.py
@@ -45,6 +45,9 @@ def test_computed_torque_fixed_base(gazebo: bindings.GazeboSimulator):
     # Get the model
     panda: bindings.Model = world.get_model(model_name)
 
+    # Disable self-collisions
+    panda.enable_self_collisions(False)
+
     # Set the controller period
     panda.set_controller_period(step_size)
 


### PR DESCRIPTION
- When inserting a model from the APIs, similarly to contact detection, self collisions are automatically enabled. If performances are not good enough, users can manually disable them.
- Self collisions requires contact detection and they will enable it automatically.