### PR TITLE
Update website generation pipeline

### DIFF
--- a/docs/sphinx/CMakeLists.txt
+++ b/docs/sphinx/CMakeLists.txt
@@ -26,27 +26,28 @@ set(BINDINGS_MODULES_DIR "${PROJECT_BINARY_DIR}/bindings")
 # - docs/sphinx/gym_ignition_environments
 
 find_package(SphinxApidoc REQUIRED)
-add_custom_target(apidoc ALL DEPENDS scenario_bindings)
+add_custom_target(apidoc ALL DEPENDS
+    doxygen Scenario::SwigScenarioCore Scenario::SwigScenarioGazebo)
 
 add_custom_command(
     TARGET apidoc POST_BUILD
     COMMAND
     ${SPHINX_APIDOC_EXECUTABLE} -f -o ${CMAKE_CURRENT_SOURCE_DIR}/gym-ignition
     ${PYTHON_PACKAGES_DIR}/gym_ignition
-    COMMENT "Building gym-ignition apidoc")
+    COMMENT "Building <gym-ignition> apidoc")
 
 add_custom_command(
     TARGET apidoc POST_BUILD
     COMMAND
     ${SPHINX_APIDOC_EXECUTABLE} -f -o ${CMAKE_CURRENT_SOURCE_DIR}/gym-ignition-environments
     ${PYTHON_PACKAGES_DIR}/gym_ignition_environments
-    COMMENT "Building gym-ignition apidoc")
+    COMMENT "Building <gym-ignition-environments> apidoc")
 
 add_custom_command(
     TARGET apidoc POST_BUILD
     COMMAND
     ${SPHINX_APIDOC_EXECUTABLE} -f -o ${CMAKE_CURRENT_SOURCE_DIR}/scenario ${BINDINGS_MODULES_DIR}
-    COMMENT "Building scenario apidoc")
+    COMMENT "Building <scenario> apidoc")
 
 # =============
 # SPHINX TARGET

--- a/docs/sphinx/CMakeLists.txt
+++ b/docs/sphinx/CMakeLists.txt
@@ -32,21 +32,31 @@ add_custom_target(apidoc ALL DEPENDS
 add_custom_command(
     TARGET apidoc POST_BUILD
     COMMAND
-    ${SPHINX_APIDOC_EXECUTABLE} -f -o ${CMAKE_CURRENT_SOURCE_DIR}/gym-ignition
+    ${SPHINX_APIDOC_EXECUTABLE} --force
+    --no-toc --module-first --maxdepth 4
+    -t ${CMAKE_CURRENT_SOURCE_DIR}/_templates
+    -o ${CMAKE_CURRENT_SOURCE_DIR}/apidoc/gym-ignition
     ${PYTHON_PACKAGES_DIR}/gym_ignition
     COMMENT "Building <gym-ignition> apidoc")
 
 add_custom_command(
     TARGET apidoc POST_BUILD
     COMMAND
-    ${SPHINX_APIDOC_EXECUTABLE} -f -o ${CMAKE_CURRENT_SOURCE_DIR}/gym-ignition-environments
+    ${SPHINX_APIDOC_EXECUTABLE} --force
+    --no-toc --module-first --maxdepth 4
+    -t ${CMAKE_CURRENT_SOURCE_DIR}/_templates
+    -o ${CMAKE_CURRENT_SOURCE_DIR}/apidoc/gym-ignition-environments
     ${PYTHON_PACKAGES_DIR}/gym_ignition_environments
     COMMENT "Building <gym-ignition-environments> apidoc")
 
 add_custom_command(
     TARGET apidoc POST_BUILD
     COMMAND
-    ${SPHINX_APIDOC_EXECUTABLE} -f -o ${CMAKE_CURRENT_SOURCE_DIR}/scenario ${BINDINGS_MODULES_DIR}
+    ${SPHINX_APIDOC_EXECUTABLE} --force
+    --no-toc --module-first --maxdepth 4
+    -t ${CMAKE_CURRENT_SOURCE_DIR}/_templates
+    -o ${CMAKE_CURRENT_SOURCE_DIR}/apidoc/scenario
+    ${BINDINGS_MODULES_DIR}
     COMMENT "Building <scenario> apidoc")
 
 # =============
@@ -67,10 +77,10 @@ set(SPHINX_SOURCE ${CMAKE_CURRENT_SOURCE_DIR})
 set(SPHINX_CMD export PYTHONPATH="${PYTHON_PACKAGES_DIR}:${BINDINGS_MODULES_DIR}:$ENV{PYTHONPATH}" &&)
 
 # Sphinx build command
-list(APPEND
-    SPHINX_CMD ${SPHINX_MULTIVERSION_EXECUTABLE}
+list(APPEND SPHINX_CMD
+    ${SPHINX_MULTIVERSION_EXECUTABLE}
     ${SPHINX_SOURCE} ${SPHINX_BUILD}
-    -D breathe_projects.GymIgnition="${DOXYGEN_OUTPUT_DIRECTORY}/xml")
+    -D breathe_projects.scenario="${DOXYGEN_OUTPUT_DIRECTORY}/xml")
 
 # Generate the website
 add_custom_target(sphinx ALL

--- a/docs/sphinx/_templates/module.rst_t
+++ b/docs/sphinx/_templates/module.rst_t
@@ -1,0 +1,8 @@
+{%- if show_headings %}
+{{- [basename, "module"] | join(' ') | e | heading }}
+
+{% endif -%}
+.. automodule:: {{ qualname }}
+{%- for option in automodule_options %}
+   :{{ option }}:
+{%- endfor %}

--- a/docs/sphinx/_templates/package.rst_t
+++ b/docs/sphinx/_templates/package.rst_t
@@ -1,0 +1,53 @@
+{%- macro automodule(modname, options) -%}
+.. automodule:: {{ modname }}
+{%- for option in options %}
+   :{{ option }}:
+{%- endfor %}
+{%- endmacro %}
+
+{%- macro toctree(docnames) -%}
+.. toctree::
+   :maxdepth: {{ maxdepth }}
+{% for docname in docnames %}
+   {{ docname }}
+{%- endfor %}
+{%- endmacro %}
+
+{%- if is_namespace %}
+{{- [pkgname, "namespace"] | join(" ") | e | heading }}
+{% else %}
+{{- [pkgname, "package"] | join(" ") | e | heading }}
+{% endif %}
+
+{%- if modulefirst and not is_namespace %}
+{{ automodule(pkgname, automodule_options) }}
+{% endif %}
+
+{%- if subpackages %}
+Subpackages
+-----------
+
+{{ toctree(subpackages) }}
+{% endif %}
+
+{%- if submodules %}
+Submodules
+----------
+{% if separatemodules %}
+{{ toctree(submodules) }}
+{% else %}
+{%- for submodule in submodules %}
+{% if show_headings %}
+{{- [submodule, "module"] | join(" ") | e | heading(2) }}
+{% endif %}
+{{ automodule(submodule, automodule_options) }}
+{% endfor %}
+{%- endif %}
+{%- endif %}
+
+{%- if not modulefirst and not is_namespace %}
+Module contents
+---------------
+
+{{ automodule(pkgname, automodule_options) }}
+{% endif %}

--- a/docs/sphinx/_templates/package.rst_t
+++ b/docs/sphinx/_templates/package.rst_t
@@ -16,7 +16,7 @@
 {%- if is_namespace %}
 {{- [pkgname, "namespace"] | join(" ") | e | heading }}
 {% else %}
-{{- [pkgname, "package"] | join(" ") | e | heading }}
+{{- pkgname | e | heading }}
 {% endif %}
 
 {%- if modulefirst and not is_namespace %}
@@ -24,21 +24,17 @@
 {% endif %}
 
 {%- if subpackages %}
-Subpackages
------------
 
 {{ toctree(subpackages) }}
 {% endif %}
 
 {%- if submodules %}
-Submodules
-----------
 {% if separatemodules %}
 {{ toctree(submodules) }}
 {% else %}
 {%- for submodule in submodules %}
 {% if show_headings %}
-{{- [submodule, "module"] | join(" ") | e | heading(2) }}
+{{- submodule | e | heading(2) }}
 {% endif %}
 {{ automodule(submodule, automodule_options) }}
 {% endfor %}

--- a/docs/sphinx/_templates/toc.rst_t
+++ b/docs/sphinx/_templates/toc.rst_t
@@ -1,0 +1,7 @@
+{{ header | heading }}
+
+.. toctree::
+   :maxdepth: {{ maxdepth }}
+{% for docname in docnames %}
+   {{ docname }}
+{%- endfor %}

--- a/docs/sphinx/apidoc/gym-ignition-environments/gym_ignition_environments.models.rst
+++ b/docs/sphinx/apidoc/gym-ignition-environments/gym_ignition_environments.models.rst
@@ -1,0 +1,24 @@
+gym\_ignition\_environments.models
+==================================
+
+.. automodule:: gym_ignition_environments.models
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+gym\_ignition\_environments.models.cartpole
+-------------------------------------------
+
+.. automodule:: gym_ignition_environments.models.cartpole
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+gym\_ignition\_environments.models.pendulum
+-------------------------------------------
+
+.. automodule:: gym_ignition_environments.models.pendulum
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sphinx/apidoc/gym-ignition-environments/gym_ignition_environments.randomizers.rst
+++ b/docs/sphinx/apidoc/gym-ignition-environments/gym_ignition_environments.randomizers.rst
@@ -1,0 +1,24 @@
+gym\_ignition\_environments.randomizers
+=======================================
+
+.. automodule:: gym_ignition_environments.randomizers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+gym\_ignition\_environments.randomizers.cartpole
+------------------------------------------------
+
+.. automodule:: gym_ignition_environments.randomizers.cartpole
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+gym\_ignition\_environments.randomizers.cartpole\_no\_rand
+----------------------------------------------------------
+
+.. automodule:: gym_ignition_environments.randomizers.cartpole_no_rand
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sphinx/apidoc/gym-ignition-environments/gym_ignition_environments.rst
+++ b/docs/sphinx/apidoc/gym-ignition-environments/gym_ignition_environments.rst
@@ -1,0 +1,15 @@
+gym\_ignition\_environments
+===========================
+
+.. automodule:: gym_ignition_environments
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. toctree::
+   :maxdepth: 4
+
+   gym_ignition_environments.models
+   gym_ignition_environments.randomizers
+   gym_ignition_environments.tasks

--- a/docs/sphinx/apidoc/gym-ignition-environments/gym_ignition_environments.tasks.rst
+++ b/docs/sphinx/apidoc/gym-ignition-environments/gym_ignition_environments.tasks.rst
@@ -1,0 +1,40 @@
+gym\_ignition\_environments.tasks
+=================================
+
+.. automodule:: gym_ignition_environments.tasks
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+gym\_ignition\_environments.tasks.cartpole\_continuous\_balancing
+-----------------------------------------------------------------
+
+.. automodule:: gym_ignition_environments.tasks.cartpole_continuous_balancing
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+gym\_ignition\_environments.tasks.cartpole\_continuous\_swingup
+---------------------------------------------------------------
+
+.. automodule:: gym_ignition_environments.tasks.cartpole_continuous_swingup
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+gym\_ignition\_environments.tasks.cartpole\_discrete\_balancing
+---------------------------------------------------------------
+
+.. automodule:: gym_ignition_environments.tasks.cartpole_discrete_balancing
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+gym\_ignition\_environments.tasks.pendulum\_swingup
+---------------------------------------------------
+
+.. automodule:: gym_ignition_environments.tasks.pendulum_swingup
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sphinx/apidoc/gym-ignition/gym_ignition.base.rst
+++ b/docs/sphinx/apidoc/gym-ignition/gym_ignition.base.rst
@@ -1,0 +1,24 @@
+gym\_ignition.base
+==================
+
+.. automodule:: gym_ignition.base
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+gym\_ignition.base.runtime
+--------------------------
+
+.. automodule:: gym_ignition.base.runtime
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+gym\_ignition.base.task
+-----------------------
+
+.. automodule:: gym_ignition.base.task
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sphinx/apidoc/gym-ignition/gym_ignition.controllers.gazebo.rst
+++ b/docs/sphinx/apidoc/gym-ignition/gym_ignition.controllers.gazebo.rst
@@ -1,0 +1,16 @@
+gym\_ignition.controllers.gazebo
+================================
+
+.. automodule:: gym_ignition.controllers.gazebo
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+gym\_ignition.controllers.gazebo.computed\_torque\_fixed\_base
+--------------------------------------------------------------
+
+.. automodule:: gym_ignition.controllers.gazebo.computed_torque_fixed_base
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sphinx/apidoc/gym-ignition/gym_ignition.controllers.rst
+++ b/docs/sphinx/apidoc/gym-ignition/gym_ignition.controllers.rst
@@ -1,0 +1,13 @@
+gym\_ignition.controllers
+=========================
+
+.. automodule:: gym_ignition.controllers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. toctree::
+   :maxdepth: 4
+
+   gym_ignition.controllers.gazebo

--- a/docs/sphinx/apidoc/gym-ignition/gym_ignition.experimental.gympp.rst
+++ b/docs/sphinx/apidoc/gym-ignition/gym_ignition.experimental.gympp.rst
@@ -1,0 +1,24 @@
+gym\_ignition.experimental.gympp
+================================
+
+.. automodule:: gym_ignition.experimental.gympp
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+gym\_ignition.experimental.gympp.cartpole
+-----------------------------------------
+
+.. automodule:: gym_ignition.experimental.gympp.cartpole
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+gym\_ignition.experimental.gympp.gympp\_env
+-------------------------------------------
+
+.. automodule:: gym_ignition.experimental.gympp.gympp_env
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sphinx/apidoc/gym-ignition/gym_ignition.experimental.rst
+++ b/docs/sphinx/apidoc/gym-ignition/gym_ignition.experimental.rst
@@ -1,0 +1,13 @@
+gym\_ignition.experimental
+==========================
+
+.. automodule:: gym_ignition.experimental
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. toctree::
+   :maxdepth: 4
+
+   gym_ignition.experimental.gympp

--- a/docs/sphinx/apidoc/gym-ignition/gym_ignition.randomizers.base.rst
+++ b/docs/sphinx/apidoc/gym-ignition/gym_ignition.randomizers.base.rst
@@ -1,0 +1,32 @@
+gym\_ignition.randomizers.base
+==============================
+
+.. automodule:: gym_ignition.randomizers.base
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+gym\_ignition.randomizers.base.model
+------------------------------------
+
+.. automodule:: gym_ignition.randomizers.base.model
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+gym\_ignition.randomizers.base.physics
+--------------------------------------
+
+.. automodule:: gym_ignition.randomizers.base.physics
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+gym\_ignition.randomizers.base.task
+-----------------------------------
+
+.. automodule:: gym_ignition.randomizers.base.task
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sphinx/apidoc/gym-ignition/gym_ignition.randomizers.model.rst
+++ b/docs/sphinx/apidoc/gym-ignition/gym_ignition.randomizers.model.rst
@@ -1,0 +1,16 @@
+gym\_ignition.randomizers.model
+===============================
+
+.. automodule:: gym_ignition.randomizers.model
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+gym\_ignition.randomizers.model.sdf
+-----------------------------------
+
+.. automodule:: gym_ignition.randomizers.model.sdf
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sphinx/apidoc/gym-ignition/gym_ignition.randomizers.physics.rst
+++ b/docs/sphinx/apidoc/gym-ignition/gym_ignition.randomizers.physics.rst
@@ -1,0 +1,16 @@
+gym\_ignition.randomizers.physics
+=================================
+
+.. automodule:: gym_ignition.randomizers.physics
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+gym\_ignition.randomizers.physics.dart
+--------------------------------------
+
+.. automodule:: gym_ignition.randomizers.physics.dart
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sphinx/apidoc/gym-ignition/gym_ignition.randomizers.rst
+++ b/docs/sphinx/apidoc/gym-ignition/gym_ignition.randomizers.rst
@@ -1,0 +1,24 @@
+gym\_ignition.randomizers
+=========================
+
+.. automodule:: gym_ignition.randomizers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. toctree::
+   :maxdepth: 4
+
+   gym_ignition.randomizers.base
+   gym_ignition.randomizers.model
+   gym_ignition.randomizers.physics
+
+
+gym\_ignition.randomizers.gazebo\_env\_randomizer
+-------------------------------------------------
+
+.. automodule:: gym_ignition.randomizers.gazebo_env_randomizer
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sphinx/apidoc/gym-ignition/gym_ignition.rst
+++ b/docs/sphinx/apidoc/gym-ignition/gym_ignition.rst
@@ -1,0 +1,19 @@
+gym\_ignition
+=============
+
+.. automodule:: gym_ignition
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. toctree::
+   :maxdepth: 4
+
+   gym_ignition.base
+   gym_ignition.controllers
+   gym_ignition.experimental
+   gym_ignition.randomizers
+   gym_ignition.runtimes
+   gym_ignition.scenario
+   gym_ignition.utils

--- a/docs/sphinx/apidoc/gym-ignition/gym_ignition.runtimes.rst
+++ b/docs/sphinx/apidoc/gym-ignition/gym_ignition.runtimes.rst
@@ -1,0 +1,24 @@
+gym\_ignition.runtimes
+======================
+
+.. automodule:: gym_ignition.runtimes
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+gym\_ignition.runtimes.gazebo\_runtime
+--------------------------------------
+
+.. automodule:: gym_ignition.runtimes.gazebo_runtime
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+gym\_ignition.runtimes.realtime\_runtime
+----------------------------------------
+
+.. automodule:: gym_ignition.runtimes.realtime_runtime
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sphinx/apidoc/gym-ignition/gym_ignition.scenario.rst
+++ b/docs/sphinx/apidoc/gym-ignition/gym_ignition.scenario.rst
@@ -1,0 +1,24 @@
+gym\_ignition.scenario
+======================
+
+.. automodule:: gym_ignition.scenario
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+gym\_ignition.scenario.model\_with\_file
+----------------------------------------
+
+.. automodule:: gym_ignition.scenario.model_with_file
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+gym\_ignition.scenario.model\_wrapper
+-------------------------------------
+
+.. automodule:: gym_ignition.scenario.model_wrapper
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sphinx/apidoc/gym-ignition/gym_ignition.utils.rst
+++ b/docs/sphinx/apidoc/gym-ignition/gym_ignition.utils.rst
@@ -1,0 +1,64 @@
+gym\_ignition.utils
+===================
+
+.. automodule:: gym_ignition.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+gym\_ignition.utils.inverse\_kinematics\_nlp
+--------------------------------------------
+
+.. automodule:: gym_ignition.utils.inverse_kinematics_nlp
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+gym\_ignition.utils.logger
+--------------------------
+
+.. automodule:: gym_ignition.utils.logger
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+gym\_ignition.utils.math
+------------------------
+
+.. automodule:: gym_ignition.utils.math
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+gym\_ignition.utils.misc
+------------------------
+
+.. automodule:: gym_ignition.utils.misc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+gym\_ignition.utils.resource\_finder
+------------------------------------
+
+.. automodule:: gym_ignition.utils.resource_finder
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+gym\_ignition.utils.scenario
+----------------------------
+
+.. automodule:: gym_ignition.utils.scenario
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+gym\_ignition.utils.typing
+--------------------------
+
+.. automodule:: gym_ignition.utils.typing
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sphinx/apidoc/scenario/scenario.bindings.rst
+++ b/docs/sphinx/apidoc/scenario/scenario.bindings.rst
@@ -1,0 +1,24 @@
+scenario.bindings
+=================
+
+.. automodule:: scenario.bindings
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+scenario.bindings.core
+----------------------
+
+.. automodule:: scenario.bindings.core
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+scenario.bindings.gazebo
+------------------------
+
+.. automodule:: scenario.bindings.gazebo
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sphinx/apidoc/scenario/scenario.rst
+++ b/docs/sphinx/apidoc/scenario/scenario.rst
@@ -1,0 +1,13 @@
+scenario
+========
+
+.. automodule:: scenario
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. toctree::
+   :maxdepth: 4
+
+   scenario.bindings

--- a/docs/sphinx/breathe/core.rst
+++ b/docs/sphinx/breathe/core.rst
@@ -1,0 +1,17 @@
+Core
+====
+
+.. doxygenclass:: scenario::core::World
+   :members:
+
+.. doxygenclass:: scenario::core::Model
+   :members:
+
+.. doxygenclass:: scenario::core::Link
+   :members:
+
+.. doxygenclass:: scenario::core::Joint
+   :members:
+
+.. doxygenfile:: core/utils/utils.h
+   :project: scenario

--- a/docs/sphinx/breathe/gazebo.rst
+++ b/docs/sphinx/breathe/gazebo.rst
@@ -1,0 +1,20 @@
+Gazebo
+======
+
+.. doxygenclass:: scenario::gazebo::GazeboSimulator
+   :members:
+
+.. doxygenclass:: scenario::gazebo::World
+   :members:
+
+.. doxygenclass:: scenario::gazebo::Model
+   :members:
+
+.. doxygenclass:: scenario::gazebo::Link
+   :members:
+
+.. doxygenclass:: scenario::gazebo::Joint
+   :members:
+
+.. doxygenfile:: gazebo/utils.h
+   :project: scenario

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -26,7 +26,6 @@ author = 'Diego Ferigo'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'breathe',
     'sphinx.ext.autodoc',
     'sphinx.ext.todo',
     'sphinx.ext.mathjax',
@@ -36,6 +35,7 @@ extensions = [
     'sphinx_autodoc_typehints',
     "sphinx_multiversion",
     "sphinx_fontawesome",
+    'breathe',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -76,7 +76,7 @@ todo_include_todos = True
 
 # -- Options for breathe extension ----------------------------------------------
 
-breathe_default_project = "GymIgnition"
+breathe_default_project = "scenario"
 
 # -- Options for sphinx_multiversion extension ----------------------------------
 

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -11,3 +11,18 @@ gym-ignition
    installation/stable
    installation/nightly
    installation/optional_dependencies
+
+.. toctree::
+   :maxdepth: 2
+   :caption: ScenarI/O C++ API:
+
+   breathe/core
+   breathe/gazebo
+
+.. toctree::
+   :maxdepth: 4
+   :caption: Python Packages
+
+   apidoc/scenario/scenario.bindings
+   apidoc/gym-ignition/gym_ignition
+   apidoc/gym-ignition-environments/gym_ignition_environments


### PR DESCRIPTION
This PR updates the pipeline to generate the website. While pushing the files is still manual, this PR updates the CMake targets, particularly:

-  Finalizes the apidoc generation. We use [sphinx-apidoc](https://www.sphinx-doc.org/en/master/man/sphinx-apidoc.html) to generate these files that have to be committed in the `docs/sphinx/apidoc` folder of each documented branch and tag.
- Adds custom templates to render apidoc in the TOC.

Result:

![Screenshot_20200816_154001](https://user-images.githubusercontent.com/469199/90335662-c3d91280-dfd6-11ea-9820-29f9006ec58d.png)


Future PR still need to:

- Add a new github workflow that checks if every PR changed the Python API and asks to update the apidoc files
- Add a new github workflow that generates the website and pushes it to the `gh-pages` branch
- Document how to generate and visualize the website locally 