### PR TITLE
Remove lib*.so prefix and postfix from Gazebo plugin names

### DIFF
--- a/cpp/scenario/gazebo/src/GazeboSimulator.cpp
+++ b/cpp/scenario/gazebo/src/GazeboSimulator.cpp
@@ -263,7 +263,7 @@ bool GazeboSimulator::gui(const int verbosity)
         sDebug << "Starting the SceneBroadcaster plugin" << std::endl;
         auto world = this->getWorld(worldName);
         if (!std::static_pointer_cast<World>(world)->insertWorldPlugin(
-                "libignition-gazebo-scene-broadcaster-system.so",
+                "ignition-gazebo-scene-broadcaster-system",
                 "ignition::gazebo::systems::SceneBroadcaster")) {
             sError << "Failed to load SceneBroadcaster plugin" << std::endl;
         }
@@ -608,7 +608,7 @@ std::shared_ptr<ignition::gazebo::Server> GazeboSimulator::Impl::getServer()
         // Get the plugin info of the ECM provider
         auto getECMPluginInfo = [](const std::string& worldName) {
             ignition::gazebo::ServerConfig::PluginInfo pluginInfo;
-            pluginInfo.SetFilename("libECMProvider.so");
+            pluginInfo.SetFilename("ECMProvider");
             pluginInfo.SetName("scenario::plugins::gazebo::ECMProvider");
             pluginInfo.SetEntityType("world");
             pluginInfo.SetEntityName(worldName);

--- a/cpp/scenario/gazebo/src/World.cpp
+++ b/cpp/scenario/gazebo/src/World.cpp
@@ -154,7 +154,7 @@ bool World::setPhysicsEngine(const PhysicsEngine engine)
 
     switch (engine) {
         case PhysicsEngine::Dart:
-            libName = "libPhysicsSystem.so";
+            libName = "PhysicsSystem";
             className = "scenario::plugins::gazebo::Physics";
             break;
     }

--- a/cpp/scenario/plugins/Physics/Physics.cpp
+++ b/cpp/scenario/plugins/Physics/Physics.cpp
@@ -473,7 +473,7 @@ void Physics::Configure(const Entity& _entity,
 
     // 3. Use DART by default
     if (pluginLib.empty()) {
-        pluginLib = "libignition-physics-dartsim-plugin.so";
+        pluginLib = "ignition-physics-dartsim-plugin";
     }
 
     // Update component


### PR DESCRIPTION
The `ignition-plugin` library does not need to strictly pass the name of library. It is platform-independent and it follows lookup rules to locate the right shared library files. After https://github.com/ignitionrobotics/ign-gazebo/issues/277, we do our part also here.