### PR TITLE
Create dot folder in user's home if missing

### DIFF
--- a/python/gym_ignition/utils/setup_environment.py
+++ b/python/gym_ignition/utils/setup_environment.py
@@ -4,6 +4,7 @@
 
 import os
 import gym.logger
+from pathlib import Path
 from gym_ignition.utils import logger
 
 
@@ -12,6 +13,11 @@ def setup_environment() -> None:
     Configure the environment depending on the detected installation method
     (User or Developer).
     """
+
+    # Make sure that the dot folder in the user's home exists
+    Path("~/.ignition/gazebo").expanduser().mkdir(mode=0o755,
+                                                  parents=True,
+                                                  exist_ok=True)
 
     # Configure the environment
     ign_gazebo_system_plugin_path = ""


### PR DESCRIPTION
In a clean setup, where `ign gazebo` has never been launched (e.g. a docker image), the dot folder `$HOME/.ignition/gazebo` does not get created and the execution fails.

I suspect that this operation is performed during the initialization process of the `ign` command line, and that part of code is bypassed by gym-ignition.

This PR ensures that the dot folder exists when the simulator is started.

Related to https://github.com/robotology/gym-ignition/issues/210#issuecomment-640584576 and https://github.com/robotology/gym-ignition/issues/209#issuecomment-644691279.