### PR TITLE
Streamline GazeboEntity resources

### DIFF
--- a/bindings/gazebo/gazebo.i
+++ b/bindings/gazebo/gazebo.i
@@ -75,7 +75,10 @@ namespace scenario::gazebo::utils {
 %shared_ptr(scenario::gazebo::GazeboEntity)
 
 // Ignored methods
+%ignore scenario::gazebo::GazeboEntity::ecm;
 %ignore scenario::gazebo::GazeboEntity::initialize;
+%ignore scenario::gazebo::GazeboEntity::validEntity;
+%ignore scenario::gazebo::GazeboEntity::eventManager;
 %ignore scenario::gazebo::GazeboEntity::createECMResources;
 
 // Workaround for https://github.com/swig/swig/issues/1830

--- a/cpp/scenario/core/include/scenario/core/Joint.h
+++ b/cpp/scenario/core/include/scenario/core/Joint.h
@@ -53,6 +53,13 @@ public:
     virtual ~Joint() = default;
 
     /**
+     * Check if the joint is valid.
+     *
+     * @return True if the joint is valid, false otherwise.
+     */
+    virtual bool valid() const = 0;
+
+    /**
      * Get the number of degrees of freedom of the joint.
      *
      * @return The number of DOFs of the joint.

--- a/cpp/scenario/core/include/scenario/core/Link.h
+++ b/cpp/scenario/core/include/scenario/core/Link.h
@@ -29,6 +29,13 @@ public:
     virtual ~Link() = default;
 
     /**
+     * Check if the link is valid.
+     *
+     * @return True if the link is valid, false otherwise.
+     */
+    virtual bool valid() const = 0;
+
+    /**
      * Get the name of the link.
      *
      * @param scoped If true, the scoped name of the link is returned.

--- a/cpp/scenario/core/include/scenario/core/World.h
+++ b/cpp/scenario/core/include/scenario/core/World.h
@@ -29,6 +29,13 @@ public:
     virtual ~World() = default;
 
     /**
+     * Check if the world is valid.
+     *
+     * @return True if the world is valid, false otherwise.
+     */
+    virtual bool valid() const = 0;
+
+    /**
      * Get the simulated time.
      *
      * @note A physics plugin need to be part of the simulation

--- a/cpp/scenario/gazebo/include/scenario/gazebo/GazeboEntity.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/GazeboEntity.h
@@ -44,8 +44,13 @@ public:
     virtual ~GazeboEntity() = default;
 
     /**
-     * Get the unique id of the entity.
-     * @return The unique entity id.
+     * Get the unique id of the object.
+     *
+     * @note It might differ from the entity number since a multi-world setting
+     * with the same models inserted in the same order would result to same
+     * numbering.
+     *
+     * @return The unique object id. Invalid objects return 0.
      */
     virtual uint64_t id() const = 0;
 
@@ -69,6 +74,49 @@ public:
      * @return True for success, false otherwise.
      */
     virtual bool createECMResources() = 0;
+
+    /**
+     * Return the entity of this object.
+     *
+     * @return The entity that corresponds to this object.
+     */
+    inline ignition::gazebo::Entity entity() const { return this->m_entity; }
+
+    /**
+     * Return the pointer to the event manager.
+     *
+     * @return The pointer to the event manager.
+     */
+    inline ignition::gazebo::EventManager* eventManager() const
+    {
+        return this->m_eventManager;
+    }
+
+    /**
+     * Return the pointer to the Entity Component Manager.
+     *
+     * @return The pointer to the Entity Component Manager.
+     */
+    inline ignition::gazebo::EntityComponentManager* ecm() const
+    {
+        return this->m_ecm;
+    }
+
+    /**
+     * Checks if the GazeboEntity is valid.
+     *
+     * @return True if the GazeboEntity is valid, false otherwise.
+     */
+    inline bool validEntity() const
+    {
+        return m_eventManager && m_ecm
+               && m_entity != ignition::gazebo::kNullEntity;
+    }
+
+protected:
+    ignition::gazebo::EventManager* m_eventManager = nullptr;
+    ignition::gazebo::EntityComponentManager* m_ecm = nullptr;
+    ignition::gazebo::Entity m_entity = ignition::gazebo::kNullEntity;
 };
 
 #endif // SCENARIO_GAZEBO_GAZEBOENTITY_H

--- a/cpp/scenario/gazebo/include/scenario/gazebo/Joint.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/Joint.h
@@ -135,6 +135,8 @@ public:
     // Joint Core
     // ==========
 
+    bool valid() const override;
+
     size_t dofs() const override;
 
     std::string name(const bool scoped = false) const override;

--- a/cpp/scenario/gazebo/include/scenario/gazebo/Link.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/Link.h
@@ -69,6 +69,8 @@ public:
     // Link Core
     // =========
 
+    bool valid() const override;
+
     std::string name(const bool scoped = false) const override;
 
     double mass() const override;

--- a/cpp/scenario/gazebo/include/scenario/gazebo/World.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/World.h
@@ -142,6 +142,8 @@ public:
     // World Core
     // ==========
 
+    bool valid() const override;
+
     double time() const override;
 
     std::string name() const override;

--- a/cpp/scenario/gazebo/include/scenario/gazebo/helpers.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/helpers.h
@@ -175,15 +175,9 @@ namespace scenario::gazebo::utils {
                             const ignition::math::Pose3d& M_H_B,
                             const ignition::math::Quaterniond& W_R_B);
 
-    std::shared_ptr<World>
-    getParentWorld(ignition::gazebo::EntityComponentManager* ecm,
-                   ignition::gazebo::EventManager* eventManager,
-                   const ignition::gazebo::Entity entity);
+    std::shared_ptr<World> getParentWorld(const GazeboEntity& gazeboEntity);
 
-    std::shared_ptr<Model>
-    getParentModel(ignition::gazebo::EntityComponentManager* ecm,
-                   ignition::gazebo::EventManager* eventManager,
-                   const ignition::gazebo::Entity entity);
+    std::shared_ptr<Model> getParentModel(const GazeboEntity& gazeboEntity);
 
     template <typename ComponentType>
     ignition::gazebo::Entity getFirstParentEntityWithComponent(

--- a/cpp/scenario/gazebo/src/Joint.cpp
+++ b/cpp/scenario/gazebo/src/Joint.cpp
@@ -74,13 +74,11 @@ Joint::~Joint() = default;
 uint64_t Joint::id() const
 {
     // Get the parent world
-    core::WorldPtr parentWorld =
-        utils::getParentWorld(m_ecm, m_eventManager, m_entity);
+    core::WorldPtr parentWorld = utils::getParentWorld(*this);
     assert(parentWorld);
 
     // Get the parent model
-    core::ModelPtr parentModel =
-        utils::getParentModel(m_ecm, m_eventManager, m_entity);
+    core::ModelPtr parentModel = utils::getParentModel(*this);
     assert(parentModel);
 
     // Build a unique string identifier of this joint
@@ -297,9 +295,7 @@ std::string Joint::name(const bool scoped) const
         ignition::gazebo::components::Name>(m_ecm, m_entity);
 
     if (scoped) {
-        auto parentModel =
-            utils::getParentModel(m_ecm, m_eventManager, m_entity);
-        jointName = parentModel->name() + "::" + jointName;
+        jointName = utils::getParentModel(*this)->name() + "::" + jointName;
     }
 
     return jointName;
@@ -343,8 +339,7 @@ bool Joint::setControlMode(const scenario::core::JointControlMode mode)
         assert(parentModelEntity);
 
         // Get the parent model
-        auto parentModel = utils::getParentModel(
-            m_ecm, m_eventManager, parentModelEntity->Data());
+        auto parentModel = utils::getParentModel(*this);
 
         if (!parentModel) {
             sError << "Failed to get the parent model of joint '"

--- a/cpp/scenario/gazebo/src/Joint.cpp
+++ b/cpp/scenario/gazebo/src/Joint.cpp
@@ -69,6 +69,8 @@ Joint::Joint()
     : pImpl{std::make_unique<Impl>()}
 {}
 
+Joint::~Joint() = default;
+
 uint64_t Joint::id() const
 {
     // Get the parent world
@@ -88,8 +90,6 @@ uint64_t Joint::id() const
     // Return the hashed string
     return std::hash<std::string>{}(scopedJointName);
 }
-
-Joint::~Joint() = default;
 
 bool Joint::initialize(const ignition::gazebo::Entity jointEntity,
                        ignition::gazebo::EntityComponentManager* ecm,
@@ -265,6 +265,11 @@ bool Joint::resetJoint(const std::vector<double>& position,
     }
 
     return true;
+}
+
+bool Joint::valid() const
+{
+    return this->validEntity();
 }
 
 size_t Joint::dofs() const

--- a/cpp/scenario/gazebo/src/Link.cpp
+++ b/cpp/scenario/gazebo/src/Link.cpp
@@ -73,6 +73,8 @@ Link::Link()
     : pImpl{std::make_unique<Impl>()}
 {}
 
+Link::~Link() = default;
+
 uint64_t Link::id() const
 {
     // Get the parent world
@@ -92,8 +94,6 @@ uint64_t Link::id() const
     // Return the hashed string
     return std::hash<std::string>{}(scopedLinkName);
 }
-
-Link::~Link() = default;
 
 bool Link::initialize(const ignition::gazebo::Entity linkEntity,
                       ignition::gazebo::EntityComponentManager* ecm,
@@ -143,6 +143,11 @@ bool Link::createECMResources()
     }
 
     return true;
+}
+
+bool Link::valid() const
+{
+    return this->validEntity() && pImpl->link.Valid(*m_ecm);
 }
 
 std::string Link::name(const bool scoped) const

--- a/cpp/scenario/gazebo/src/Link.cpp
+++ b/cpp/scenario/gazebo/src/Link.cpp
@@ -78,13 +78,11 @@ Link::~Link() = default;
 uint64_t Link::id() const
 {
     // Get the parent world
-    core::WorldPtr parentWorld =
-        utils::getParentWorld(m_ecm, m_eventManager, m_entity);
+    core::WorldPtr parentWorld = utils::getParentWorld(*this);
     assert(parentWorld);
 
     // Get the parent model
-    core::ModelPtr parentModel =
-        utils::getParentModel(m_ecm, m_eventManager, m_entity);
+    core::ModelPtr parentModel = utils::getParentModel(*this);
     assert(parentModel);
 
     // Build a unique string identifier of this joint
@@ -161,9 +159,7 @@ std::string Link::name(const bool scoped) const
     std::string linkName = linkNameOptional.value();
 
     if (scoped) {
-        auto parentModel =
-            utils::getParentModel(m_ecm, m_eventManager, m_entity);
-        linkName = parentModel->name() + "::" + linkName;
+        linkName = utils::getParentModel(*this)->name() + "::" + linkName;
     }
 
     return linkName;

--- a/cpp/scenario/gazebo/src/Model.cpp
+++ b/cpp/scenario/gazebo/src/Model.cpp
@@ -99,6 +99,8 @@ Model::Model()
     : pImpl{std::make_unique<Impl>()}
 {}
 
+Model::~Model() = default;
+
 uint64_t Model::id() const
 {
     // Get the parent world
@@ -112,8 +114,6 @@ uint64_t Model::id() const
     // Return the hashed string
     return std::hash<std::string>{}(scopedModelName);
 }
-
-Model::~Model() = default;
 
 bool Model::initialize(const ignition::gazebo::Entity modelEntity,
                        ignition::gazebo::EntityComponentManager* ecm,
@@ -339,8 +339,7 @@ bool Model::resetBaseWorldVelocity(const std::array<double, 3>& linear,
 
 bool Model::valid() const
 {
-    // TODO: extend the checks
-    return pImpl->model.Valid(*m_ecm);
+    return this->validEntity() && pImpl->model.Valid(*m_ecm);
 }
 
 size_t Model::dofs(const std::vector<std::string>& jointNames) const

--- a/cpp/scenario/gazebo/src/Model.cpp
+++ b/cpp/scenario/gazebo/src/Model.cpp
@@ -104,8 +104,7 @@ Model::~Model() = default;
 uint64_t Model::id() const
 {
     // Get the parent world
-    core::WorldPtr parentWorld =
-        utils::getParentWorld(m_ecm, m_eventManager, m_entity);
+    core::WorldPtr parentWorld = utils::getParentWorld(*this);
     assert(parentWorld);
 
     // Build a unique string identifier of this model

--- a/cpp/scenario/gazebo/src/World.cpp
+++ b/cpp/scenario/gazebo/src/World.cpp
@@ -71,12 +71,12 @@ World::World()
     : pImpl{std::make_unique<Impl>()}
 {}
 
+World::~World() = default;
+
 uint64_t World::id() const
 {
     return std::hash<std::string>{}(this->name());
 }
-
-World::~World() = default;
 
 bool World::initialize(const ignition::gazebo::Entity worldEntity,
                        ignition::gazebo::EntityComponentManager* ecm,
@@ -189,6 +189,11 @@ bool World::setGravity(const std::array<double, 3>& gravity)
         m_ecm, m_entity, utils::toIgnitionVector3(gravity));
 
     return true;
+}
+
+bool World::valid() const
+{
+    return this->validEntity();
 }
 
 double World::time() const

--- a/cpp/scenario/gazebo/src/helpers.cpp
+++ b/cpp/scenario/gazebo/src/helpers.cpp
@@ -499,17 +499,21 @@ utils::fromBaseToModelVelocity(const ignition::math::Vector3d& linBaseVelocity,
     return {linModelVelocity, angModelVelocity};
 }
 
-std::shared_ptr<World>
-utils::getParentWorld(ignition::gazebo::EntityComponentManager* ecm,
-                      ignition::gazebo::EventManager* eventManager,
-                      const ignition::gazebo::Entity entity)
+std::shared_ptr<World> utils::getParentWorld(const GazeboEntity& gazeboEntity)
 {
+    if (!gazeboEntity.validEntity()) {
+        sError << "The GazeboEntity is not valid" << std::endl;
+        return nullptr;
+    }
+
     auto worldEntity = getFirstParentEntityWithComponent< //
-        ignition::gazebo::components::World>(ecm, entity);
+        ignition::gazebo::components::World>(gazeboEntity.ecm(),
+                                             gazeboEntity.entity());
 
     auto world = std::make_shared<World>();
 
-    if (!world->initialize(worldEntity, ecm, eventManager)) {
+    if (!world->initialize(
+            worldEntity, gazeboEntity.ecm(), gazeboEntity.eventManager())) {
         sError << "Failed to initialize world" << std::endl;
         return nullptr;
     }
@@ -517,17 +521,21 @@ utils::getParentWorld(ignition::gazebo::EntityComponentManager* ecm,
     return world;
 }
 
-std::shared_ptr<Model>
-utils::getParentModel(ignition::gazebo::EntityComponentManager* ecm,
-                      ignition::gazebo::EventManager* eventManager,
-                      const ignition::gazebo::Entity entity)
+std::shared_ptr<Model> utils::getParentModel(const GazeboEntity& gazeboEntity)
 {
+    if (!gazeboEntity.validEntity()) {
+        sError << "The GazeboEntity is not valid" << std::endl;
+        return nullptr;
+    }
+
     auto modelEntity = getFirstParentEntityWithComponent< //
-        ignition::gazebo::components::Model>(ecm, entity);
+        ignition::gazebo::components::Model>(gazeboEntity.ecm(),
+                                             gazeboEntity.entity());
 
     auto model = std::make_shared<Model>();
 
-    if (!model->initialize(modelEntity, ecm, eventManager)) {
+    if (!model->initialize(
+            modelEntity, gazeboEntity.ecm(), gazeboEntity.eventManager())) {
         sError << "Failed to initialize model" << std::endl;
         return nullptr;
     }


### PR DESCRIPTION
This PR tries to unify the storage of the Gazebo ECM resources among all its implementations.

Furthermore, a new `*::valid()` method was added to the ScenarI/O core interfaces and implementations.