### PR TITLE
Website automatic deployment

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,101 @@
+name: Website
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+      - devel
+
+jobs:
+  website:
+    name: Build and Deploy
+    runs-on: ubuntu-20.04
+
+    steps:
+
+      - uses: actions/checkout@master
+        with:
+          persist-credentials: false
+
+      - run: git fetch --prune --unshallow
+
+      - name: Setup Environment
+        run: |
+          echo "::set-env name=CC::gcc"
+          echo "::set-env name=CXX::g++"
+          echo "::set-env name=PYTHON_VERSION::3.8"
+          env
+
+      - name: Inspect Environment
+        run: |
+          env | grep ^GITHUB
+          cat ${GITHUB_EVENT_PATH}
+
+      - name: Setup docker image [master]
+        if: |
+          (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+          (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'master')
+        run: |
+          docker run -d -i --name ci -v $(pwd):/github -w /github \
+            -v /home/runner/work/_temp/:/home/runner/work/_temp/:rw \
+            -e PYTHON_VERSION=$PYTHON_VERSION -e CC=$CC -e CXX=$CXX \
+            diegoferigo/gym-ignition:ci-master bash
+
+      - name: Setup docker image [devel]
+        if: |
+          (github.event_name == 'push' && github.ref != 'refs/heads/master') ||
+          (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'devel')
+        run: |
+          docker run -d -i --name ci -v $(pwd):/github -w /github \
+            -v /home/runner/work/_temp/:/home/runner/work/_temp/:rw \
+            -e PYTHON_VERSION=$PYTHON_VERSION -e CC=$CC -e CXX=$CXX \
+            diegoferigo/gym-ignition:ci-devel bash
+
+      - name: Wait entrypoint
+        run: |
+          sleep 30
+          docker logs ci
+
+      - name: Install packages
+        shell: docker exec -i ci bash -i -e {0}
+        run: |
+          apt-get update
+          apt-get install -y doxygen texlive-font-utils
+
+      - name: Install website dependecies
+        shell: docker exec -i ci bash -i -e {0}
+        run: pip3 install -e .[website]
+
+      - name: Inspect metadata
+        shell: docker exec -i ci bash -i -e {0}
+        run: sphinx-multiversion --dump-metadata docs/sphinx/ build/
+
+      - name: Build sphinx website
+        shell: docker exec -i ci bash -i -e {0}
+        run: |
+          mkdir build && cd build
+          cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DBUILD_DOCS:BOOL=ON
+          cmake --build . --target sphinx
+
+      - name: Check new uncommitted apidoc
+        run: test $(git status --porcelain | wc -l) -eq 0
+
+      - name: git status
+        if: ${{ failure() }}
+        run: |
+          git status
+          git diff
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        if: |
+          github.event_name == 'push' &&
+          github.repository == 'robotology/gym-ignition' &&
+          (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/devel')
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: build/html
+          CLEAN: true
+          CLEAN_EXCLUDE: '[".gitignore", ".nojekyll"]'

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -82,7 +82,7 @@ breathe_default_project = "scenario"
 
 # From: https://holzhaus.github.io/sphinx-multiversion
 smv_prefer_remote_refs = False
-smv_remote_whitelist = None
+smv_remote_whitelist = r'^(origin|upstream)$'
 smv_tag_whitelist = r'^v.*$'
 smv_branch_whitelist = r'^(master|devel|docs/.*)$'
 smv_released_pattern = r'^tags/.*$'

--- a/setup.py
+++ b/setup.py
@@ -147,6 +147,16 @@ setup(
         'gym_ignition_models',
         'lxml',
     ],
+    extras_require=dict(
+        website=[
+            "sphinx",
+            "sphinx-rtd-theme",
+            "sphinx-autodoc-typehints",
+            "sphinx_fontawesome",
+            "sphinx-multiversion",
+            "breathe",
+        ],
+    ),
     packages=find_packages("python"),
     package_dir={'': "python"},
     ext_modules=[CMakeExtension(name='InstallAllTargets', cmake_configuration='PyPI')],


### PR DESCRIPTION
This PR adds a new GItHub workflow that builds and deploys the sphinx website. Few comments:

- The process has the following steps, performed by CMake:
  1. Generating doxygen xml from C++
  1. Building the ScenarI/O Python bindings (using the CI docker images)
  1. Generating the apidoc of both the autogenerated bindings and the `gym_ignition` / `gym_ignition_environments` modules
  1. Generating the apidoc of the C++ code
  1. Build the website with sphinx and breathe
- We use [Holzhaus/sphinx-multiversion](https://github.com/Holzhaus/sphinx-multiversion) for the last step of building the website. It supports building multiple versions / tags / branches but we have to pay the price of a more complex git handling. There are limitations on the local generation of the website, only `master`, `devel`, and `docs/*` branches are enabled locally and before generating the website all the changes must be committed.
- Push to `gh-pages` with [JamesIves/github-pages-deploy-action](https://github.com/JamesIves/github-pages-deploy-action).

For some limitation I'll omit, when the apidocs change, the updated version are stored in the sources tree. This is due to the need of sphinx multiversion of having all the website resources committed in the git repo. This also means that in case of apidocs change, the PR must also contain the updated apidoc files (`docs/sphinx/apidoc/*`). The workflow fails if this step is missing.