### PR TITLE
Update pytest files after new scenario bindings structure

### DIFF
--- a/python/gym_ignition/experimental/gympp/cartpole.py
+++ b/python/gym_ignition/experimental/gympp/cartpole.py
@@ -20,7 +20,7 @@ class CartPoleDiscrete(gympp_env.GymppEnv):
     def _plugin_metadata(self) -> "gympp_bindings.PluginMetadata":
 
         # Lazy module import
-        from gym_ignition import gympp_bindings as bindings
+        import gympp_bindings as bindings
 
         # Get the empty world file
         empty_world_sdf = misc.string_to_file(gympp.get_empty_world())

--- a/python/gym_ignition/experimental/gympp/gympp_env.py
+++ b/python/gym_ignition/experimental/gympp/gympp_env.py
@@ -48,7 +48,7 @@ class GymppEnv(gym.Env):
         if self._env:
             return self._env
 
-        from gym_ignition import gympp_bindings as bindings
+        import gympp_bindings as bindings
 
         # Get the metadata
         md = self._plugin_metadata
@@ -69,7 +69,7 @@ class GymppEnv(gym.Env):
 
     @property
     def gazebo(self):
-        from gym_ignition import gympp_bindings as bindings
+        import gympp_bindings as bindings
         return bindings.env_to_gazebo_simulator(self.gympp_env)
 
     @property
@@ -122,7 +122,7 @@ class GymppEnv(gym.Env):
             action_list = list(action)
 
         # Create the gympp::Sample object
-        from gym_ignition import gympp_bindings as bindings
+        import gympp_bindings as bindings
         action_buffer = getattr(bindings, 'Vector' + self._act_dt)(action_list)
         action_sample = bindings.Sample(action_buffer)
 
@@ -195,7 +195,7 @@ class GymppEnv(gym.Env):
 
     def render(self, mode: str = 'human') -> None:
 
-        from gym_ignition import gympp_bindings as bindings
+        import gympp_bindings as bindings
 
         render_mode = {'human': bindings.Environment.RenderMode_human}
         ok = self.gympp_env.render(render_mode[mode])
@@ -246,7 +246,7 @@ class GymppEnv(gym.Env):
               also a method suffix string (such as "_d" for double) that is appended to
               the calls of the swig bindings methods (e.g. obs.getBuffer_d()).
         """
-        from gym_ignition import gympp_bindings as bindings
+        import gympp_bindings as bindings
         assert isinstance(md, bindings.SpaceMetadata), "Wrong type for method argument"
 
         space_type = md.get_type()

--- a/tests/test_gym_ignition/test_normalization.py
+++ b/tests/test_gym_ignition/test_normalization.py
@@ -3,6 +3,8 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 import pytest
+pytestmark = pytest.mark.gym_ignition
+
 from gym_ignition.utils.math import normalize, denormalize
 
 

--- a/tests/test_gym_ignition/test_sdf_randomizer.py
+++ b/tests/test_gym_ignition/test_sdf_randomizer.py
@@ -8,8 +8,9 @@ pytestmark = pytest.mark.gym_ignition
 from lxml import etree
 import gym_ignition_models
 from gym_ignition.utils import misc
+
+from scenario import gazebo as scenario
 from gym_ignition.randomizers.model import sdf
-from gym_ignition import scenario_bindings as bindings
 from gym_ignition.randomizers.model.sdf import Distribution, Method
 from gym_ignition.randomizers.model.sdf import UniformParams, GaussianParams
 
@@ -20,7 +21,7 @@ def test_sdf_randomizer():
     urdf_model = gym_ignition_models.get_model_file("cartpole")
 
     # Convert it to a SDF string
-    sdf_model_string = bindings.urdffile_to_sdfstring(urdf_model)
+    sdf_model_string = scenario.urdffile_to_sdfstring(urdf_model)
 
     # Write the SDF string to a temp file
     sdf_model = misc.string_to_file(sdf_model_string)
@@ -104,12 +105,6 @@ def test_randomizer_reproducibility():
         .sampled_from(Distribution.Uniform,
                       UniformParams(low=0, high=100)) \
         .add()
-    randomizer1.new_randomization() \
-        .at_xpath("*/link/collision/surface/friction/ode/mu2") \
-        .method(Method.Absolute) \
-        .sampled_from(Distribution.Uniform,
-                      UniformParams(low=0, high=50)) \
-        .add()
 
     # Add randomizations for #2
     randomizer2.new_randomization() \
@@ -118,12 +113,6 @@ def test_randomizer_reproducibility():
         .sampled_from(Distribution.Uniform,
                       UniformParams(low=0, high=100)) \
         .add()
-    randomizer2.new_randomization() \
-        .at_xpath("*/link/collision/surface/friction/ode/mu2") \
-        .method(Method.Absolute) \
-        .sampled_from(Distribution.Uniform,
-                      UniformParams(low=0, high=50)) \
-        .add()
 
     # Add randomizations for #3
     randomizer3.new_randomization() \
@@ -131,12 +120,6 @@ def test_randomizer_reproducibility():
         .method(Method.Absolute) \
         .sampled_from(Distribution.Uniform,
                       UniformParams(low=0, high=100)) \
-        .add()
-    randomizer3.new_randomization() \
-        .at_xpath("*/link/collision/surface/friction/ode/mu2") \
-        .method(Method.Absolute) \
-        .sampled_from(Distribution.Uniform,
-                      UniformParams(low=0, high=50)) \
         .add()
 
     # Process the randomizations
@@ -159,7 +142,7 @@ def test_randomize_missing_element():
     urdf_model = gym_ignition_models.get_model_file("pendulum")
 
     # Convert it to a SDF string
-    sdf_model_string = bindings.urdffile_to_sdfstring(urdf_model)
+    sdf_model_string = scenario.urdffile_to_sdfstring(urdf_model)
 
     # Write the SDF string to a temp file
     sdf_model = misc.string_to_file(sdf_model_string)
@@ -218,7 +201,7 @@ def test_full_panda_randomization():
     urdf_model = gym_ignition_models.get_model_file("panda")
 
     # Convert it to a SDF string
-    sdf_model_string = bindings.urdffile_to_sdfstring(urdf_model)
+    sdf_model_string = scenario.urdffile_to_sdfstring(urdf_model)
 
     # Write the SDF string to a temp file
     sdf_model = misc.string_to_file(sdf_model_string)

--- a/tests/test_gympp/test_bindings.py
+++ b/tests/test_gympp/test_bindings.py
@@ -7,16 +7,17 @@ pytestmark = pytest.mark.gympp
 
 import numpy as np
 from numpy import pi
-from gym_ignition import scenario_bindings
+from scenario import gazebo as scenario
+
 
 try:
-    from gym_ignition import gympp_bindings as bindings
+    import gympp_bindings as bindings
 except ImportError:
     pytest.skip("gympp bindings not found", allow_module_level=True)
 
 
 # Set verbosity
-scenario_bindings.set_verbosity(4)
+scenario.set_verbosity(4)
 
 
 @pytest.fixture

--- a/tests/test_gympp/test_environments_gympp.py
+++ b/tests/test_gympp/test_environments_gympp.py
@@ -6,16 +6,16 @@ import pytest
 pytestmark = pytest.mark.gympp
 
 import gym
-from gym_ignition import scenario_bindings
+from scenario import gazebo as scenario
 
 try:
-    from gym_ignition import gympp_bindings as bindings
+    import gympp_bindings as bindings
 except ImportError:
     pytest.skip("gympp bindings not found", allow_module_level=True)
 
 
 # Set verbosity
-scenario_bindings.set_verbosity(4)
+scenario.set_verbosity(4)
 
 
 def test_create_cpp_environment():

--- a/tests/test_gympp/test_factory.py
+++ b/tests/test_gympp/test_factory.py
@@ -10,17 +10,17 @@ import numpy as np
 from pathlib import Path
 import gym_ignition_models
 from gym_ignition.utils import misc
-from gym_ignition import scenario_bindings
+from scenario import gazebo as scenario
 from gym_ignition.experimental import gympp
 
 try:
-    from gym_ignition import gympp_bindings as bindings
+    import gympp_bindings as bindings
 except ImportError:
     pytest.skip("gympp bindings not found", allow_module_level=True)
 
 
 # Set verbosity
-scenario_bindings.set_verbosity(4)
+scenario.set_verbosity(4)
 
 
 def test_metadata():

--- a/tests/test_scenario/test_contacts.py
+++ b/tests/test_scenario/test_contacts.py
@@ -6,12 +6,16 @@ import pytest
 pytestmark = pytest.mark.scenario
 
 import numpy as np
+from scenario import core
 from ..common import utils
 import gym_ignition_models
 from typing import Callable
 from gym_ignition.utils import misc
+from scenario import gazebo as scenario
 from ..common.utils import gazebo_fixture as gazebo
-from gym_ignition import scenario_bindings as bindings
+
+# Set the verbosity
+scenario.set_verbosity(scenario.Verbosity_debug)
 
 
 def get_cube_urdf_string_double_collision() -> str:
@@ -56,14 +60,14 @@ def get_cube_urdf_string_double_collision() -> str:
                           ((0.001, 1.0, 1), get_cube_urdf_string_double_collision)],
                          indirect=["gazebo"],
                          ids=utils.id_gazebo_fn)
-def test_cube_contact(gazebo: bindings.GazeboSimulator,
+def test_cube_contact(gazebo: scenario.GazeboSimulator,
                       get_model_str: Callable):
 
     assert gazebo.initialize()
-    world = gazebo.get_world()
+    world = gazebo.get_world().to_gazebo()
 
     # Insert the Physics system
-    assert world.set_physics_engine(bindings.PhysicsEngine_dart)
+    assert world.set_physics_engine(scenario.PhysicsEngine_dart)
 
     # Insert the ground plane
     assert world.insert_model(gym_ignition_models.get_model_file("ground_plane"))
@@ -72,8 +76,8 @@ def test_cube_contact(gazebo: bindings.GazeboSimulator,
     # Insert the cube
     cube_urdf = misc.string_to_file(get_model_str())
     assert world.insert_model(cube_urdf,
-                             bindings.Pose([0, 0, 0.15], [1., 0, 0, 0]),
-                             "cube")
+                              core.Pose([0, 0, 0.15], [1., 0, 0, 0]),
+                              "cube")
     assert len(world.model_names()) == 2
 
     # Get the cube
@@ -113,7 +117,7 @@ def test_cube_contact(gazebo: bindings.GazeboSimulator,
 
     # Forces of all contact points are combined by the following method
     assert cube.get_link("cube").contact_wrench() == \
-           pytest.approx([0, 0, np.sum(z_forces), 0, 0, 0])
+        pytest.approx([0, 0, np.sum(z_forces), 0, 0, 0])
 
 
 @pytest.mark.parametrize("gazebo, get_model_str",
@@ -121,14 +125,14 @@ def test_cube_contact(gazebo: bindings.GazeboSimulator,
                           ((0.001, 1.0, 1), get_cube_urdf_string_double_collision)],
                          indirect=["gazebo"],
                          ids=utils.id_gazebo_fn)
-def test_cube_multiple_contacts(gazebo: bindings.GazeboSimulator,
+def test_cube_multiple_contacts(gazebo: scenario.GazeboSimulator,
                                 get_model_str: Callable):
 
     assert gazebo.initialize()
-    world = gazebo.get_world()
+    world = gazebo.get_world().to_gazebo()
 
     # Insert the Physics system
-    assert world.set_physics_engine(bindings.PhysicsEngine_dart)
+    assert world.set_physics_engine(scenario.PhysicsEngine_dart)
 
     # Insert the ground plane
     assert world.insert_model(gym_ignition_models.get_model_file("ground_plane"))
@@ -137,10 +141,10 @@ def test_cube_multiple_contacts(gazebo: bindings.GazeboSimulator,
     # Insert two cubes side to side with a 10cm gap
     cube_urdf = misc.string_to_file(get_model_str())
     assert world.insert_model(cube_urdf,
-                              bindings.Pose([0, -0.15, 0.101], [1., 0, 0, 0]),
+                              core.Pose([0, -0.15, 0.101], [1., 0, 0, 0]),
                               "cube1")
     assert world.insert_model(cube_urdf,
-                              bindings.Pose([0, 0.15, 0.101], [1., 0, 0, 0]),
+                              core.Pose([0, 0.15, 0.101], [1., 0, 0, 0]),
                               "cube2")
     assert len(world.model_names()) == 3
 
@@ -171,7 +175,7 @@ def test_cube_multiple_contacts(gazebo: bindings.GazeboSimulator,
 
     # Now we make another cube fall above the gap. It will touch both cubes.
     assert world.insert_model(cube_urdf,
-                              bindings.Pose([0, 0, 0.301], [1., 0, 0, 0]),
+                              core.Pose([0, 0, 0.301], [1., 0, 0, 0]),
                               "cube3")
     assert len(world.model_names()) == 4
 

--- a/tests/test_scenario/test_custom_controllers.py
+++ b/tests/test_scenario/test_custom_controllers.py
@@ -6,21 +6,22 @@ import pytest
 pytestmark = pytest.mark.scenario
 
 import numpy as np
+from scenario import core
 import gym_ignition_models
 from ..common import utils
+from scenario import gazebo as scenario
 from ..common.utils import gazebo_fixture as gazebo
-from gym_ignition import scenario_bindings as bindings
 from gym_ignition.controllers.gazebo import computed_torque_fixed_base as context
 
 # Set the verbosity
-bindings.set_verbosity(4)
+scenario.set_verbosity(scenario.Verbosity_debug)
 
 
 @pytest.mark.parametrize("gazebo",
                          [(0.001, 5.0, 1)],
                          indirect=True,
                          ids=utils.id_gazebo_fn)
-def test_computed_torque_fixed_base(gazebo: bindings.GazeboSimulator):
+def test_computed_torque_fixed_base(gazebo: scenario.GazeboSimulator):
 
     assert gazebo.initialize()
     step_size = gazebo.step_size()
@@ -29,21 +30,21 @@ def test_computed_torque_fixed_base(gazebo: bindings.GazeboSimulator):
     world = gazebo.get_world()
 
     # Insert the physics
-    assert world.set_physics_engine(bindings.PhysicsEngine_dart)
+    assert world.set_physics_engine(scenario.PhysicsEngine_dart)
 
     # Get the panda urdf
     panda_urdf = gym_ignition_models.get_model_file("panda")
 
     # Insert the panda arm
     model_name = "panda"
-    assert world.insert_model(panda_urdf, bindings.Pose_identity(), model_name)
+    assert world.insert_model(panda_urdf, core.Pose_identity(), model_name)
 
     # import time
     # gazebo.gui()
     # time.sleep(3)
 
     # Get the model
-    panda: bindings.Model = world.get_model(model_name)
+    panda: scenario.Model = world.get_model(model_name).to_gazebo()
 
     # Disable self-collisions
     panda.enable_self_collisions(False)

--- a/tests/test_scenario/test_gazebo_simulator.py
+++ b/tests/test_scenario/test_gazebo_simulator.py
@@ -6,11 +6,11 @@ import pytest
 pytestmark = pytest.mark.scenario
 
 from ..common import utils
+from scenario import gazebo as scenario
 from ..common.utils import gazebo_fixture as gazebo
-from gym_ignition import scenario_bindings as bindings
 
 # Set the verbosity
-bindings.set_verbosity(4)
+scenario.set_verbosity(scenario.Verbosity_debug)
 
 
 @pytest.mark.parametrize("gazebo",
@@ -22,7 +22,7 @@ bindings.set_verbosity(4)
                              (0.001, 1.0, 0),
                              (0, 1.0, 1),
                          ], indirect=True, ids=utils.id_gazebo_fn)
-def test_initialization(gazebo: bindings.GazeboSimulator):
+def test_initialization(gazebo: scenario.GazeboSimulator):
 
     ok = gazebo.initialize()
 
@@ -54,7 +54,7 @@ def test_initialization(gazebo: bindings.GazeboSimulator):
                          [(0.001, 1.0, 1)],
                          indirect=True,
                          ids=utils.id_gazebo_fn)
-def test_run(gazebo: bindings.GazeboSimulator):
+def test_run(gazebo: scenario.GazeboSimulator):
 
     assert gazebo.initialize()
     assert gazebo.run(paused=True)
@@ -65,7 +65,7 @@ def test_run(gazebo: bindings.GazeboSimulator):
                          [(0.001, 1.0, 1)],
                          indirect=True,
                          ids=utils.id_gazebo_fn)
-def test_pause(gazebo: bindings.GazeboSimulator):
+def test_pause(gazebo: scenario.GazeboSimulator):
 
     assert gazebo.initialize()
     assert not gazebo.running()
@@ -89,7 +89,7 @@ def test_pause(gazebo: bindings.GazeboSimulator):
                          [(0.001, 1.0, 1)],
                          indirect=True,
                          ids=utils.id_gazebo_fn)
-def test_load_default_world(gazebo: bindings.GazeboSimulator):
+def test_load_default_world(gazebo: scenario.GazeboSimulator):
 
     assert gazebo.initialize()
     assert gazebo.world_names()

--- a/tests/test_scenario/test_ignition_fuel.py
+++ b/tests/test_scenario/test_ignition_fuel.py
@@ -6,18 +6,19 @@ import pytest
 pytestmark = pytest.mark.scenario
 
 from ..common import utils
+from scenario import core
+from scenario import gazebo as scenario
 from ..common.utils import gazebo_fixture as gazebo
-from gym_ignition import scenario_bindings as bindings
 
 # Set the verbosity
-bindings.set_verbosity(4)
+scenario.set_verbosity(scenario.Verbosity_debug)
 
 
 @pytest.mark.parametrize("gazebo",
                          [(0.001, 1.0, 1)],
                          indirect=True,
                          ids=utils.id_gazebo_fn)
-def test_download_model_from_fuel(gazebo: bindings.GazeboSimulator):
+def test_download_model_from_fuel(gazebo: scenario.GazeboSimulator):
 
     assert gazebo.initialize()
 
@@ -26,16 +27,16 @@ def test_download_model_from_fuel(gazebo: bindings.GazeboSimulator):
 
     # Download a model from Fuel (testing a name with spaces)
     model_name = "Electrical Box"
-    model_sdf = bindings.get_model_file_from_fuel(
+    model_sdf = scenario.get_model_file_from_fuel(
         f"https://fuel.ignitionrobotics.org/openrobotics/models/{model_name}", False)
     assert model_sdf
 
-    assert world.insert_model(model_sdf, bindings.Pose_identity())
+    assert world.insert_model(model_sdf, core.Pose_identity())
     assert model_name in world.model_names()
 
     # Insert another model changing its name
     other_model_name = "my_box"
-    other_model_pose = bindings.Pose([3.0, 0.0, 0.0], [1.0, 0, 0, 0])
+    other_model_pose = core.Pose([3.0, 0.0, 0.0], [1.0, 0, 0, 0])
     assert world.insert_model(model_sdf, other_model_pose, other_model_name)
     assert other_model_name in world.model_names()
 

--- a/tests/test_scenario/test_multi_world.py
+++ b/tests/test_scenario/test_multi_world.py
@@ -6,18 +6,18 @@ import pytest
 pytestmark = pytest.mark.scenario
 
 from ..common import utils
+from scenario import gazebo as scenario
 from ..common.utils import gazebo_fixture as gazebo
-from gym_ignition import scenario_bindings as bindings
 
 # Set the verbosity
-bindings.set_verbosity(4)
+scenario.set_verbosity(scenario.Verbosity_debug)
 
 
 @pytest.mark.parametrize("gazebo",
                          [(0.001, 1.0, 1)],
                          indirect=True,
                          ids=utils.id_gazebo_fn)
-def test_insert_multiple_worlds(gazebo: bindings.GazeboSimulator):
+def test_insert_multiple_worlds(gazebo: scenario.GazeboSimulator):
 
     empty_world_sdf = utils.get_empty_world_sdf()
     assert gazebo.insert_world_from_sdf(empty_world_sdf, "myWorld1")
@@ -41,7 +41,7 @@ def test_insert_multiple_worlds(gazebo: bindings.GazeboSimulator):
                          [(0.001, 1.0, 1)],
                          indirect=True,
                          ids=utils.id_gazebo_fn)
-def test_insert_multiple_world(gazebo: bindings.GazeboSimulator):
+def test_insert_multiple_world(gazebo: scenario.GazeboSimulator):
 
     multi_world_sdf = utils.get_multi_world_sdf_file()
 
@@ -64,7 +64,7 @@ def test_insert_multiple_world(gazebo: bindings.GazeboSimulator):
                          [(0.001, 1.0, 1)],
                          indirect=True,
                          ids=utils.id_gazebo_fn)
-def test_insert_multiple_world_rename(gazebo: bindings.GazeboSimulator):
+def test_insert_multiple_world_rename(gazebo: scenario.GazeboSimulator):
 
     multi_world_sdf = utils.get_multi_world_sdf_file()
 
@@ -88,7 +88,7 @@ def test_insert_multiple_world_rename(gazebo: bindings.GazeboSimulator):
                          [(0.001, 1.0, 1)],
                          indirect=True,
                          ids=utils.id_gazebo_fn)
-def test_insert_world_multiple_calls(gazebo: bindings.GazeboSimulator):
+def test_insert_world_multiple_calls(gazebo: scenario.GazeboSimulator):
 
     single_world_sdf = utils.get_empty_world_sdf()
 

--- a/tests/test_scenario/test_world.py
+++ b/tests/test_scenario/test_world.py
@@ -5,19 +5,20 @@
 import pytest
 pytestmark = pytest.mark.scenario
 
+from scenario import core
 from ..common import utils
+from scenario import gazebo as scenario
 from ..common.utils import gazebo_fixture as gazebo
-from gym_ignition import scenario_bindings as bindings
 
 # Set the verbosity
-bindings.set_verbosity(4)
+scenario.set_verbosity(scenario.Verbosity_debug)
 
 
 @pytest.mark.parametrize("gazebo",
                          [(0.001, 1.0, 1)],
                          indirect=True,
                          ids=utils.id_gazebo_fn)
-def test_load_default_world(gazebo: bindings.GazeboSimulator):
+def test_load_default_world(gazebo: scenario.GazeboSimulator):
 
     assert gazebo.initialize()
     world = gazebo.get_world()
@@ -31,7 +32,7 @@ def test_load_default_world(gazebo: bindings.GazeboSimulator):
                          [(0.001, 1.0, 1)],
                          indirect=True,
                          ids=utils.id_gazebo_fn)
-def test_load_default_world_from_file(gazebo: bindings.GazeboSimulator):
+def test_load_default_world_from_file(gazebo: scenario.GazeboSimulator):
 
     empty_world_sdf = utils.get_empty_world_sdf()
 
@@ -49,7 +50,7 @@ def test_load_default_world_from_file(gazebo: bindings.GazeboSimulator):
                          [(0.001, 1.0, 1)],
                          indirect=True,
                          ids=utils.id_gazebo_fn)
-def test_rename_default_world(gazebo: bindings.GazeboSimulator):
+def test_rename_default_world(gazebo: scenario.GazeboSimulator):
 
     empty_world_sdf = utils.get_empty_world_sdf()
     assert gazebo.insert_world_from_sdf(empty_world_sdf, "myWorld")
@@ -72,7 +73,7 @@ def test_rename_default_world(gazebo: bindings.GazeboSimulator):
                          [(0.001, 1.0, 1)],
                          indirect=True,
                          ids=utils.id_gazebo_fn)
-def test_world_api(gazebo: bindings.GazeboSimulator):
+def test_world_api(gazebo: scenario.GazeboSimulator):
 
     assert gazebo.initialize()
     world = gazebo.get_world()
@@ -91,7 +92,7 @@ def test_world_api(gazebo: bindings.GazeboSimulator):
     assert world.insert_model(cube_urdf)
     assert len(world.model_names()) == 1
 
-    default_model_name = bindings.get_model_name_from_sdf(cube_urdf, 0)
+    default_model_name = scenario.get_model_name_from_sdf(cube_urdf, 0)
     assert default_model_name in world.model_names()
     cube1 = world.get_model(default_model_name)
     # TODO: assert cube1
@@ -107,7 +108,7 @@ def test_world_api(gazebo: bindings.GazeboSimulator):
     # Insert second cube with custom name and pose
     custom_model_name = "other_cube"
     assert custom_model_name != default_model_name
-    custom_model_pose = bindings.Pose([1, 1, 0], [0, 0, 0, 1])
+    custom_model_pose = core.Pose([1, 1, 0], [0, 0, 0, 1])
 
     assert world.insert_model(cube_urdf, custom_model_pose, custom_model_name)
     assert custom_model_name in world.model_names()
@@ -138,7 +139,7 @@ def test_world_api(gazebo: bindings.GazeboSimulator):
                          [(0.001, 1.0, 1)],
                          indirect=True,
                          ids=utils.id_gazebo_fn)
-def test_world_physics_plugin(gazebo: bindings.GazeboSimulator):
+def test_world_physics_plugin(gazebo: scenario.GazeboSimulator):
 
     assert gazebo.initialize()
     world = gazebo.get_world()
@@ -150,7 +151,7 @@ def test_world_physics_plugin(gazebo: bindings.GazeboSimulator):
     # Insert a cube
     cube_urdf = utils.get_cube_urdf()
     cube_name = "my_cube"
-    cube_pose = bindings.Pose([0, 0, 1.0], [1, 0, 0, 0])
+    cube_pose = core.Pose([0, 0, 1.0], [1, 0, 0, 0])
     assert world.insert_model(cube_urdf, cube_pose, cube_name)
     assert cube_name in world.model_names()
 
@@ -164,7 +165,7 @@ def test_world_physics_plugin(gazebo: bindings.GazeboSimulator):
     assert world.time() == 0
 
     # Insert the Physics system
-    assert world.set_physics_engine(bindings.PhysicsEngine_dart)
+    assert world.set_physics_engine(scenario.PhysicsEngine_dart)
 
     # After the first step, the physics catches up with time
     gazebo.run()
@@ -185,7 +186,7 @@ def test_world_physics_plugin(gazebo: bindings.GazeboSimulator):
                          [(0.001, 1.0, 1)],
                          indirect=True,
                          ids=utils.id_gazebo_fn)
-def test_sim_time_starts_from_zero(gazebo: bindings.GazeboSimulator):
+def test_sim_time_starts_from_zero(gazebo: scenario.GazeboSimulator):
 
     assert gazebo.initialize()
     world = gazebo.get_world()
@@ -193,7 +194,7 @@ def test_sim_time_starts_from_zero(gazebo: bindings.GazeboSimulator):
     dt = gazebo.step_size()
 
     assert world.time() == 0
-    assert world.set_physics_engine(bindings.PhysicsEngine_dart)
+    assert world.set_physics_engine(scenario.PhysicsEngine_dart)
     assert world.time() == 0
 
     gazebo.run(paused=True)


### PR DESCRIPTION
This PR updates the Python tests to use the new ScenarI/O bindings structure introduced in #223.

This PR is part of a bigger picture that can be found in #220. CI is green again :tada: