### PR TITLE
Finalize porting the Gazebo backend to the new ScenarI/O interfaces

### DIFF
--- a/cpp/scenario/controllers/CMakeLists.txt
+++ b/cpp/scenario/controllers/CMakeLists.txt
@@ -1,26 +1,6 @@
-# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT)
-# All rights reserved.
-#
-#  This project is dual licensed under LGPL v2.1+ or Apache License.
-#
-# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-#
-#  This software may be modified and distributed under the terms of the
-#  GNU Lesser General Public License v2.1 or any later version.
-#
-# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
 
 find_package(iDynTree REQUIRED)
 find_package (Eigen3 3.3 REQUIRED NO_MODULE)

--- a/cpp/scenario/controllers/include/scenario/controllers/ComputedTorqueFixedBase.h
+++ b/cpp/scenario/controllers/include/scenario/controllers/ComputedTorqueFixedBase.h
@@ -2,26 +2,8 @@
  * Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT)
  * All rights reserved.
  *
- * This project is dual licensed under LGPL v2.1+ or Apache License.
- *
- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- *
  * This software may be modified and distributed under the terms of the
  * GNU Lesser General Public License v2.1 or any later version.
- *
- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 
 #ifndef SCENARIO_CONTROLLERS_COMPUTEDTORQUEFIXEDBASE_H

--- a/cpp/scenario/controllers/include/scenario/controllers/ComputedTorqueFixedBase.h
+++ b/cpp/scenario/controllers/include/scenario/controllers/ComputedTorqueFixedBase.h
@@ -35,15 +35,14 @@
 #include <string>
 #include <vector>
 
-namespace scenario {
-    namespace gazebo {
-        class Model;
-    } // namespace gazebo
-    namespace controllers {
-        class ControllersFactory;
-        class ComputedTorqueFixedBase;
-    } // namespace controllers
-} // namespace scenario
+namespace scenario::core {
+    class Model;
+} // namespace scenario::core
+
+namespace scenario::controllers {
+    class ControllersFactory;
+    class ComputedTorqueFixedBase;
+} // namespace scenario::controllers
 
 class scenario::controllers::ComputedTorqueFixedBase final
     : public scenario::controllers::Controller
@@ -53,7 +52,7 @@ class scenario::controllers::ComputedTorqueFixedBase final
 public:
     ComputedTorqueFixedBase() = delete;
     ComputedTorqueFixedBase(const std::string& urdfFile,
-                            std::shared_ptr<gazebo::Model> model,
+                            std::shared_ptr<core::Model> model,
                             const std::vector<double>& kp,
                             const std::vector<double>& kd,
                             const std::vector<std::string>& controlledJoints,

--- a/cpp/scenario/controllers/include/scenario/controllers/Controller.h
+++ b/cpp/scenario/controllers/include/scenario/controllers/Controller.h
@@ -2,26 +2,8 @@
  * Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT)
  * All rights reserved.
  *
- * This project is dual licensed under LGPL v2.1+ or Apache License.
- *
- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- *
  * This software may be modified and distributed under the terms of the
  * GNU Lesser General Public License v2.1 or any later version.
- *
- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 
 #ifndef SCENARIO_CONTROLLERS_CONTROLLER_H

--- a/cpp/scenario/controllers/include/scenario/controllers/Controller.h
+++ b/cpp/scenario/controllers/include/scenario/controllers/Controller.h
@@ -34,20 +34,19 @@
 #include <string>
 #include <vector>
 
-namespace scenario {
-    namespace controllers {
-        class Controller;
-        class UseScenarioModel;
-        class SetBaseReferences;
-        class SetJointReferences;
-        using ControllerPtr = std::shared_ptr<Controller>;
-        constexpr std::array<double, 3> g = {0, 0, -9.80665};
-    } // namespace controllers
-    namespace gazebo {
-        class Model;
-        using ModelPtr = std::shared_ptr<Model>;
-    } // namespace gazebo
-} // namespace scenario
+namespace scenario::controllers {
+    class Controller;
+    class UseScenarioModel;
+    class SetBaseReferences;
+    class SetJointReferences;
+    using ControllerPtr = std::shared_ptr<Controller>;
+    constexpr std::array<double, 3> g = {0, 0, -9.80665};
+} // namespace scenario::controllers
+
+namespace scenario::core {
+    class Model;
+    using ModelPtr = std::shared_ptr<Model>;
+} // namespace scenario::core
 
 class scenario::controllers::Controller
     : public std::enable_shared_from_this<scenario::controllers::Controller>
@@ -72,7 +71,7 @@ public:
     virtual bool updateStateFromModel() = 0;
 
 protected:
-    gazebo::ModelPtr m_model;
+    core::ModelPtr m_model;
 };
 
 class scenario::controllers::SetBaseReferences

--- a/cpp/scenario/controllers/include/scenario/controllers/References.h
+++ b/cpp/scenario/controllers/include/scenario/controllers/References.h
@@ -2,26 +2,8 @@
  * Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT)
  * All rights reserved.
  *
- * This project is dual licensed under LGPL v2.1+ or Apache License.
- *
- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- *
  * This software may be modified and distributed under the terms of the
  * GNU Lesser General Public License v2.1 or any later version.
- *
- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 
 #ifndef SCENARIO_CONTROLLERS_REFERENCES_H

--- a/cpp/scenario/controllers/include/scenario/controllers/References.h
+++ b/cpp/scenario/controllers/include/scenario/controllers/References.h
@@ -30,12 +30,10 @@
 #include <array>
 #include <vector>
 
-namespace scenario {
-    namespace controllers {
-        struct BaseReferences;
-        struct JointReferences;
-    } // namespace controllers
-} // namespace scenario
+namespace scenario::controllers {
+    struct BaseReferences;
+    struct JointReferences;
+} // namespace scenario::controllers
 
 struct scenario::controllers::BaseReferences
 {

--- a/cpp/scenario/controllers/src/ComputedTorqueFixedBase.cpp
+++ b/cpp/scenario/controllers/src/ComputedTorqueFixedBase.cpp
@@ -2,26 +2,8 @@
  * Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT)
  * All rights reserved.
  *
- * This project is dual licensed under LGPL v2.1+ or Apache License.
- *
- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- *
  * This software may be modified and distributed under the terms of the
  * GNU Lesser General Public License v2.1 or any later version.
- *
- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 
 #include "scenario/controllers/ComputedTorqueFixedBase.h"

--- a/cpp/scenario/plugins/ControllerRunner/CMakeLists.txt
+++ b/cpp/scenario/plugins/ControllerRunner/CMakeLists.txt
@@ -22,6 +22,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+find_package(sdformat9 REQUIRED)
+
 # ==================
 # ControllersFactory
 # ==================
@@ -33,9 +35,10 @@ add_library(ControllersFactory STATIC
 target_link_libraries(ControllersFactory
     PUBLIC
     Controller
+    ScenarioCore
+    sdformat9::sdformat9
     PRIVATE
     ScenarioGazebo
-    ignition-gazebo3::core
     ComputedTorqueFixedBase)
 
 target_include_directories(ControllersFactory PRIVATE

--- a/cpp/scenario/plugins/ControllerRunner/ControllerRunner.cpp
+++ b/cpp/scenario/plugins/ControllerRunner/ControllerRunner.cpp
@@ -59,7 +59,7 @@ class ControllerRunner::Impl
 public:
     bool referencesHaveBeenSet = false;
 
-    scenario::gazebo::ModelPtr model;
+    std::shared_ptr<Model> model;
     ignition::gazebo::Entity modelEntity;
     std::chrono::steady_clock::duration prevUpdateTime{0};
 
@@ -330,7 +330,7 @@ bool ControllerRunner::Impl::updateBaseReferencesfromECM(
     Pose3d& basePoseTarget = utils::getExistingComponentData< //
         components::BasePoseTarget>(&ecm, modelEntity);
 
-    base::Pose basePose = utils::fromIgnitionPose(basePoseTarget);
+    core::Pose basePose = utils::fromIgnitionPose(basePoseTarget);
     baseReferences.position = basePose.position;
     baseReferences.orientation = basePose.orientation;
 

--- a/cpp/scenario/plugins/ControllerRunner/ControllerRunner.h
+++ b/cpp/scenario/plugins/ControllerRunner/ControllerRunner.h
@@ -35,13 +35,9 @@
 
 #include <memory>
 
-namespace scenario {
-    namespace plugins {
-        namespace gazebo {
-            class ControllerRunner;
-        } // namespace gazebo
-    } // namespace plugins
-} // namespace scenario
+namespace scenario::plugins::gazebo {
+    class ControllerRunner;
+} // namespace scenario::plugins::gazebo
 
 class scenario::plugins::gazebo::ControllerRunner final
     : public ignition::gazebo::System

--- a/cpp/scenario/plugins/ControllerRunner/ControllersFactory.cpp
+++ b/cpp/scenario/plugins/ControllerRunner/ControllersFactory.cpp
@@ -72,8 +72,7 @@ scenario::plugins::gazebo::ControllersFactory& ControllersFactory::Instance()
 }
 
 scenario::controllers::ControllerPtr
-ControllersFactory::get(const sdf::ElementPtr context,
-                        scenario::gazebo::ModelPtr model)
+ControllersFactory::get(const sdf::ElementPtr context, core::ModelPtr model)
 {
     if (!Impl::ContextValid(context)) {
         sError << "Controller context not valid" << std::endl;
@@ -101,10 +100,10 @@ ControllersFactory::get(const sdf::ElementPtr context,
         auto urdf = Impl::GetElementValueAs<std::string>("urdf", context);
         auto kp = Impl::GetElementValueAs<std::vector<double>>("kp", context);
         auto kd = Impl::GetElementValueAs<std::vector<double>>("kd", context);
-        auto gravity =
-            Impl::GetElementValueAs<std::vector<double>>("gravity", context);
-        auto joints = Impl::GetElementValueAs<std::vector<std::string>>(
-            "joints", context);
+        auto gravity = Impl::GetElementValueAs< //
+            std::vector<double>>("gravity", context);
+        auto joints = Impl::GetElementValueAs< //
+            std::vector<std::string>>("joints", context);
 
         if (gravity.size() != 3) {
             sError << "Parsed gravity does not have three elements";
@@ -120,7 +119,7 @@ ControllersFactory::get(const sdf::ElementPtr context,
                 joints,
                 std::array<double, 3>{gravity[0], gravity[1], gravity[2]});
 
-        return std::move(controller);
+        return controller;
     }
 
     return nullptr;

--- a/cpp/scenario/plugins/ControllerRunner/ControllersFactory.h
+++ b/cpp/scenario/plugins/ControllerRunner/ControllersFactory.h
@@ -28,30 +28,25 @@
 #define SCENARIO_PLUGINS_CONTROLLERSFACTORY_H
 
 #include "scenario/controllers/Controller.h"
-#include "scenario/gazebo/Model.h"
+#include "scenario/core/Model.h"
 
 #include <sdf/Element.hh>
 
 #include <memory>
 
-namespace scenario {
-    namespace plugins {
-        namespace gazebo {
-            class ControllersFactory;
-        } // namespace gazebo
-    } // namespace plugins
-} // namespace scenario
+namespace scenario::plugins::gazebo {
+    class ControllersFactory;
+} // namespace scenario::plugins::gazebo
 
 class scenario::plugins::gazebo::ControllersFactory
 {
-
 public:
     ControllersFactory();
     ~ControllersFactory();
 
     static ControllersFactory& Instance();
     controllers::ControllerPtr get(const sdf::ElementPtr context,
-                                   scenario::gazebo::ModelPtr model);
+                                   scenario::core::ModelPtr model);
 
 private:
     class Impl;

--- a/cpp/scenario/plugins/ECMProvider/CMakeLists.txt
+++ b/cpp/scenario/plugins/ECMProvider/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(ECMProvider
     ignition-gazebo3::core
     PRIVATE
     ECMSingleton
+    ScenarioGazebo
     ExtraComponents)
 
 target_include_directories(ECMProvider PRIVATE

--- a/cpp/scenario/plugins/ECMProvider/include/scenario/plugins/gazebo/ECMProvider.h
+++ b/cpp/scenario/plugins/ECMProvider/include/scenario/plugins/gazebo/ECMProvider.h
@@ -35,13 +35,9 @@
 
 #include <memory>
 
-namespace scenario {
-    namespace plugins {
-        namespace gazebo {
-            class ECMProvider;
-        } // namespace gazebo
-    } // namespace plugins
-} // namespace scenario
+namespace scenario::plugins::gazebo {
+    class ECMProvider;
+} // namespace scenario::plugins::gazebo
 
 class scenario::plugins::gazebo::ECMProvider final
     : public ignition::gazebo::System

--- a/cpp/scenario/plugins/ECMProvider/include/scenario/plugins/gazebo/ECMSingleton.h
+++ b/cpp/scenario/plugins/ECMProvider/include/scenario/plugins/gazebo/ECMSingleton.h
@@ -32,13 +32,9 @@
 
 #include <memory>
 
-namespace scenario {
-    namespace plugins {
-        namespace gazebo {
-            class ECMSingleton;
-        } // namespace gazebo
-    } // namespace plugins
-} // namespace scenario
+namespace scenario::plugins::gazebo {
+    class ECMSingleton;
+} // namespace scenario::plugins::gazebo
 
 class scenario::plugins::gazebo::ECMSingleton
 {

--- a/cpp/scenario/plugins/JointController/JointController.h
+++ b/cpp/scenario/plugins/JointController/JointController.h
@@ -35,13 +35,9 @@
 
 #include <memory>
 
-namespace scenario {
-    namespace plugins {
-        namespace gazebo {
-            class JointController;
-        } // namespace gazebo
-    } // namespace plugins
-} // namespace scenario
+namespace scenario::plugins::gazebo {
+    class JointController;
+} // namespace scenario::plugins::gazebo
 
 class scenario::plugins::gazebo::JointController final
     : public ignition::gazebo::System

--- a/cpp/scenario/plugins/Physics/Physics.cpp
+++ b/cpp/scenario/plugins/Physics/Physics.cpp
@@ -1164,13 +1164,13 @@ void Physics::Impl::UpdatePhysics(const ignition::gazebo::UpdateInfo& _info,
 
             if (jointVelocity.size()
                 != jointIt->second->GetDegreesOfFreedom()) {
-                ignwarn << "There is a mismatch in the degrees of freedom "
-                           "between "
-                        << "Joint [" << _name->Data() << "(Entity=" << _entity
-                        << ")] and its JointForceCmd component. The joint has "
-                        << jointIt->second->GetDegreesOfFreedom()
-                        << " while the "
-                        << " component has " << jointVelocity.size() << ".\n";
+                ignwarn
+                    << "There is a mismatch in the degrees of freedom "
+                       "between "
+                    << "Joint [" << _name->Data() << "(Entity=" << _entity
+                    << ")] and its JointVelocityReset component. The joint has "
+                    << jointIt->second->GetDegreesOfFreedom() << " while the "
+                    << " component has " << jointVelocity.size() << ".\n";
             }
 
             std::size_t nDofs = std::min(
@@ -1187,13 +1187,13 @@ void Physics::Impl::UpdatePhysics(const ignition::gazebo::UpdateInfo& _info,
 
             if (jointPosition.size()
                 != jointIt->second->GetDegreesOfFreedom()) {
-                ignwarn << "There is a mismatch in the degrees of freedom "
-                           "between "
-                        << "Joint [" << _name->Data() << "(Entity=" << _entity
-                        << ")] and its JointForceCmd component. The joint has "
-                        << jointIt->second->GetDegreesOfFreedom()
-                        << " while the "
-                        << " component has " << jointPosition.size() << ".\n";
+                ignwarn
+                    << "There is a mismatch in the degrees of freedom "
+                       "between "
+                    << "Joint [" << _name->Data() << "(Entity=" << _entity
+                    << ")] and its JointPositionReset component. The joint has "
+                    << jointIt->second->GetDegreesOfFreedom() << " while the "
+                    << " component has " << jointPosition.size() << ".\n";
             }
             std::size_t nDofs = std::min(
                 jointPosition.size(), jointIt->second->GetDegreesOfFreedom());

--- a/cpp/scenario/plugins/Physics/Physics.h
+++ b/cpp/scenario/plugins/Physics/Physics.h
@@ -26,29 +26,24 @@
 #include <unordered_map>
 #include <utility>
 
-namespace scenario {
-    namespace plugins {
-        namespace gazebo {
-            class Physics;
-            template <typename PolicyT,
-                      typename ToFeatureList,
-                      typename MinimumFeatureList,
-                      template <typename, typename>
-                      class ToEntity,
-                      template <typename, typename>
-                      class MinimumEntity>
-            ignition::physics::EntityPtr<ToEntity<PolicyT, ToFeatureList>>
-            entityCast(
-                ignition::gazebo::Entity _entity,
-                const ignition::physics::EntityPtr<
-                    MinimumEntity<PolicyT, MinimumFeatureList>>& _minimumEntity,
-                std::unordered_map<ignition::gazebo::Entity,
-                                   ignition::physics::EntityPtr<
-                                       ToEntity<PolicyT, ToFeatureList>>>&
-                    _castMap);
-        } // namespace gazebo
-    } // namespace plugins
-} // namespace scenario
+namespace scenario::plugins::gazebo {
+    class Physics;
+    template <typename PolicyT,
+              typename ToFeatureList,
+              typename MinimumFeatureList,
+              template <typename, typename>
+              class ToEntity,
+              template <typename, typename>
+              class MinimumEntity>
+    ignition::physics::EntityPtr<ToEntity<PolicyT, ToFeatureList>> entityCast(
+        ignition::gazebo::Entity _entity,
+        const ignition::physics::EntityPtr<
+            MinimumEntity<PolicyT, MinimumFeatureList>>& _minimumEntity,
+        std::unordered_map<
+            ignition::gazebo::Entity,
+            ignition::physics::EntityPtr<ToEntity<PolicyT, ToFeatureList>>>&
+            _castMap);
+} // namespace scenario::plugins::gazebo
 
 class scenario::plugins::gazebo::Physics final
     : public ignition::gazebo::System


### PR DESCRIPTION
After #221, this PR updates the remaining classes to use the new core interfaces introduces in #219.

This PR is part of a bigger picture that can be found in #220.