### PR TITLE
Remove iDynTree private CMake export dependency

### DIFF
--- a/cpp/scenario/CMakeLists.txt
+++ b/cpp/scenario/CMakeLists.txt
@@ -13,7 +13,6 @@ if(GYMIGNITION_USE_IGNITION)
     add_subdirectory(plugins)
     add_subdirectory(controllers)
 
-    list(APPEND SCENARIO_PRIVATE_DEPENDENCIES iDynTree)
     list(APPEND SCENARIO_COMPONENTS ScenarioGazebo ScenarioControllers)
 
 endif()

--- a/cpp/scenario/controllers/CMakeLists.txt
+++ b/cpp/scenario/controllers/CMakeLists.txt
@@ -33,7 +33,7 @@ add_custom_target(ScenarioControllersABC SOURCES ${CONTROLLERS_ABC_PUBLIC_HDRS})
 # ComputedTorqueFixedBase
 # =======================
 
-add_library(ComputedTorqueFixedBase
+add_library(ComputedTorqueFixedBase SHARED
     include/scenario/controllers/ComputedTorqueFixedBase.h
     src/ComputedTorqueFixedBase.cpp)
 add_library(ScenarioControllers::ComputedTorqueFixedBase ALIAS ComputedTorqueFixedBase)


### PR DESCRIPTION
The configuration of downstream projects that import the CMake targets fail if iDynTree is not installed in the system.

We use iDynTree in our demo [`ComputedTorqueFixedBase`](https://github.com/robotology/gym-ignition/blob/ae21546903/cpp/scenario/controllers/include/scenario/controllers/ComputedTorqueFixedBase.h) controller, however it is a private dependency:

https://github.com/robotology/gym-ignition/blob/ae2154690356431e71203201448bb9f3bbad5c3e/cpp/scenario/controllers/CMakeLists.txt#L41-L50

I originally though that exporting the dependency as follows was correct, but it turns out that CMake calls find_package anyway when downstream projects import the exported targets:

https://github.com/robotology/gym-ignition/blob/ae2154690356431e71203201448bb9f3bbad5c3e/cpp/scenario/CMakeLists.txt#L16

https://github.com/robotology/gym-ignition/blob/ae2154690356431e71203201448bb9f3bbad5c3e/cpp/scenario/CMakeLists.txt#L28-L37

---

From the [YCM documentation](https://github.com/robotology/ycm/blob/32e544488537e435d61ffe237bb72f3908552c9c/modules/InstallBasicPackageFiles.cmake#L47-L60), private dependencies are taken into account only when the project is exported with `BUILD_SHARED_LIBS` disabled. Since iDynTree is only used by one controller, this PR forces that library to be built as SHARED and removes iDynTree from the PRIVATE_DEPENDENCIES list. 