### PR TITLE
Simplify controlling models with PIDs

### DIFF
--- a/cpp/scenario/gazebo/CMakeLists.txt
+++ b/cpp/scenario/gazebo/CMakeLists.txt
@@ -34,6 +34,7 @@ set(EXTRA_COMPONENTS_HDRS
     ${CMAKE_CURRENT_SOURCE_DIR}/include/scenario/gazebo/components/BaseWorldAccelerationTarget.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/scenario/gazebo/components/MaxJointForce.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/scenario/gazebo/components/JointControlMode.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/scenario/gazebo/components/JointController.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/scenario/gazebo/components/WorldVelocityCmd.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/scenario/gazebo/components/JointPositionTarget.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/scenario/gazebo/components/JointVelocityTarget.h

--- a/cpp/scenario/gazebo/include/scenario/gazebo/components/JointController.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/components/JointController.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This project is dual licensed under LGPL v2.1+ or Apache License.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IGNITION_GAZEBO_COMPONENTS_JOINTCONTROLLER_H
+#define IGNITION_GAZEBO_COMPONENTS_JOINTCONTROLLER_H
+
+#include <ignition/gazebo/components/Component.hh>
+#include <ignition/gazebo/components/Factory.hh>
+#include <ignition/gazebo/config.hh>
+
+namespace ignition::gazebo {
+    // Inline bracket to help doxygen filtering.
+    inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
+        namespace components {
+            /// \brief Marks whether a model has a JointController plugin.
+            using JointController = Component<bool, class JointControllerTag>;
+            IGN_GAZEBO_REGISTER_COMPONENT(
+                "ign_gazebo_components.JointController",
+                JointController)
+        } // namespace components
+    } // namespace IGNITION_GAZEBO_VERSION_NAMESPACE
+} // namespace ignition::gazebo
+
+#endif // IGNITION_GAZEBO_COMPONENTS_JOINTCONTROLLER_H

--- a/cpp/scenario/gazebo/include/scenario/gazebo/helpers.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/helpers.h
@@ -27,7 +27,6 @@
 #ifndef SCENARIO_GAZEBO_HELPERS_H
 #define SCENARIO_GAZEBO_HELPERS_H
 
-#include "scenario/core/World.h"
 #include "scenario/gazebo/Joint.h"
 #include "scenario/gazebo/Link.h"
 #include "scenario/gazebo/Model.h"
@@ -176,13 +175,15 @@ namespace scenario::gazebo::utils {
                             const ignition::math::Pose3d& M_H_B,
                             const ignition::math::Quaterniond& W_R_B);
 
-    core::WorldPtr getParentWorld(ignition::gazebo::EntityComponentManager* ecm,
-                                  ignition::gazebo::EventManager* eventManager,
-                                  const ignition::gazebo::Entity entity);
+    std::shared_ptr<World>
+    getParentWorld(ignition::gazebo::EntityComponentManager* ecm,
+                   ignition::gazebo::EventManager* eventManager,
+                   const ignition::gazebo::Entity entity);
 
-    core::ModelPtr getParentModel(ignition::gazebo::EntityComponentManager* ecm,
-                                  ignition::gazebo::EventManager* eventManager,
-                                  const ignition::gazebo::Entity entity);
+    std::shared_ptr<Model>
+    getParentModel(ignition::gazebo::EntityComponentManager* ecm,
+                   ignition::gazebo::EventManager* eventManager,
+                   const ignition::gazebo::Entity entity);
 
     template <typename ComponentType>
     ignition::gazebo::Entity getFirstParentEntityWithComponent(

--- a/cpp/scenario/gazebo/src/helpers.cpp
+++ b/cpp/scenario/gazebo/src/helpers.cpp
@@ -499,7 +499,7 @@ utils::fromBaseToModelVelocity(const ignition::math::Vector3d& linBaseVelocity,
     return {linModelVelocity, angModelVelocity};
 }
 
-scenario::core::WorldPtr
+std::shared_ptr<World>
 utils::getParentWorld(ignition::gazebo::EntityComponentManager* ecm,
                       ignition::gazebo::EventManager* eventManager,
                       const ignition::gazebo::Entity entity)
@@ -517,7 +517,7 @@ utils::getParentWorld(ignition::gazebo::EntityComponentManager* ecm,
     return world;
 }
 
-scenario::core::ModelPtr
+std::shared_ptr<Model>
 utils::getParentModel(ignition::gazebo::EntityComponentManager* ecm,
                       ignition::gazebo::EventManager* eventManager,
                       const ignition::gazebo::Entity entity)

--- a/cpp/scenario/plugins/JointController/JointController.cpp
+++ b/cpp/scenario/plugins/JointController/JointController.cpp
@@ -29,6 +29,7 @@
 #include "scenario/gazebo/Log.h"
 #include "scenario/gazebo/Model.h"
 #include "scenario/gazebo/components/JointControlMode.h"
+#include "scenario/gazebo/components/JointController.h"
 #include "scenario/gazebo/components/JointPID.h"
 #include "scenario/gazebo/components/JointPositionTarget.h"
 #include "scenario/gazebo/components/JointVelocityTarget.h"
@@ -79,6 +80,13 @@ void JointController::Configure(
     ignition::gazebo::EntityComponentManager& ecm,
     ignition::gazebo::EventManager& eventMgr)
 {
+    // Check if the model already has a JointController plugin
+    if (ecm.EntityHasComponentType(
+            entity, ignition::gazebo::components::JointController().TypeId())) {
+        sError << "The model already has a JointController plugin" << std::endl;
+        return;
+    }
+
     // Store the model entity
     pImpl->modelEntity = entity;
 
@@ -96,6 +104,10 @@ void JointController::Configure(
                << std::endl;
         return;
     }
+
+    // Add the JointController component to the model
+    utils::setComponentData<ignition::gazebo::components::JointController>(
+        &ecm, entity, true);
 }
 
 void JointController::PreUpdate(const ignition::gazebo::UpdateInfo& info,

--- a/tests/test_scenario/test_pid_controllers.py
+++ b/tests/test_scenario/test_pid_controllers.py
@@ -1,0 +1,115 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import pytest
+pytestmark = pytest.mark.scenario
+
+import numpy as np
+from typing import Tuple
+import gym_ignition_models
+from scenario import core
+from scenario import gazebo as scenario
+from ..common.utils import default_world_fixture as default_world
+
+# Set the verbosity
+scenario.set_verbosity(scenario.Verbosity_debug)
+
+# Panda PID gains
+# https://github.com/mkrizmancic/franka_gazebo/blob/master/config/default.yaml
+panda_pid_gains_1000Hz = {
+    'panda_joint1': core.PID(50,    0,  20),
+    'panda_joint2': core.PID(10000, 0, 500),
+    'panda_joint3': core.PID(100,   0,  10),
+    'panda_joint4': core.PID(1000,  0,  50),
+    'panda_joint5': core.PID(100,   0,  10),
+    'panda_joint6': core.PID(100,   0,  10),
+    'panda_joint7': core.PID(10,    0.5, 0.1),
+    'panda_finger_joint1': core.PID(100, 0, 50),
+    'panda_finger_joint2': core.PID(100, 0, 50),
+}
+
+
+@pytest.mark.parametrize("default_world", [(1.0 / 1_000, 1.0, 1)], indirect=True)
+def test_position_pid(default_world: Tuple[scenario.GazeboSimulator, scenario.World]):
+
+    # Get the simulator and the world
+    gazebo, world = default_world
+
+    # Insert a panda model
+    panda_urdf = gym_ignition_models.get_model_file("panda")
+    assert world.insert_model(panda_urdf)
+    assert "panda" in world.model_names()
+
+    # Show the GUI
+    # import time
+    # gazebo.gui()
+    # gazebo.run(paused=True)
+    # time.sleep(3)
+
+    # Get the model and cast it to Gazebo
+    panda = world.get_model("panda").to_gazebo()
+
+    # Reset joint1 to its middle position
+    joint1 = panda.get_joint("panda_joint1").to_gazebo()
+    joint1_range = np.abs(joint1.position_limit().max - joint1.position_limit().min)
+    joint1_middle = joint1.position_limit().min + joint1_range / 2
+    assert joint1.reset_position(joint1_middle)
+
+    # Reset joint6 to its middle position
+    joint6 = panda.get_joint("panda_joint6").to_gazebo()
+    joint6_range = np.abs(joint6.position_limit().max - joint6.position_limit().min)
+    joint6_middle = joint6.position_limit().min + joint6_range / 2
+    assert joint6.reset_position(joint6_middle)
+
+    # Update the model state without stepping the physics
+    assert gazebo.run(paused=True)
+
+    # Set the controller period equal to the physics step (1000Hz)
+    panda.set_controller_period(gazebo.step_size())
+
+    # Check that we have gains for all joints
+    assert set(panda.joint_names()) == set(panda_pid_gains_1000Hz.keys())
+
+    # Set the PID gains
+    for joint_name, pid in panda_pid_gains_1000Hz.items():
+        assert panda.get_joint(joint_name).set_pid(pid=pid)
+
+    # Switch to position control mode (it sets the current position as active target)
+    assert panda.set_joint_control_mode(core.JointControlMode_position)
+    assert panda.joint_position_targets() == pytest.approx(panda.joint_positions())
+
+    # Just fight gravity for a while
+    for _ in range(1_000):
+        assert gazebo.run()
+
+    # Check that it didn't move
+    assert panda.joint_positions() == pytest.approx(panda.joint_position_targets(),
+                                                    abs=np.deg2rad(1))
+
+    # joint1 trajectory
+    q0_joint1 = joint1.position()
+    q_joint1 = (0.9 * joint1_range / 2 * np.sin(2 * np.pi * 0.33 * t)
+                for t in np.arange(start=0, stop=10.0, step=gazebo.step_size()))
+
+    # joint6 trajectory
+    q0_joint6 = joint6.position()
+    q_joint6 = (0.9 * joint6_range / 2 * np.sin(2 * np.pi * 0.33 * t)
+                for t in np.arange(start=0, stop=10.0, step=gazebo.step_size()))
+
+    for _ in range(5_000):
+
+        # Generate the new references
+        joint1_reference = q0_joint1 + next(q_joint1)
+        joint6_reference = q0_joint6 + next(q_joint6)
+
+        # Set the new references
+        assert joint1.set_position_target(position=joint1_reference)
+        assert joint6.set_position_target(position=joint6_reference)
+
+        # Run the simulation
+        assert gazebo.run()
+
+        # Check that trajectory is being followed
+        assert joint1.position() == pytest.approx(joint1_reference, abs=np.deg2rad(3))
+        assert joint6.position() == pytest.approx(joint6_reference, abs=np.deg2rad(3))


### PR DESCRIPTION
`core.JointControlMode_position` is among the supported joint control modes we have implemented. Given a model, it can be enabled model-wise as follows:

```python
# Enable position control
panda: scenario.bindings.gazebo.Model = world.get_model("panda").to_gazebo()
panda.set_controller_period(0.001)
panda.set_joint_control_mode(core.JointControlMode_position)

# Set a reference
joint1 = panda.get_joint("panda_joint1")
joint1.set_position_target(position=joint1_reference)
```

However, this was not enough. In order to insert the PIDs in the simulation, the user also had to add the [`JointController`](https://github.com/robotology/gym-ignition/tree/devel/cpp/scenario/plugins/JointController) plugin to the model as follows:

```python
panda.insert_model_plugin("JointController", "scenario::plugins::gazebo::JointController")
```

The main reason is that, similarly to custom controllers (#167), also the JointController is a plugin that runs in its own thread. This was done in this way to allow running Python code at a lower rate than the controller and the physics (by executing multiple iterations every `GazeboSimulator.run`).

However, this plugin insertion is quite a low-level detail, and it requires the user to downcast the `scenario.bindings.core.Model` object to a `scenario.bindings.gazebo.Model`. This PR loads the plugin automatically as soon as either Position or Velocity control modes are enabled to any of the model joints.