### PR TITLE
Wrap scenario::core with SWIG and create standalone scenario Python package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ set_property(CACHE Python3_FIND_VIRTUALENV PROPERTY STRINGS ${Python3_FIND_VIRTU
 
 # Find Python3
 find_package(Python3 3.6 EXACT COMPONENTS Interpreter Development REQUIRED)
+message(STATUS "Using Python: ${Python3_EXECUTABLE}")
 
 # Configure RPATH
 include(AddInstallRPATHSupport)
@@ -111,6 +112,7 @@ if(NOT CMAKE_BUILD_TYPE STREQUAL "PyPI")
         LIB_DIRS "${CMAKE_INSTALL_FULL_LIBDIR}"
                  "${CMAKE_INSTALL_FULL_LIBDIR}/scenario/plugins"
                  "${Python3_SITELIB}"
+                 "${Python3_SITELIB}/scenario/bindings"
         INSTALL_NAME_DIR "${CMAKE_INSTALL_FULL_LIBDIR}"
         DEPENDS ENABLE_RPATH
         USE_LINK_PATH)
@@ -118,6 +120,9 @@ else()
     add_install_rpath_support(
         BIN_DIRS "${CMAKE_INSTALL_FULL_BINDIR}"
         LIB_DIRS "${Python3_SITELIB}"
+        LIB_DIRS "${Python3_SITELIB}/scenario/lib"
+        LIB_DIRS "${Python3_SITELIB}/scenario/plugins"
+        LIB_DIRS "${Python3_SITELIB}/scenario/bindings"
         INSTALL_NAME_DIR "${CMAKE_INSTALL_FULL_LIBDIR}"
         DEPENDS ENABLE_RPATH
         USE_LINK_PATH)

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -19,17 +19,28 @@ set(CMAKE_SWIG_OUTDIR ${CMAKE_CURRENT_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-# This is needed to generate the install path of the plugins
-# during the packaging of the PyPI archives
-set(PYTHON_PACKAGE_IMPORT_NAME "gym_ignition" CACHE STRING
-    "Name of the installed package matching the desired 'import <package_name>'")
-
 if(GYMIGNITION_ENABLE_SCENARIO)
-    add_subdirectory(scenario)
+
+    add_subdirectory(core)
+    add_subdirectory(gazebo)
+#    add_subdirectory(yarp)
 
     if(GYMIGNITION_ENABLE_GYMPP)
         add_subdirectory(gympp)
     endif()
+
+    if(NOT CMAKE_BUILD_TYPE STREQUAL "PyPI")
+        install(
+            FILES
+            ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py
+            DESTINATION ${Python3_SITELIB}/scenario)
+    else()
+        install(
+            FILES
+            ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py
+            DESTINATION ${CMAKE_INSTALL_PREFIX}/scenario)
+    endif()
+
 endif()
 
 

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -2,6 +2,28 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
+# The SWIG bindings are installed as a standalone <scenario> Python package.
+#
+# We create with CMake the following structure in the build tree:
+#
+# <build>/bindings/scenario/
+# ├── bindings
+# │   ├── core.py
+# │   ├── _core.so
+# │   ├── gazebo.py
+# │   ├── _gazebo.so
+# │   └── __init__.py
+# └── __init__.py
+#
+# That is later installed either in the active virtualenv or packaged
+# as a PyPI package. The former is related to the Develop Installation
+# and the latter to the User Installation.
+#
+# Having a working Python package tree in the build folder has multiple
+# benefit, including the possibility to use it without installing.
+# Beyond this reason, our documentation pipeline requires to import
+# a working package from the build tree.
+
 if(${CMAKE_VERSION} VERSION_GREATER 3.13)
     cmake_policy(SET CMP0078 NEW)
 endif()
@@ -14,32 +36,39 @@ find_package(SWIG 4.0 REQUIRED)
 set(UseSWIG_MODULE_VERSION 2)
 include(${SWIG_USE_FILE})
 
-set(CMAKE_SWIG_OUTDIR ${CMAKE_CURRENT_BINARY_DIR})
-#set(SWIG_OUTFILE_DIR ${CMAKE_CURRENT_BINARY_DIR})
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+# Change the install prefix of the bindings targets depending on
+# the installation mode (User or Developer)
+if(NOT CMAKE_BUILD_TYPE STREQUAL "PyPI")
+    # Install in the python site-package directory
+    set(BINDINGS_INSTALL_PREFIX ${Python3_SITELIB})
+else()
+    # Install in the root of the PyPI package directory that
+    # will become the archive to install / publish.
+    set(BINDINGS_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
+endif()
 
 if(GYMIGNITION_ENABLE_SCENARIO)
 
     add_subdirectory(core)
     add_subdirectory(gazebo)
-#    add_subdirectory(yarp)
 
     if(GYMIGNITION_ENABLE_GYMPP)
         add_subdirectory(gympp)
     endif()
 
-    if(NOT CMAKE_BUILD_TYPE STREQUAL "PyPI")
-        install(
-            FILES
-            ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py
-            DESTINATION ${Python3_SITELIB}/scenario)
-    else()
-        install(
-            FILES
-            ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py
-            DESTINATION ${CMAKE_INSTALL_PREFIX}/scenario)
-    endif()
+    # Move main init.py file to package root of the build tree
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py
+        ${CMAKE_CURRENT_BINARY_DIR}/scenario/__init__.py)
+
+    # Make scenario.bindings a package
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/scenario/bindings)
+    file(TOUCH ${CMAKE_CURRENT_BINARY_DIR}/scenario/bindings/__init__.py)
+
+    # Move main init.py file to package root of the install tree
+    install(
+        FILES ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py
+        DESTINATION ${BINDINGS_INSTALL_PREFIX}/scenario/)
 
 endif()
 

--- a/bindings/__init__.py
+++ b/bindings/__init__.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import os
+import sys
+from enum import auto, Enum
+
+
+class InstallMode(Enum):
+    User = auto()
+    Developer = auto()
+
+
+def detect_install_mode() -> InstallMode:
+
+    import scenario.bindings.core
+    install_prefix = scenario.bindings.core.get_install_prefix()
+    return InstallMode.User if install_prefix == "" else InstallMode.Developer
+
+
+def setup_gazebo_environment() -> None:
+
+    import scenario.bindings.core
+
+    # Configure the environment
+    ign_gazebo_system_plugin_path = ""
+
+    if "IGN_GAZEBO_SYSTEM_PLUGIN_PATH" in os.environ:
+        ign_gazebo_system_plugin_path = os.environ.get("IGN_GAZEBO_SYSTEM_PLUGIN_PATH")
+
+    # Add the plugins path
+    if detect_install_mode() == InstallMode.Developer:
+        # Get the install prefix from C++. It is defined only in Developer mode.
+        install_prefix = scenario.bindings.core.get_install_prefix()
+        ign_gazebo_system_plugin_path += f":{install_prefix}/lib/scenario/plugins"
+    else:
+        from pathlib import Path
+        plugin_dir = Path(os.path.dirname(__file__)) / "plugins"
+        ign_gazebo_system_plugin_path += f":{str(plugin_dir)}"
+
+    os.environ["IGN_GAZEBO_SYSTEM_PLUGIN_PATH"] = ign_gazebo_system_plugin_path
+
+
+def import_gazebo() -> None:
+
+    # Check the the module was never loaded by someone else
+    if "scenario.bindings._gazebo" in sys.modules:
+        raise ImportError("Failed to load ScenarI/O Gazebo with custom dlopen flags")
+
+    # Import SWIG bindings
+    # See https://github.com/robotology/gym-ignition/issues/7
+    #     https://stackoverflow.com/a/45473441/12150968
+    if sys.platform.startswith('linux') or sys.platform.startswith('darwin'):
+
+        # Update the dlopen flags
+        dlopen_flags = sys.getdlopenflags()
+        sys.setdlopenflags(dlopen_flags | os.RTLD_GLOBAL)
+
+        import scenario.bindings.gazebo
+
+        # Restore the flags
+        sys.setdlopenflags(dlopen_flags)
+
+    else:
+        import scenario.bindings.gazebo
+
+
+# ===================
+# Import the bindings
+# ===================
+
+try:
+    import_gazebo()
+    setup_gazebo_environment()
+    from .bindings import gazebo
+except ImportError:
+    pass
+
+try:
+    from .bindings.yarp import yarp
+except ImportError:
+    pass
+
+from .bindings import core

--- a/bindings/core/CMakeLists.txt
+++ b/bindings/core/CMakeLists.txt
@@ -1,0 +1,49 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+set(scenario_swig_name "core")
+set_source_files_properties(${scenario_swig_name}.i PROPERTIES CPLUSPLUS ON)
+
+swig_add_library(${scenario_swig_name}
+    TYPE SHARED
+    LANGUAGE python
+    SOURCES ${scenario_swig_name}.i)
+
+target_link_libraries(${scenario_swig_name} PUBLIC
+    ScenarioCore
+    ScenarioCoreUtils
+    Python3::Python)
+
+set_property(TARGET ${scenario_swig_name} PROPERTY
+    SWIG_USE_TARGET_INCLUDE_DIRECTORIES TRUE)
+
+set_property(TARGET ${scenario_swig_name}
+    PROPERTY SWIG_COMPILE_OPTIONS -doxygen)
+
+if(NOT CMAKE_BUILD_TYPE STREQUAL "PyPI")
+
+    install(
+        TARGETS ${scenario_swig_name}
+        EXPORT bindings
+        LIBRARY DESTINATION ${Python3_SITELIB}/scenario/bindings
+        ARCHIVE DESTINATION ${Python3_SITELIB}/scenario/bindings
+        RUNTIME DESTINATION ${Python3_SITELIB}/scenario/bindings)
+
+    install(
+        FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/../${scenario_swig_name}.py
+        DESTINATION ${Python3_SITELIB}/scenario/bindings)
+
+else()
+
+    install(
+        TARGETS ${scenario_swig_name}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/scenario/bindings)
+
+    install(
+        FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/../${scenario_swig_name}.py
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/scenario/bindings)
+
+endif()

--- a/bindings/core/CMakeLists.txt
+++ b/bindings/core/CMakeLists.txt
@@ -5,10 +5,16 @@
 set(scenario_swig_name "core")
 set_source_files_properties(${scenario_swig_name}.i PROPERTIES CPLUSPLUS ON)
 
+# The bindings shared library is stored in the Python package of the build tree
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../scenario/bindings)
+
 swig_add_library(${scenario_swig_name}
     TYPE SHARED
     LANGUAGE python
+    OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/../scenario/bindings
+    OUTFILE_DIR ${CMAKE_CURRENT_BINARY_DIR}/..
     SOURCES ${scenario_swig_name}.i)
+add_library(Scenario::SwigScenarioCore ALIAS core)
 
 target_link_libraries(${scenario_swig_name} PUBLIC
     ScenarioCore
@@ -30,29 +36,16 @@ if(GYMIGNITION_USE_IGNITION)
     target_link_libraries(${scenario_swig_name} PUBLIC ScenarioGazebo)
 endif()
 
-if(NOT CMAKE_BUILD_TYPE STREQUAL "PyPI")
+# Get the core.py wrapper file
+get_property(WRAPPER_PY_FILE TARGET ${scenario_swig_name} PROPERTY SWIG_SUPPORT_FILES)
 
-    install(
-        TARGETS ${scenario_swig_name}
-        EXPORT bindings
-        LIBRARY DESTINATION ${Python3_SITELIB}/scenario/bindings
-        ARCHIVE DESTINATION ${Python3_SITELIB}/scenario/bindings
-        RUNTIME DESTINATION ${Python3_SITELIB}/scenario/bindings)
+install(
+    TARGETS ${scenario_swig_name}
+    EXPORT bindings
+    LIBRARY DESTINATION ${BINDINGS_INSTALL_PREFIX}/scenario/bindings
+    ARCHIVE DESTINATION ${BINDINGS_INSTALL_PREFIX}/scenario/bindings
+    RUNTIME DESTINATION ${BINDINGS_INSTALL_PREFIX}/scenario/bindings)
 
-    install(
-        FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/../${scenario_swig_name}.py
-        DESTINATION ${Python3_SITELIB}/scenario/bindings)
-
-else()
-
-    install(
-        TARGETS ${scenario_swig_name}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/scenario/bindings)
-
-    install(
-        FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/../${scenario_swig_name}.py
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/scenario/bindings)
-
-endif()
+install(
+    FILES ${WRAPPER_PY_FILE}
+    DESTINATION ${BINDINGS_INSTALL_PREFIX}/scenario/bindings)

--- a/bindings/core/CMakeLists.txt
+++ b/bindings/core/CMakeLists.txt
@@ -21,6 +21,15 @@ set_property(TARGET ${scenario_swig_name} PROPERTY
 set_property(TARGET ${scenario_swig_name}
     PROPERTY SWIG_COMPILE_OPTIONS -doxygen)
 
+# Add the to_gazebo() helpers
+if(GYMIGNITION_USE_IGNITION)
+    set_property(TARGET ${scenario_swig_name} PROPERTY
+        SWIG_COMPILE_DEFINITIONS SCENARIO_HAS_GAZEBO)
+    set_property(TARGET ${scenario_swig_name} PROPERTY
+        SWIG_DEPENDS "../gazebo/to_gazebo.i")
+    target_link_libraries(${scenario_swig_name} PUBLIC ScenarioGazebo)
+endif()
+
 if(NOT CMAKE_BUILD_TYPE STREQUAL "PyPI")
 
     install(

--- a/bindings/core/core.i
+++ b/bindings/core/core.i
@@ -95,3 +95,8 @@ from typing import Tuple
 %include "scenario/core/Link.h"
 %include "scenario/core/Model.h"
 %include "scenario/core/World.h"
+
+// Downcast pointers to the implementation classes
+#if defined (SCENARIO_HAS_GAZEBO)
+%include "../gazebo/to_gazebo.i"
+#endif

--- a/bindings/core/core.i
+++ b/bindings/core/core.i
@@ -1,0 +1,87 @@
+%module(package="scenario.bindings") core
+
+%{
+#define SWIG_FILE_WITH_INIT
+#include "scenario/core/Joint.h"
+#include "scenario/core/Link.h"
+#include "scenario/core/Model.h"
+#include "scenario/core/World.h"
+#include "scenario/core/utils/utils.h"
+%}
+
+%naturalvar;
+
+// STL classes
+%include <stdint.i>
+%include <std_pair.i>
+%include <std_array.i>
+%include <std_string.i>
+%include <std_vector.i>
+%include <std_shared_ptr.i>
+
+// Convert python list to std::vector
+%template(VectorI) std::vector<int>;
+%template(VectorU) std::vector<size_t>;
+%template(VectorF) std::vector<float>;
+%template(VectorD) std::vector<double>;
+%template(VectorS) std::vector<std::string>;
+
+// Convert python list to std::array
+%template(Array3d) std::array<double, 3>;
+%template(Array4d) std::array<double, 4>;
+%template(Array6d) std::array<double, 6>;
+
+// Pair instantiation
+%template(PosePair) std::pair<std::array<double, 3>, std::array<double, 4>>;
+
+// ScenarI/O templates
+%template(VectorOfLinks) std::vector<scenario::core::LinkPtr>;
+%template(VectorOfJoints) std::vector<scenario::core::JointPtr>;
+%template(VectorOfContacts) std::vector<scenario::core::Contact>;
+%template(VectorOfContactPoints) std::vector<scenario::core::ContactPoint>;
+
+// Doxygen typemaps
+%typemap(doctype) std::array<double, 3> "Tuple[float, float, float]";
+%typemap(doctype) std::array<double, 4> "Tuple[float, float, float, float]";
+%typemap(doctype) std::array<double, 6> "Tuple[float, float, float, float, float, float,]";
+%typemap(doctype) std::vector<double> "Tuple[float, ...]";
+%typemap(doctype) std::vector<std::string> "Tuple[string, ...]";
+%typemap(doctype) std::vector<scenario::core::LinkPtr> "Tuple[Link, ...]";
+%typemap(doctype) std::vector<scenario::core::JointPtr> "Tuple[Joint, ...]";
+%typemap(doctype) std::vector<scenario::core::Contact> "Tuple[Contact, ...]";
+%typemap(doctype) std::vector<scenario::core::ContactPoint> "Tuple[ContactPoint, ...]";
+
+%pythonbegin %{
+from typing import Tuple
+%}
+
+// NOTE: Keep all template instantiations above.
+// Rename all methods to undercase with _ separators excluding the classes.
+%rename("%(undercase)s") "";
+%rename("") PID;
+%rename("") Pose;
+%rename("") Link;
+%rename("") Joint;
+%rename("") Model;
+%rename("") World;
+%rename("") Limit;
+%rename("") Contact;
+%rename("") JointType;
+%rename("") JointLimit;
+%rename("") ContactPoint;
+%rename("") JointControlMode;
+
+// Public helpers
+%include "scenario/core/utils/utils.h"
+
+// Other templates for ScenarI/O APIs
+%shared_ptr(scenario::core::Joint)
+%shared_ptr(scenario::core::Link)
+%shared_ptr(scenario::core::Model)
+%shared_ptr(scenario::core::World)
+
+// ScenarI/O core headers
+%include "scenario/core/Joint.h"
+%include "scenario/core/Link.h"
+%include "scenario/core/Model.h"
+%include "scenario/core/World.h"

--- a/bindings/core/core.i
+++ b/bindings/core/core.i
@@ -11,6 +11,16 @@
 
 %naturalvar;
 
+// Convert all exceptions to RuntimeError
+%include "exception.i"
+%exception {
+  try {
+    $action
+  } catch (const std::exception& e) {
+    SWIG_exception(SWIG_RuntimeError, e.what());
+  }
+}
+
 // STL classes
 %include <stdint.i>
 %include <std_pair.i>

--- a/bindings/gazebo/CMakeLists.txt
+++ b/bindings/gazebo/CMakeLists.txt
@@ -5,9 +5,14 @@
 set(scenario_swig_name "gazebo")
 set_source_files_properties(${scenario_swig_name}.i PROPERTIES CPLUSPLUS ON)
 
+# The bindings shared library is stored in the Python package of the build tree
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../scenario/bindings)
+
 swig_add_library(${scenario_swig_name}
     TYPE SHARED
     LANGUAGE python
+    OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/../scenario/bindings
+    OUTFILE_DIR ${CMAKE_CURRENT_BINARY_DIR}/..
     SOURCES ${scenario_swig_name}.i)
 
 target_link_libraries(${scenario_swig_name} PUBLIC
@@ -16,13 +21,14 @@ target_link_libraries(${scenario_swig_name} PUBLIC
     ScenarioGazebo
     GazeboSimulator
     Python3::Python)
+add_library(Scenario::SwigScenarioGazebo ALIAS gazebo)
 
 set_property(TARGET ${scenario_swig_name} PROPERTY
     SWIG_USE_TARGET_INCLUDE_DIRECTORIES TRUE)
 
 # https://github.com/swig/swig/issues/672#issuecomment-400577864
 set_property(TARGET ${scenario_swig_name} PROPERTY
-    SWIG_COMPILE_OPTIONS -doxygen -Dfinal=)
+    SWIG_COMPILE_OPTIONS -doxygen -Dfinal)
 
 # Disable SWIG debug code due to the following error:
 #   int SWIG_Python_ConvertPtrAndOwn(PyObject *, void **, swig_type_info *, int, int *):
@@ -31,41 +37,32 @@ set_property(TARGET ${scenario_swig_name} PROPERTY
 # https://github.com/swig/swig/issues/773
 target_compile_definitions(${scenario_swig_name} PRIVATE NDEBUG)
 
-if(NOT CMAKE_BUILD_TYPE STREQUAL "PyPI")
+# Get the gazebo.py wrapper file
+get_property(WRAPPER_PY_FILE TARGET ${scenario_swig_name} PROPERTY SWIG_SUPPORT_FILES)
 
-    install(
-        TARGETS ${scenario_swig_name}
-        EXPORT bindings
-        LIBRARY DESTINATION ${Python3_SITELIB}/scenario/bindings
-        ARCHIVE DESTINATION ${Python3_SITELIB}/scenario/bindings
-        RUNTIME DESTINATION ${Python3_SITELIB}/scenario/bindings)
+install(
+    TARGETS ${scenario_swig_name}
+    EXPORT bindings
+    LIBRARY DESTINATION ${BINDINGS_INSTALL_PREFIX}/scenario/bindings
+    ARCHIVE DESTINATION ${BINDINGS_INSTALL_PREFIX}/scenario/bindings
+    RUNTIME DESTINATION ${BINDINGS_INSTALL_PREFIX}/scenario/bindings)
 
-    install(
-        FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/../${scenario_swig_name}.py
-        DESTINATION ${Python3_SITELIB}/scenario/bindings)
+install(
+    FILES ${WRAPPER_PY_FILE}
+    DESTINATION ${BINDINGS_INSTALL_PREFIX}/scenario/bindings)
 
-else()
-
-    install(
-        TARGETS ${scenario_swig_name}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/scenario/bindings)
-
-    install(
-        FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/../${scenario_swig_name}.py
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/scenario/bindings)
-
+# When packaging for PyPI, also install in the Python site-package the
+# Ignition Gazebo plugins and their dependending libraries
+if(CMAKE_BUILD_TYPE STREQUAL "PyPI")
     # Install the plugins
     install(
         TARGETS ECMProvider PhysicsSystem ControllerRunner JointController
-        LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/scenario/plugins)
+        LIBRARY DESTINATION ${BINDINGS_INSTALL_PREFIX}/scenario/plugins)
 
     # Install other shared libraries.
     # Required for libs that contain singletons otherwise when the
     # project is statically compiled they do not work properly.
     install(
         TARGETS ECMSingleton
-        LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/scenario/lib)
-
+        LIBRARY DESTINATION ${BINDINGS_INSTALL_PREFIX}/scenario/lib)
 endif()

--- a/bindings/gazebo/CMakeLists.txt
+++ b/bindings/gazebo/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
-set(scenario_swig_name "scenario_bindings")
+set(scenario_swig_name "gazebo")
 set_source_files_properties(${scenario_swig_name}.i PROPERTIES CPLUSPLUS ON)
 
 swig_add_library(${scenario_swig_name}
@@ -12,6 +12,7 @@ swig_add_library(${scenario_swig_name}
 
 target_link_libraries(${scenario_swig_name} PUBLIC
     ECMSingleton
+    ScenarioCore
     ScenarioGazebo
     GazeboSimulator
     Python3::Python)
@@ -19,46 +20,52 @@ target_link_libraries(${scenario_swig_name} PUBLIC
 set_property(TARGET ${scenario_swig_name} PROPERTY
     SWIG_USE_TARGET_INCLUDE_DIRECTORIES TRUE)
 
-#set_property(TARGET ${scenario_swig_name} PROPERTY SWIG_COMPILE_OPTIONS -builtin)
+# https://github.com/swig/swig/issues/672#issuecomment-400577864
+set_property(TARGET ${scenario_swig_name} PROPERTY
+    SWIG_COMPILE_OPTIONS -doxygen -Dfinal=)
 
-set_property(TARGET ${scenario_swig_name} PROPERTY SWIG_COMPILE_OPTIONS -py3)
-set_property(TARGET ${scenario_swig_name} PROPERTY SWIG_COMPILE_OPTIONS -doxygen)
+# Disable SWIG debug code due to the following error:
+#   int SWIG_Python_ConvertPtrAndOwn(PyObject *, void **, swig_type_info *, int, int *):
+#   Assertion `own' failed.
+# https://github.com/swig/swig/issues/731
+# https://github.com/swig/swig/issues/773
+target_compile_definitions(${scenario_swig_name} PRIVATE NDEBUG)
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL "PyPI")
 
     install(
         TARGETS ${scenario_swig_name}
-        EXPORT scenario
-        LIBRARY DESTINATION ${Python3_SITELIB}
-        ARCHIVE DESTINATION ${Python3_SITELIB}
-        RUNTIME DESTINATION ${Python3_SITELIB})
+        EXPORT bindings
+        LIBRARY DESTINATION ${Python3_SITELIB}/scenario/bindings
+        ARCHIVE DESTINATION ${Python3_SITELIB}/scenario/bindings
+        RUNTIME DESTINATION ${Python3_SITELIB}/scenario/bindings)
 
     install(
         FILES
         ${CMAKE_CURRENT_BINARY_DIR}/../${scenario_swig_name}.py
-        DESTINATION ${Python3_SITELIB})
+        DESTINATION ${Python3_SITELIB}/scenario/bindings)
 
 else()
 
     install(
         TARGETS ${scenario_swig_name}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX})
+        LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/scenario/bindings)
 
     install(
         FILES
         ${CMAKE_CURRENT_BINARY_DIR}/../${scenario_swig_name}.py
-        DESTINATION ${CMAKE_INSTALL_PREFIX})
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/scenario/bindings)
 
     # Install the plugins
     install(
         TARGETS ECMProvider PhysicsSystem ControllerRunner JointController
-        LIBRARY DESTINATION ${PYTHON_PACKAGE_IMPORT_NAME}/plugins)
+        LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/scenario/plugins)
 
     # Install other shared libraries.
     # Required for libs that contain singletons otherwise when the
     # project is statically compiled they do not work properly.
     install(
         TARGETS ECMSingleton
-        LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX})
+        LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/scenario/lib)
 
 endif()

--- a/bindings/gazebo/to_gazebo.i
+++ b/bindings/gazebo/to_gazebo.i
@@ -1,0 +1,25 @@
+%pythonbegin %{
+from typing import Union
+import scenario.bindings.gazebo
+%}
+
+%extend scenario::core::World {
+  %pythoncode %{
+    def to_gazebo(self) -> Union["scenario.bindings.gazebo.World", "scenario.bindings.core.World"]:
+        return scenario.bindings.gazebo.ToGazeboWorld(self)
+  %}
+}
+
+%extend scenario::core::Model {
+  %pythoncode %{
+    def to_gazebo(self) -> Union["scenario.bindings.gazebo.Model", "scenario.bindings.core.Model"]:
+        return scenario.bindings.gazebo.ToGazeboModel(self)
+  %}
+}
+
+%extend scenario::core::Joint {
+  %pythoncode %{
+    def to_gazebo(self) -> Union["scenario.bindings.gazebo.Joint", "scenario.bindings.core.Joint"]:
+        return scenario.bindings.gazebo.ToGazeboJoint(self)
+  %}
+}


### PR DESCRIPTION
This PR:

- Implements all the SWIG machinery to wrap the abstract classes introduced in #219 
- Adapts the existing Gazebo bindings
- Creates with CMake a standalone `scenario` Python package

The new `scenario.core` module provides wrapped classes of the `scenario::core` interfaces introduced in #219, plus some other classes like `Pose` and enums like `JointControlMode` and `JointType`. The old `scenario_bindings` with the Gazebo implementation now became `scenario.gazebo`.

The scenario package can be imported in the following two ways:

```python
# Importing high-level aliases
from scenario import core, gazebo
# [...]

# Importing the low-level modules
import scenario.bindings.core
import scenario.bindings.gazebo
# [...]
```

The initialization code for the Gazebo backend (dlopen, env vars) was moved to this new `scenario` package from `gym_ignition`. This makes `scenario` a real standalone package that can be used without `gym_ignition`. Now it became a real alternative to `pybullet` and `mujoco-py`.

This PR is part of a bigger picture that can be found in #220.