### PR TITLE
Update to new ign-gazebo API for executing paused runs

### DIFF
--- a/.docker/tags_citadel.yaml
+++ b/.docker/tags_citadel.yaml
@@ -14,7 +14,7 @@ repositories:
   ign-gazebo:
     type: git
     url: https://github.com/diegoferigo/ign-gazebo
-    version: release/gym-ignition-devel
+    version: feature/paused-step
   ign-gui:
     type: git
     url: https://github.com/ignitionrobotics/ign-gui

--- a/cpp/scenario/gazebo/src/GazeboSimulator.cpp
+++ b/cpp/scenario/gazebo/src/GazeboSimulator.cpp
@@ -224,10 +224,16 @@ bool GazeboSimulator::run(const bool paused)
         iterations = 1;
     }
 
+    if (paused && !server->RunOnce(/*paused=*/true)) {
+        sError << "The server couldn't execute the paused step" << std::endl;
+        return false;
+    }
+
     // Run the simulation
-    if (!server->Run(/*blocking=*/deterministic,
-                     /*iterations=*/iterations,
-                     /*paused=*/paused)) {
+    if (!paused
+        && !server->Run(/*blocking=*/deterministic,
+                        /*iterations=*/iterations,
+                        /*paused=*/false)) {
         sError << "The server couldn't execute the step" << std::endl;
         return false;
     }
@@ -663,8 +669,8 @@ std::shared_ptr<ignition::gazebo::Server> GazeboSimulator::Impl::getServer()
         assert(server);
 
         sDebug << "Starting the gazebo server" << std::endl;
-        if (!server->Run(
-                /*blocking=*/true, /*iterations=*/1, /*paused=*/true)) {
+
+        if (!server->RunOnce(/*paused=*/true)) {
             sError << "Failed to initialize the first gazebo server run"
                    << std::endl;
             return nullptr;

--- a/tests/test_scenario/test_gazebo_simulator.py
+++ b/tests/test_scenario/test_gazebo_simulator.py
@@ -6,6 +6,7 @@ import pytest
 pytestmark = pytest.mark.scenario
 
 from ..common import utils
+import gym_ignition_models
 from scenario import gazebo as scenario
 from ..common.utils import gazebo_fixture as gazebo
 
@@ -84,6 +85,26 @@ def test_pause(gazebo: scenario.GazeboSimulator):
     assert not gazebo.running()
     assert gazebo.pause()
 
+
+@pytest.mark.parametrize("gazebo",
+                         [(0.001, 1.0, 1)],
+                         indirect=True,
+                         ids=utils.id_gazebo_fn)
+def test_paused_step(gazebo: scenario.GazeboSimulator):
+
+    assert gazebo.initialize()
+
+    world = gazebo.get_world().to_gazebo()
+    assert world.insert_model(gym_ignition_models.get_model_file("ground_plane"))
+    assert "ground_plane" in world.model_names()
+    gazebo.run(paused=True)
+
+    world.remove_model("ground_plane")
+
+    assert "ground_plane" in world.model_names()
+    gazebo.run(paused=True)
+    assert "ground_plane" not in world.model_names()
+    assert world.time() == 0.0
 
 @pytest.mark.parametrize("gazebo",
                          [(0.001, 1.0, 1)],


### PR DESCRIPTION
This PR updates our `GazeboSimulator` class with the new APIs that have been proposed upstream in https://github.com/ignitionrobotics/ign-gazebo/pull/297 to execute single paused runs. This feature is fundamental to us since it allows to update the state of the ECM without advancing the physics.