### PR TITLE
Experimental support to sensors and depth camera example

### DIFF
--- a/bindings/gazebo/gazebo.i
+++ b/bindings/gazebo/gazebo.i
@@ -9,6 +9,7 @@
 #include "scenario/gazebo/Model.h"
 #include "scenario/gazebo/utils.h"
 #include "scenario/gazebo/World.h"
+#include "scenario/gazebo/sensors/DepthCamera.h" // TODO
 #include "scenario/plugins/gazebo/ECMSingleton.h"
 #include <cstdint>
 %}
@@ -40,6 +41,9 @@ namespace scenario::gazebo::utils {
 %include <std_vector.i>
 %include <std_shared_ptr.i>
 
+// Sensors TODO
+%shared_ptr(scenario::gazebo::sensors::DepthCamera)
+
 // Import the module with core classes
 // From http://www.swig.org/Doc4.0/Modules.html
 %import "../core/core.i"
@@ -58,6 +62,7 @@ namespace scenario::gazebo::utils {
 %rename("") JointType;
 %rename("") Verbosity;
 %rename("") JointLimit;
+%rename("") DepthCamera;
 %rename("") ContactPoint;
 %rename("") ECMSingleton;
 %rename("") GazeboEntity;
@@ -74,6 +79,7 @@ namespace scenario::gazebo::utils {
 %shared_ptr(scenario::gazebo::Model)
 %shared_ptr(scenario::gazebo::World)
 %shared_ptr(scenario::gazebo::GazeboEntity)
+%shared_ptr(scenario::gazebo::sensors::DepthCamera)
 
 // Ignored methods
 %ignore scenario::gazebo::GazeboEntity::ecm;
@@ -98,6 +104,7 @@ namespace scenario::gazebo::utils {
 %include "scenario/gazebo/GazeboEntity.h"
 
 // ScenarI/O headers
+%include "scenario/gazebo/sensors/DepthCamera.h"
 %include "scenario/gazebo/Joint.h"
 %include "scenario/gazebo/Link.h"
 %include "scenario/gazebo/Model.h"

--- a/cpp/scenario/gazebo/CMakeLists.txt
+++ b/cpp/scenario/gazebo/CMakeLists.txt
@@ -78,7 +78,8 @@ set(SCENARIO_GAZEBO_PUBLIC_HDRS
     include/scenario/gazebo/Log.h
     include/scenario/gazebo/utils.h
     include/scenario/gazebo/helpers.h
-    include/scenario/gazebo/exceptions.h)
+    include/scenario/gazebo/exceptions.h
+    include/scenario/gazebo/sensors/DepthCamera.h)
 
 add_library(ScenarioGazebo
     ${SCENARIO_GAZEBO_PUBLIC_HDRS}
@@ -87,7 +88,8 @@ add_library(ScenarioGazebo
     src/Joint.cpp
     src/Link.cpp
     src/utils.cpp
-    src/helpers.cpp)
+    src/helpers.cpp
+    src/DepthCamera.cpp)
 add_library(ScenarioGazebo::ScenarioGazebo ALIAS ScenarioGazebo)
 
 target_include_directories(ScenarioGazebo PUBLIC

--- a/cpp/scenario/gazebo/CMakeLists.txt
+++ b/cpp/scenario/gazebo/CMakeLists.txt
@@ -43,6 +43,8 @@ set(EXTRA_COMPONENTS_PUBLIC_HEADERS
     include/scenario/gazebo/components/Timestamp.h
     include/scenario/gazebo/components/JointControllerPeriod.h
     include/scenario/gazebo/components/JointAcceleration.h
+    include/scenario/gazebo/components/DepthCameraPtr.h
+    include/scenario/gazebo/components/SensorsPlugin.h
     )
 
 add_library(ExtraComponents INTERFACE)

--- a/cpp/scenario/gazebo/CMakeLists.txt
+++ b/cpp/scenario/gazebo/CMakeLists.txt
@@ -103,7 +103,9 @@ target_link_libraries(ScenarioGazebo
     ${ignition-common.ignition-common}
     PRIVATE
     ScenarioCore::CoreUtils
-    ScenarioGazebo::ExtraComponents)
+    ScenarioGazebo::ExtraComponents
+    ${ignition-sensors.ignition-sensors-all}
+    ${ignition-rendering.ignition-rendering})
 
 set_target_properties(ScenarioGazebo PROPERTIES
     PUBLIC_HEADER "${SCENARIO_GAZEBO_PUBLIC_HDRS}")

--- a/cpp/scenario/gazebo/include/scenario/gazebo/Model.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/Model.h
@@ -43,6 +43,10 @@ namespace scenario::gazebo {
     class Model;
 } // namespace scenario::gazebo
 
+namespace scenario::gazebo::sensors {
+    class DepthCamera;
+} // namespace scenario::gazebo::sensors
+
 class scenario::gazebo::Model final
     : public scenario::core::Model
     , public scenario::gazebo::GazeboEntity
@@ -342,6 +346,21 @@ public:
     std::array<double, 3> baseWorldLinearAccelerationTarget() const override;
 
     std::array<double, 3> baseWorldAngularAccelerationTarget() const override;
+
+    // =======
+    // Sensors
+    // =======
+
+    std::vector<std::string> sensorNames() const;
+
+    /**
+     * Return a depth camera belonging to this model.
+     *
+     * @param name The name of the depth camera sensor.
+     * @return The desired depth camera sensor.
+     */
+    std::shared_ptr<sensors::DepthCamera>
+    depthCamera(const std::string& name) const;
 
 private:
     class Impl;

--- a/cpp/scenario/gazebo/include/scenario/gazebo/World.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/World.h
@@ -138,6 +138,17 @@ public:
      */
     bool removeModel(const std::string& modelName);
 
+    /**
+     * Enable the sensors system.
+     *
+     * @note Disabling the sensors once they are already running is not yet
+     * supported.
+     *
+     * @param enable True to enable, false to disable.
+     * @return True for success, false otherwise.
+     */
+    bool enableSensors(const bool enable = true);
+
     // ==========
     // World Core
     // ==========

--- a/cpp/scenario/gazebo/include/scenario/gazebo/components/DepthCameraPtr.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/components/DepthCameraPtr.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This project is dual licensed under LGPL v2.1+ or Apache License.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IGNITION_GAZEBO_COMPONENTS_DEPTHCAMERAPTR_H
+#define IGNITION_GAZEBO_COMPONENTS_DEPTHCAMERAPTR_H
+
+#include <ignition/gazebo/components/Component.hh>
+#include <ignition/gazebo/components/Factory.hh>
+#include <ignition/gazebo/config.hh>
+#include <ignition/sensors/config.hh>
+
+namespace ignition::sensors {
+    inline namespace IGNITION_SENSORS_VERSION_NAMESPACE {
+        class DepthCameraSensor;
+    } // namespace IGNITION_SENSORS_VERSION_NAMESPACE
+} // namespace ignition::sensors
+
+namespace ignition::gazebo {
+    // Inline bracket to help doxygen filtering.
+    inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
+        namespace components {
+            /// \brief TODO
+            using DepthCameraPtr =
+                Component<sensors::DepthCameraSensor*, class DepthCameraPtrTag>;
+            IGN_GAZEBO_REGISTER_COMPONENT(
+                "ign_gazebo_components.DepthCameraPtr",
+                DepthCameraPtr)
+        } // namespace components
+    } // namespace IGNITION_GAZEBO_VERSION_NAMESPACE
+} // namespace ignition::gazebo
+
+#endif // IGNITION_GAZEBO_COMPONENTS_DEPTHCAMERAPTR_H

--- a/cpp/scenario/gazebo/include/scenario/gazebo/components/SensorsPlugin.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/components/SensorsPlugin.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This project is dual licensed under LGPL v2.1+ or Apache License.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IGNITION_GAZEBO_COMPONENTS_SENSORSPLUGIN_H
+#define IGNITION_GAZEBO_COMPONENTS_SENSORSPLUGIN_H
+
+#include <ignition/gazebo/components/Component.hh>
+#include <ignition/gazebo/components/Factory.hh>
+#include <ignition/gazebo/config.hh>
+
+namespace ignition::gazebo {
+    // Inline bracket to help doxygen filtering.
+    inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
+        namespace components {
+            /// \brief Marks whether a world has a Sensors plugin.
+            using SensorsPlugin = Component<bool, class SensorsPluginTag>;
+            IGN_GAZEBO_REGISTER_COMPONENT(
+                "ign_gazebo_components.SensorsPlugin",
+                SensorsPlugin)
+        } // namespace components
+    } // namespace IGNITION_GAZEBO_VERSION_NAMESPACE
+} // namespace ignition::gazebo
+
+#endif // IGNITION_GAZEBO_COMPONENTS_SENSORSPLUGIN_H

--- a/cpp/scenario/gazebo/include/scenario/gazebo/helpers.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/helpers.h
@@ -79,6 +79,9 @@ namespace scenario::gazebo::utils {
                                const long rows,
                                const long cols);
 
+    std::vector<std::string> tokenize(const std::string& input,
+                                      const std::string& delimiter);
+
     class FixedSizeQueue
     {
     public:

--- a/cpp/scenario/gazebo/include/scenario/gazebo/sensors/DepthCamera.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/sensors/DepthCamera.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef SCENARIO_GAZEBO_SENSORS_DEPTHCAMERA_H
+#define SCENARIO_GAZEBO_SENSORS_DEPTHCAMERA_H
+
+#include "scenario/gazebo/GazeboEntity.h"
+
+#include <ignition/gazebo/Entity.hh>
+#include <ignition/gazebo/EntityComponentManager.hh>
+#include <ignition/gazebo/EventManager.hh>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace scenario::gazebo::sensors {
+    class DepthCamera;
+} // namespace scenario::gazebo::sensors
+
+class scenario::gazebo::sensors::DepthCamera final
+    : public scenario::gazebo::GazeboEntity
+{
+public:
+    DepthCamera();
+    virtual ~DepthCamera();
+
+    // =============
+    // Gazebo Entity
+    // =============
+
+    uint64_t id() const override;
+
+    bool initialize(const ignition::gazebo::Entity parentEntity,
+                    ignition::gazebo::EntityComponentManager* ecm,
+                    ignition::gazebo::EventManager* eventManager) override;
+
+    bool createECMResources() override;
+
+    // ===========
+    // Camera Core
+    // ===========
+
+    std::string name(const bool scoped = false) const;
+
+    double width() const;
+    double height() const;
+
+    double farClip() const;
+    double nearClip() const;
+
+    const std::vector<float>& image() const;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> pImpl;
+};
+
+#endif // SCENARIO_GAZEBO_SENSORS_DEPTHCAMERA_H

--- a/cpp/scenario/gazebo/src/DepthCamera.cpp
+++ b/cpp/scenario/gazebo/src/DepthCamera.cpp
@@ -159,10 +159,6 @@ bool DepthCamera::initialize(const ignition::gazebo::Entity parentEntity,
         pImpl->tNextImage += dtCamera;
         const auto tPreviousImage = tCurrentImage - dtCamera;
 
-        sDebug << "t=" << Impl::ToNanoseconds(tCurrentImage)
-               << " CopyImageDataCB" << std::endl;
-        sDebug << "id=" << pImpl->depthCamera->Id() << std::endl;
-
         // Copy the image into the current buffer
         pImpl->imageBuffer->resize(img.width() * img.height());
         std::memcpy(pImpl->imageBuffer->data(),

--- a/cpp/scenario/gazebo/src/DepthCamera.cpp
+++ b/cpp/scenario/gazebo/src/DepthCamera.cpp
@@ -1,0 +1,257 @@
+/*
+ * Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include "scenario/gazebo/sensors/DepthCamera.h"
+#include "scenario/gazebo/Log.h"
+#include "scenario/gazebo/components/DepthCameraPtr.h"
+#include "scenario/gazebo/components/SensorsPlugin.h"
+#include "scenario/gazebo/components/SimulatedTime.h"
+#include "scenario/gazebo/helpers.h"
+
+#include <ignition/common/events/Types.hh>
+#include <ignition/gazebo/components/World.hh>
+#include <ignition/msgs/image.pb.h>
+#include <ignition/sensors/DepthCameraSensor.hh>
+
+#include <future>
+#include <mutex>
+
+using namespace scenario::gazebo::sensors;
+
+class DepthCamera::Impl
+{
+public:
+    mutable std::mutex mutex;
+    ignition::common::ConnectionPtr connection = nullptr;
+    ignition::sensors::DepthCameraSensor* depthCamera = nullptr;
+
+    using SimTime = double;
+    using ImageBuffer = std::vector<float>;
+    using ImageBufferPtr = std::shared_ptr<ImageBuffer>;
+    std::unordered_map<SimTime, std::promise<ImageBufferPtr>> promisedImages;
+
+    ImageBufferPtr imageBuffer;
+    mutable std::mutex copyImageDataCBMutex;
+
+    ignition::common::Time t0;
+    ignition::common::Time tNextImage;
+    ignition::gazebo::Entity entityWithSimTime = ignition::gazebo::kNullEntity;
+
+    static inline size_t ToNanoseconds(const ignition::common::Time& time)
+    {
+        return time.sec * 1e9 + time.nsec;
+    }
+
+    static inline size_t
+    ToNanoseconds(const std::chrono::steady_clock::duration& time)
+    {
+        return std::chrono::nanoseconds(time).count();
+    }
+};
+
+DepthCamera::DepthCamera()
+    : pImpl{std::make_unique<Impl>()}
+{}
+
+DepthCamera::~DepthCamera() = default;
+
+uint64_t DepthCamera::id() const
+{
+    // Get the parent world
+    const core::WorldPtr parentWorld = utils::getParentWorld(*this);
+    assert(parentWorld);
+
+    // Build a unique string identifier of the sensors
+    const std::string scopedSensorName =
+        parentWorld->name() + "::" + this->name(/*scoped=*/true);
+
+    // Return the hashed string
+    return std::hash<std::string>{}(scopedSensorName);
+}
+
+bool DepthCamera::initialize(const ignition::gazebo::Entity parentEntity,
+                             ignition::gazebo::EntityComponentManager* ecm,
+                             ignition::gazebo::EventManager* eventManager)
+{
+    if (parentEntity == ignition::gazebo::kNullEntity || !ecm
+        || !eventManager) {
+        sError << "Failed to initialize DepthCamera" << std::endl;
+        return false;
+    }
+
+    m_ecm = ecm;
+    m_entity = parentEntity;
+    m_eventManager = eventManager;
+
+    const auto& parentWorld = utils::getParentWorld(*this);
+    assert(parentWorld);
+
+    // Fail if the Sensors system was not explicitly enabled
+    if (!m_ecm->EntityHasComponentType(
+            parentWorld->entity(),
+            ignition::gazebo::components::SensorsPlugin::typeId)) {
+        sError << "This world has the sensors system disabled" << std::endl;
+        return false;
+    }
+
+    // Get the depth camera
+    pImpl->depthCamera = utils::getExistingComponentData<
+        ignition::gazebo::components::DepthCameraPtr>(ecm, parentEntity);
+
+    // Configure the depth camera if the update rate is 0
+    if (pImpl->depthCamera->UpdateRate()
+        < std::numeric_limits<double>::epsilon()) {
+        // TODO: do not hardcode the update rate
+        const auto serverUpdateRate = 1000.;
+        pImpl->depthCamera->SetUpdateRate(serverUpdateRate);
+    }
+
+    // Get the entity with simulated time
+    pImpl->entityWithSimTime = utils::getFirstParentEntityWithComponent<
+        ignition::gazebo::components::SimulatedTime>(m_ecm, m_entity);
+
+    // Get the simulated time
+    const auto& now = utils::steadyClockDurationToDouble(
+        utils::getExistingComponentData<
+            ignition::gazebo::components::SimulatedTime>(
+            m_ecm, pImpl->entityWithSimTime));
+
+    // Store the initial time. It is used to get the image at the time timestep.
+    pImpl->t0 = ignition::common::Time(now);
+
+    // Get the next time a new image is expected
+    const ignition::common::Time dt(1.0 / pImpl->depthCamera->UpdateRate());
+    pImpl->tNextImage = pImpl->t0 + dt;
+    sDebug << "Image of camera " << this->name()
+           << " availailable from t=" << pImpl->tNextImage.Double()
+           << std::endl;
+
+    // Allocate the buffer
+    pImpl->imageBuffer = std::make_shared<Impl::ImageBuffer>();
+
+    // Create the first promise and a dummy promise for the previous step.
+    // Note: We use nanoseconds to avoid using floating point arithmetics
+    //       on map's keys and being more robust to numerical errors.
+    pImpl->promisedImages[Impl::ToNanoseconds(pImpl->tNextImage)] = {};
+    pImpl->promisedImages[Impl::ToNanoseconds(pImpl->t0)].set_value(
+        pImpl->imageBuffer);
+
+    // Callback executed when a new image is available
+    auto CopyImageDataCB = [&](const ignition::msgs::Image& img) -> void {
+        // Execute the callback sequentially.
+        // TODO: this does not guarantee the order of acquisition in case
+        //       multiplet threads are waiting (in this case, we'd be interested
+        //       only in the last one). For the moment we ignore this use case.
+        //       A custom queued locking mechanism should be implemented.
+        std::unique_lock lock(pImpl->copyImageDataCBMutex);
+
+        // Get the time step of the camera
+        const ignition::common::Time dtCamera(
+            1.0 / pImpl->depthCamera->UpdateRate());
+
+        // Get the sim time of the previous, current, and next images
+        const auto tCurrentImage = pImpl->tNextImage;
+        pImpl->tNextImage += dtCamera;
+        const auto tPreviousImage = tCurrentImage - dtCamera;
+
+        sDebug << "t=" << Impl::ToNanoseconds(tCurrentImage)
+               << " CopyImageDataCB" << std::endl;
+        sDebug << "id=" << pImpl->depthCamera->Id() << std::endl;
+
+        // Copy the image into the current buffer
+        pImpl->imageBuffer->resize(img.width() * img.height());
+        std::memcpy(pImpl->imageBuffer->data(),
+                    img.data().c_str(),
+                    pImpl->imageBuffer->size() * sizeof(float));
+
+        // Store the current buffer into the current promise
+        pImpl->promisedImages[Impl::ToNanoseconds(tCurrentImage)].set_value(
+            pImpl->imageBuffer);
+
+        // Create the next promise
+        pImpl->promisedImages[Impl::ToNanoseconds(pImpl->tNextImage)] = {};
+
+        // Delete the previous promise
+        pImpl->promisedImages.erase(Impl::ToNanoseconds(tPreviousImage));
+    };
+
+    // Enable the callback
+    pImpl->connection =
+        pImpl->depthCamera->ConnectImageCallback(CopyImageDataCB);
+
+    return true;
+}
+
+bool DepthCamera::createECMResources()
+{
+    sMessage << "  [" << m_entity << "] " << this->name() << std::endl;
+    return true;
+}
+
+std::string DepthCamera::name(const bool scoped) const
+{
+    if (scoped) {
+        return pImpl->depthCamera->Name();
+    }
+
+    const std::string scopedSensorName = pImpl->depthCamera->Name();
+    const auto tokens = utils::tokenize(scopedSensorName, "::");
+    assert(!tokens.empty());
+
+    return tokens.back();
+}
+
+double DepthCamera::width() const
+{
+    return pImpl->depthCamera->RenderingCamera()->ImageWidth();
+}
+
+double DepthCamera::height() const
+{
+    return pImpl->depthCamera->RenderingCamera()->ImageHeight();
+}
+
+double DepthCamera::farClip() const
+{
+    return pImpl->depthCamera->FarClip();
+}
+
+double DepthCamera::nearClip() const
+{
+    return pImpl->depthCamera->NearClip();
+}
+
+const std::vector<float>& DepthCamera::image() const
+{
+    // Get the simulated time. It is used to retrieve the right image.
+    const auto& tSim = utils::getExistingComponentData<
+        ignition::gazebo::components::SimulatedTime //
+        >(m_ecm, pImpl->entityWithSimTime);
+
+    try {
+        // Get the promise of this simulated time.
+        // Raise if the promise does not exist.
+        auto& promise = pImpl->promisedImages.at(Impl::ToNanoseconds(tSim));
+
+        // Get the image buffer
+        const auto& futureImage = promise.get_future().share();
+
+        // Return the buffer
+        return *futureImage.get();
+    }
+    catch (...) {
+        const auto t = utils::steadyClockDurationToDouble(tSim);
+        throw std::runtime_error("Failed to find image at t="
+                                 + std::to_string(t));
+    }
+}
+
+// bool DepthCamera::valid() const
+//{
+//    return this->validEntity() && pImpl->link.Valid(*m_ecm);
+//}

--- a/cpp/scenario/gazebo/src/Model.cpp
+++ b/cpp/scenario/gazebo/src/Model.cpp
@@ -1021,14 +1021,13 @@ Model::depthCamera(const std::string& name) const
         throw std::runtime_error("Failed to find depth camera '" + name + "'");
     }
 
+    // TODO: cache the object
     auto depthCamera = std::make_shared<sensors::DepthCamera>();
 
-    sError << "initializing" << std::endl;
     if (!depthCamera->initialize(depthCameraEntity, m_ecm, m_eventManager)) {
         throw std::runtime_error("Failed to initialize depth camera '" + name
                                  + "'");
     }
-    sError << "post initializing" << std::endl;
 
     return depthCamera;
 }

--- a/cpp/scenario/gazebo/src/Model.cpp
+++ b/cpp/scenario/gazebo/src/Model.cpp
@@ -32,17 +32,21 @@
 #include "scenario/gazebo/components/BasePoseTarget.h"
 #include "scenario/gazebo/components/BaseWorldAccelerationTarget.h"
 #include "scenario/gazebo/components/BaseWorldVelocityTarget.h"
+#include "scenario/gazebo/components/DepthCameraPtr.h"
 #include "scenario/gazebo/components/JointControllerPeriod.h"
 #include "scenario/gazebo/components/WorldVelocityCmd.h"
 #include "scenario/gazebo/exceptions.h"
 #include "scenario/gazebo/helpers.h"
+#include "scenario/gazebo/sensors/DepthCamera.h"
 
 #include <ignition/common/Event.hh>
 #include <ignition/gazebo/Events.hh>
 #include <ignition/gazebo/Model.hh>
 #include <ignition/gazebo/components/CanonicalLink.hh>
+#include <ignition/gazebo/components/DepthCamera.hh>
 #include <ignition/gazebo/components/Joint.hh>
 #include <ignition/gazebo/components/Link.hh>
+#include <ignition/gazebo/components/Model.hh>
 #include <ignition/gazebo/components/Name.hh>
 #include <ignition/gazebo/components/ParentEntity.hh>
 #include <ignition/gazebo/components/Pose.hh>
@@ -50,6 +54,7 @@
 #include <ignition/gazebo/components/SelfCollide.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/math/Vector3.hh>
+#include <ignition/sensors/DepthCameraSensor.hh>
 #include <sdf/Element.hh>
 #include <sdf/Root.hh>
 
@@ -953,6 +958,79 @@ std::string Model::baseFrame() const
         ignition::gazebo::components::Name>(m_ecm, candidateBaseLinks.front());
 
     return baseLinkName;
+}
+
+std::vector<std::string> Model::sensorNames() const
+{
+    std::vector<std::string> names;
+
+    m_ecm->Each<ignition::gazebo::components::Name,
+                ignition::gazebo::components::DepthCamera,
+                //                ignition::gazebo::components::DepthCameraPtr,
+                ignition::gazebo::components::ParentEntity>(
+        [&](const ignition::gazebo::Entity& /*entity*/,
+            ignition::gazebo::components::Name* nameComponent,
+            ignition::gazebo::components::DepthCamera* /*depthCameraComponent*/,
+            //            ignition::gazebo::components::
+            //                DepthCameraPtr* /*depthCameraPtrComponent*/,
+            ignition::gazebo::components::ParentEntity* parentEntityComponent)
+            -> bool {
+            assert(nameComponent);
+            assert(parentEntityComponent);
+
+            // Discard sensors not belonging to this model
+            if (parentEntityComponent->Data() != m_entity) {
+                return true;
+            }
+
+            // Append the sensor name
+            names.push_back(nameComponent->Data());
+            return true;
+        });
+
+    return names;
+}
+
+std::shared_ptr<sensors::DepthCamera>
+Model::depthCamera(const std::string& name) const
+{
+    auto depthCameraEntity = ignition::gazebo::kNullEntity;
+
+    m_ecm->Each<ignition::gazebo::components::Name,
+                ignition::gazebo::components::DepthCamera>(
+        [&](const ignition::gazebo::Entity& entity,
+            ignition::gazebo::components::Name* nameComponent,
+            ignition::gazebo::components::DepthCamera*) -> bool {
+            assert(nameComponent);
+
+            if (utils::getFirstParentEntityWithComponent<
+                    ignition::gazebo::components::Model>(m_ecm, entity)
+                != m_entity) {
+                return true;
+            }
+
+            if (nameComponent->Data() != name) {
+                return true;
+            }
+
+            depthCameraEntity = entity;
+            return true;
+        });
+
+    if (depthCameraEntity == ignition::gazebo::kNullEntity) {
+        throw std::runtime_error("Failed to find depth camera '" + name + "'");
+    }
+
+    auto depthCamera = std::make_shared<sensors::DepthCamera>();
+
+    sError << "initializing" << std::endl;
+    if (!depthCamera->initialize(depthCameraEntity, m_ecm, m_eventManager)) {
+        throw std::runtime_error("Failed to initialize depth camera '" + name
+                                 + "'");
+    }
+    sError << "post initializing" << std::endl;
+
+    return depthCamera;
 }
 
 std::array<double, 3> Model::basePosition() const

--- a/cpp/scenario/gazebo/src/World.cpp
+++ b/cpp/scenario/gazebo/src/World.cpp
@@ -27,6 +27,7 @@
 #include "scenario/gazebo/World.h"
 #include "scenario/gazebo/Log.h"
 #include "scenario/gazebo/Model.h"
+#include "scenario/gazebo/components/SensorsPlugin.h"
 #include "scenario/gazebo/components/SimulatedTime.h"
 #include "scenario/gazebo/components/Timestamp.h"
 #include "scenario/gazebo/exceptions.h"
@@ -400,6 +401,35 @@ bool World::removeModel(const std::string& modelName)
 
     // Remove the cached model
     pImpl->models.erase(modelName);
+
+    return true;
+}
+
+bool World::enableSensors(const bool enable)
+{
+    if (!enable) {
+        sError << "Disabling the sensors is not yet supported" << std::endl;
+        return false;
+    }
+
+    // Insert the plugin if the model does not have it already
+    if (!m_ecm->EntityHasComponentType(
+            m_entity, ignition::gazebo::components::SensorsPlugin::typeId)) {
+
+        sDebug << "Loading Sensors plugin for world '" << this->name() << "'"
+               << std::endl;
+
+        const std::string context =
+            "<sdf version='1.7'><render_engine>ogre2</render_engine></sdf>";
+
+        // Load the JointController plugin
+        if (!this->insertWorldPlugin(
+                "Sensors", "scenario::plugins::gazebo::Sensors", context)) {
+            sError << "Failed to insert the Sensors plugin for world '"
+                   << this->name() << "'" << std::endl;
+            return false;
+        }
+    }
 
     return true;
 }

--- a/cpp/scenario/gazebo/src/helpers.cpp
+++ b/cpp/scenario/gazebo/src/helpers.cpp
@@ -127,6 +127,23 @@ void utils::rowMajorToColumnMajor(std::vector<double>& input,
     colMajorView = rowMajorView.eval();
 }
 
+std::vector<std::string> utils::tokenize(const std::string& input,
+                                         const std::string& delimiter)
+{
+    std::vector<std::string> tokens;
+
+    size_t start = input.find_first_not_of(delimiter);
+    size_t end = start;
+
+    while (start != std::string::npos) {
+        end = input.find(delimiter, start);
+        tokens.push_back(input.substr(start, end - start));
+        start = input.find_first_not_of(delimiter, end);
+    }
+
+    return tokens;
+}
+
 scenario::core::Pose
 utils::fromIgnitionPose(const ignition::math::Pose3d& ignitionPose)
 {

--- a/cpp/scenario/plugins/Sensors/CMakeLists.txt
+++ b/cpp/scenario/plugins/Sensors/CMakeLists.txt
@@ -22,19 +22,35 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-add_subdirectory(Physics)
-add_subdirectory(Sensors)
-add_subdirectory(ECMProvider)
-add_subdirectory(JointController)
-add_subdirectory(ControllerRunner)
+find_package(ignition-sensors3-all REQUIRED)
+find_package(ignition-rendering3 REQUIRED)
+find_package(ignition-gazebo3-rendering REQUIRED)
 
-install_basic_package_files(ScenarioGazeboPlugins
-    COMPONENT ScenarioGazeboPlugins
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY AnyNewerVersion
-    EXPORT ScenarioGazeboPluginsExport
-    DEPENDENCIES ${ignition-gazebo}
-    NAMESPACE ScenarioGazeboPlugins::
-    NO_CHECK_REQUIRED_COMPONENTS_MACRO
-    INSTALL_DESTINATION
-    ${SCENARIO_INSTALL_LIBDIR}/cmake/ScenarioGazeboPlugins)
+# =======
+# Sensors
+# =======
+
+add_library(Sensors SHARED
+    Sensors.h
+    Sensors.cpp)
+
+target_link_libraries(Sensors
+    PUBLIC
+    ignition-gazebo3::core
+    PRIVATE
+    ignition-sensors3::ignition-sensors3-all
+    ignition-rendering3::ignition-rendering3
+    ignition-gazebo3::ignition-gazebo3-rendering)
+
+target_include_directories(Sensors PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+
+# ===================
+# Install the targets
+# ===================
+
+install(
+    TARGETS Sensors
+    LIBRARY DESTINATION ${SCENARIO_INSTALL_LIBDIR}/scenario/plugins
+    ARCHIVE DESTINATION ${SCENARIO_INSTALL_LIBDIR}/scenario/plugins
+    RUNTIME DESTINATION ${SCENARIO_INSTALL_BINDIR})

--- a/cpp/scenario/plugins/Sensors/CMakeLists.txt
+++ b/cpp/scenario/plugins/Sensors/CMakeLists.txt
@@ -38,6 +38,8 @@ target_link_libraries(Sensors
     PUBLIC
     ignition-gazebo3::core
     PRIVATE
+    ScenarioGazebo::ScenarioGazebo
+    ScenarioGazebo::ExtraComponents
     ignition-sensors3::ignition-sensors3-all
     ignition-rendering3::ignition-rendering3
     ignition-gazebo3::ignition-gazebo3-rendering)

--- a/cpp/scenario/plugins/Sensors/Sensors.cpp
+++ b/cpp/scenario/plugins/Sensors/Sensors.cpp
@@ -1,0 +1,517 @@
+/*
+ * Copyright (C) 2018 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <set>
+
+#include <ignition/common/Profiler.hh>
+#include <ignition/plugin/Register.hh>
+
+#include <sdf/Sensor.hh>
+
+#include <ignition/common/Time.hh>
+#include <ignition/math/Helpers.hh>
+
+#include <ignition/rendering/Scene.hh>
+#include <ignition/sensors/CameraSensor.hh>
+#include <ignition/sensors/Manager.hh>
+#include <ignition/sensors/RenderingSensor.hh>
+#include <ignition/sensors/ThermalCameraSensor.hh>
+
+#include "ignition/gazebo/EntityComponentManager.hh"
+#include "ignition/gazebo/Events.hh"
+#include "ignition/gazebo/components/Atmosphere.hh"
+#include "ignition/gazebo/components/Camera.hh"
+#include "ignition/gazebo/components/DepthCamera.hh"
+#include "ignition/gazebo/components/GpuLidar.hh"
+#include "ignition/gazebo/components/RgbdCamera.hh"
+#include "ignition/gazebo/components/ThermalCamera.hh"
+#include "ignition/gazebo/components/World.hh"
+
+#include "ignition/gazebo/rendering/RenderUtil.hh"
+
+#include "Sensors.h"
+
+using namespace ignition;
+using namespace gazebo;
+using namespace systems;
+using namespace scenario::plugins::gazebo;
+
+// Private data class.
+class scenario::plugins::gazebo::Sensors::SensorsPrivate
+{
+    /// \brief Sensor manager object. This manages the lifecycle of the
+    /// instantiated sensors.
+public:
+    sensors::Manager sensorManager;
+
+    /// \brief used to store whether rendering objects have been created.
+public:
+    bool initialized = false;
+
+    /// \brief Main rendering interface
+public:
+    RenderUtil renderUtil;
+
+    /// \brief Unique set of sensor ids
+    // TODO(anyone) Remove element when sensor is deleted
+public:
+    std::set<sensors::SensorId> sensorIds;
+
+    /// \brief rendering scene to be managed by the scene manager and used to
+    /// generate sensor data
+public:
+    rendering::ScenePtr scene;
+
+    /// \brief Temperature used by thermal camera. Defaults to temperature at
+    /// sea level
+public:
+    double ambientTemperature = 288.15;
+
+    /// \brief Keep track of cameras, in case we need to handle stereo cameras.
+    /// Key: Camera's parent scoped name
+    /// Value: Pointer to camera
+    // TODO(anyone) Remove element when sensor is deleted
+public:
+    std::map<std::string, sensors::CameraSensor*> cameras;
+
+    /// \brief Flag to indicate if worker threads are running
+public:
+    std::atomic<bool> running{false};
+
+    /// \brief Flag to signal if initialization should occur
+public:
+    bool doInit{false};
+
+    /// \brief Flag to signal if rendering update is needed
+public:
+    bool updateAvailable{false};
+
+    /// \brief Thread that rendering will occur in
+public:
+    std::thread renderThread;
+
+    /// \brief Mutex to protect rendering data
+public:
+    std::mutex renderMutex;
+
+    /// \brief Condition variable to signal rendering thread
+    ///
+    /// This variable is used to block/unblock operations in the rendering
+    /// thread.  For a more detailed explanation on the flow refer to the
+    /// documentation on RenderThread.
+public:
+    std::condition_variable renderCv;
+
+    /// \brief Connection to events::Stop event, used to stop thread
+public:
+    ignition::common::ConnectionPtr stopConn;
+
+    /// \brief Update time for the next rendering iteration
+public:
+    ignition::common::Time updateTime;
+
+    /// \brief Sensors to include in the next rendering iteration
+public:
+    std::vector<sensors::RenderingSensor*> activeSensors;
+
+    /// \brief Mutex to protect sensorMask
+public:
+    std::mutex sensorMaskMutex;
+
+    /// \brief Mask sensor updates for sensors currently being rendered
+public:
+    std::map<sensors::SensorId, ignition::common::Time> sensorMask;
+
+    /// \brief Wait for initialization to happen
+private:
+    void WaitForInit();
+
+    /// \brief Run one rendering iteration
+private:
+    void RunOnce();
+
+    /// \brief Top level function for the rendering thread
+    ///
+    /// This function captures all of the behavior of the rendering thread.
+    /// The behavior is captured in two phases: initialization and steady state.
+    ///
+    /// When the thread is first started, it waits on renderCv until the
+    /// prerequisites for initialization are met, and the `doInit` flag is set.
+    /// In order for initialization to proceed, rendering sensors must be
+    /// available in the EntityComponentManager.
+    ///
+    /// When doInit is set, and renderCv is notified, initialization
+    /// is performed (creating the render context and scene). During
+    /// initialization, execution is blocked for the caller of PostUpdate.
+    /// When initialization is complete, PostUpdate will be notified via
+    /// renderCv and execution will continue.
+    ///
+    /// Once in steady state, a rendering operation is triggered by setting
+    /// updateAvailable to true, and notifying via the renderCv.
+    /// The rendering operation is done in `RunOnce`.
+    ///
+    /// The caller of PostUpdate will not be blocked if there is no
+    /// rendering operation currently ongoing. Rendering will occur
+    /// asyncronously.
+    //
+    /// The caller of PostUpdate will be blocked if there is a rendering
+    /// operation currently ongoing, until that completes.
+private:
+    void RenderThread();
+
+    /// \brief Launch the rendering thread
+public:
+    void Run();
+
+    /// \brief Stop the rendering thread
+public:
+    void Stop();
+};
+
+//////////////////////////////////////////////////
+void Sensors::SensorsPrivate::WaitForInit()
+{
+    while (!this->initialized && this->running) {
+        ignwarn << "Waiting for init" << std::endl;
+        std::unique_lock<std::mutex> lock(this->renderMutex);
+        // Wait to be ready for initialization or stopped running.
+        // We need rendering sensors to be available to initialize.
+        this->renderCv.wait(
+            lock, [this]() { return this->doInit || !this->running; });
+
+        if (this->doInit) {
+            // Only initialize if there are rendering sensors
+            ignwarn << "Initializing render context" << std::endl;
+            this->renderUtil.Init();
+            this->scene = this->renderUtil.Scene();
+            this->initialized = true;
+        }
+
+        this->updateAvailable = false;
+        this->renderCv.notify_one();
+    }
+    ignwarn << "Rendering Thread initialized" << std::endl;
+}
+
+//////////////////////////////////////////////////
+void Sensors::SensorsPrivate::RunOnce()
+{
+    std::unique_lock<std::mutex> lock(this->renderMutex);
+    this->renderCv.wait(
+        lock, [this]() { return !this->running || this->updateAvailable; });
+
+    if (!this->running)
+        return;
+
+    IGN_PROFILE("SensorsPrivate::RunOnce");
+    {
+        IGN_PROFILE("Update");
+        this->renderUtil.Update();
+    }
+
+    if (!this->activeSensors.empty()) {
+        this->sensorMaskMutex.lock();
+        // Check the active sensors against masked sensors.
+        //
+        // The internal state of a rendering sensor is not updated until the
+        // rendering operation is complete, which can leave us in a position
+        // where the sensor is falsely indicating that an update is needed.
+        //
+        // To prevent this, add sensors that are currently being rendered to
+        // a mask. Sensors are removed from the mask when 90% of the update
+        // delta has passed, which will allow rendering to proceed.
+        for (const auto& sensor : this->activeSensors) {
+            // 90% of update delta (1/UpdateRate());
+            ignition::common::Time delta(0.9 / sensor->UpdateRate());
+            this->sensorMask[sensor->Id()] = this->updateTime + delta;
+        }
+        this->sensorMaskMutex.unlock();
+
+        {
+            IGN_PROFILE("PreRender");
+            // Update the scene graph manually to improve performance
+            // We only need to do this once per frame It is important to call
+            // sensors::RenderingSensor::SetManualSceneUpdate and set it to true
+            // so we don't waste cycles doing one scene graph update per sensor
+            this->scene->PreRender();
+        }
+
+        {
+            // publish data
+            IGN_PROFILE("RunOnce");
+            this->sensorManager.RunOnce(this->updateTime);
+        }
+
+        this->activeSensors.clear();
+    }
+
+    this->updateAvailable = false;
+    lock.unlock();
+    this->renderCv.notify_one();
+}
+
+//////////////////////////////////////////////////
+void Sensors::SensorsPrivate::RenderThread()
+{
+    IGN_PROFILE_THREAD_NAME("RenderThread");
+
+    ignwarn << "SensorsPrivate::RenderThread started" << std::endl;
+
+    // We have to wait for rendering sensors to be available
+    this->WaitForInit();
+
+    while (this->running) {
+        this->RunOnce();
+    }
+
+    for (auto id : this->sensorIds)
+        this->sensorManager.Remove(id);
+
+    ignwarn << "SensorsPrivate::RenderThread stopped" << std::endl;
+}
+
+//////////////////////////////////////////////////
+void Sensors::SensorsPrivate::Run()
+{
+    ignwarn << "SensorsPrivate::Run" << std::endl;
+    this->running = true;
+    this->renderThread = std::thread(&SensorsPrivate::RenderThread, this);
+}
+
+//////////////////////////////////////////////////
+void Sensors::SensorsPrivate::Stop()
+{
+    ignwarn << "SensorsPrivate::Stop" << std::endl;
+    std::unique_lock<std::mutex> lock(this->renderMutex);
+    this->running = false;
+
+    if (this->stopConn) {
+        // Clear connection to stop additional incoming events.
+        this->stopConn.reset();
+    }
+
+    lock.unlock();
+    this->renderCv.notify_all();
+
+    if (this->renderThread.joinable()) {
+        this->renderThread.join();
+    }
+}
+
+//////////////////////////////////////////////////
+Sensors::Sensors()
+    : System()
+    , dataPtr(std::make_unique<SensorsPrivate>())
+{}
+
+//////////////////////////////////////////////////
+Sensors::~Sensors()
+{
+    this->dataPtr->Stop();
+}
+
+//////////////////////////////////////////////////
+void Sensors::Configure(const Entity& /*_id*/,
+                        const std::shared_ptr<const sdf::Element>& _sdf,
+                        EntityComponentManager& _ecm,
+                        EventManager& _eventMgr)
+{
+    ignwarn << "Configuring Sensors system" << std::endl;
+    // Setup rendering
+    std::string engineName =
+        _sdf->Get<std::string>("render_engine", "ogre2").first;
+
+    this->dataPtr->renderUtil.SetEngineName(engineName);
+    this->dataPtr->renderUtil.SetEnableSensors(
+        true,
+        std::bind(&Sensors::CreateSensor,
+                  this,
+                  std::placeholders::_1,
+                  std::placeholders::_2));
+
+    // parse sensor-specific data
+    auto worldEntity = _ecm.EntityByComponents(components::World());
+    if (kNullEntity != worldEntity) {
+        // temperature used by thermal camera
+        auto atmosphere = _ecm.Component<components::Atmosphere>(worldEntity);
+        if (atmosphere) {
+            auto atmosphereSdf = atmosphere->Data();
+            this->dataPtr->ambientTemperature =
+                atmosphereSdf.Temperature().Kelvin();
+        }
+    }
+
+    this->dataPtr->stopConn = _eventMgr.Connect<events::Stop>(
+        std::bind(&SensorsPrivate::Stop, this->dataPtr.get()));
+
+    // Kick off worker thread
+    this->dataPtr->Run();
+}
+
+//////////////////////////////////////////////////
+void Sensors::PostUpdate(const UpdateInfo& _info,
+                         const EntityComponentManager& _ecm)
+{
+    IGN_PROFILE("Sensors::PostUpdate");
+
+    // \TODO(anyone) Support rewind
+    if (_info.dt < std::chrono::steady_clock::duration::zero()) {
+        ignwarn << "Detected jump back in time ["
+                << std::chrono::duration_cast<std::chrono::seconds>(_info.dt)
+                       .count()
+                << "s]. System may not work properly." << std::endl;
+    }
+
+    if (!this->dataPtr->initialized
+        && (_ecm.HasComponentType(components::Camera::typeId)
+            || _ecm.HasComponentType(components::DepthCamera::typeId)
+            || _ecm.HasComponentType(components::GpuLidar::typeId)
+            || _ecm.HasComponentType(components::RgbdCamera::typeId)
+            || _ecm.HasComponentType(components::ThermalCamera::typeId))) {
+        igndbg << "Initialization needed" << std::endl;
+        std::unique_lock<std::mutex> lock(this->dataPtr->renderMutex);
+        this->dataPtr->doInit = true;
+        this->dataPtr->renderCv.notify_one();
+    }
+
+    if (this->dataPtr->running && this->dataPtr->initialized) {
+        this->dataPtr->renderUtil.UpdateFromECM(_info, _ecm);
+
+        auto time = math::durationToSecNsec(_info.simTime);
+        auto t = common::Time(time.first, time.second);
+
+        std::vector<sensors::RenderingSensor*> activeSensors;
+
+        this->dataPtr->sensorMaskMutex.lock();
+        for (auto id : this->dataPtr->sensorIds) {
+            sensors::Sensor* s = this->dataPtr->sensorManager.Sensor(id);
+            auto rs = dynamic_cast<sensors::RenderingSensor*>(s);
+
+            auto it = this->dataPtr->sensorMask.find(id);
+            if (it != this->dataPtr->sensorMask.end()) {
+                if (it->second <= t) {
+                    this->dataPtr->sensorMask.erase(it);
+                }
+                else {
+                    continue;
+                }
+            }
+
+            if (rs && rs->NextUpdateTime() <= t) {
+                activeSensors.push_back(rs);
+            }
+        }
+        this->dataPtr->sensorMaskMutex.unlock();
+
+        if (!activeSensors.empty()
+            || this->dataPtr->renderUtil.PendingSensors() > 0) {
+            std::unique_lock<std::mutex> lock(this->dataPtr->renderMutex);
+            this->dataPtr->renderCv.wait(lock, [this] {
+                return !this->dataPtr->running
+                       || !this->dataPtr->updateAvailable;
+            });
+
+            if (!this->dataPtr->running) {
+                return;
+            }
+
+            this->dataPtr->activeSensors = std::move(activeSensors);
+            this->dataPtr->updateTime = t;
+            this->dataPtr->updateAvailable = true;
+            this->dataPtr->renderCv.notify_one();
+        }
+    }
+}
+
+//////////////////////////////////////////////////
+std::string Sensors::CreateSensor(const sdf::Sensor& _sdf,
+                                  const std::string& _parentName)
+{
+    if (_sdf.Type() == sdf::SensorType::NONE) {
+        ignerr << "Unable to create sensor. SDF sensor type is NONE."
+               << std::endl;
+        return std::string();
+    }
+
+    // Create within ign-sensors
+    auto sensorId = this->dataPtr->sensorManager.CreateSensor(_sdf);
+    auto sensor = this->dataPtr->sensorManager.Sensor(sensorId);
+
+    if (nullptr == sensor || sensors::NO_SENSOR == sensor->Id()) {
+        ignerr << "Failed to create sensor [" << _sdf.Name() << "]"
+               << std::endl;
+        return std::string();
+    }
+
+    this->dataPtr->sensorIds.insert(sensorId);
+
+    // Set the scene so it can create the rendering sensor
+    auto renderingSensor = dynamic_cast<sensors::RenderingSensor*>(sensor);
+    renderingSensor->SetScene(this->dataPtr->scene);
+    renderingSensor->SetParent(_parentName);
+    renderingSensor->SetManualSceneUpdate(true);
+
+    // Special case for stereo cameras
+    auto cameraSensor = dynamic_cast<sensors::CameraSensor*>(sensor);
+    if (nullptr != cameraSensor) {
+        // Parent
+        auto parent = cameraSensor->Parent();
+
+        // If parent has other camera children, set the baseline.
+        // For stereo pairs, the baseline for the left camera is zero, and for
+        // the right camera it's the distance between them. For more than 2
+        // cameras, the first camera's baseline is zero and the others have the
+        // distance between them.
+        if (this->dataPtr->cameras.find(parent)
+            != this->dataPtr->cameras.end()) {
+            // TODO(anyone) This is safe because we're not removing sensors
+            // First camera added to the parent link
+            auto leftCamera = this->dataPtr->cameras[parent];
+            auto rightCamera = cameraSensor;
+
+            // If cameras have right / left topic, use that to decide which is
+            // which
+            if (leftCamera->Topic().find("right") != std::string::npos
+                && rightCamera->Topic().find("left") != std::string::npos) {
+                std::swap(rightCamera, leftCamera);
+            }
+
+            // Camera sensor's Y axis is orthogonal to the optical axis
+            auto baseline = abs(rightCamera->Pose().Pos().Y()
+                                - leftCamera->Pose().Pos().Y());
+            rightCamera->SetBaseline(baseline);
+        }
+        else {
+            this->dataPtr->cameras[parent] = cameraSensor;
+        }
+    }
+
+    // Sensor-specific settings
+    auto thermalSensor = dynamic_cast<sensors::ThermalCameraSensor*>(sensor);
+    if (nullptr != thermalSensor) {
+        thermalSensor->SetAmbientTemperature(this->dataPtr->ambientTemperature);
+    }
+
+    return sensor->Name();
+}
+
+IGNITION_ADD_PLUGIN(Sensors,
+                    System,
+                    Sensors::ISystemConfigure,
+                    Sensors::ISystemPostUpdate)
+
+IGNITION_ADD_PLUGIN_ALIAS(Sensors, "ignition::gazebo::systems::Sensors")

--- a/cpp/scenario/plugins/Sensors/Sensors.cpp
+++ b/cpp/scenario/plugins/Sensors/Sensors.cpp
@@ -600,28 +600,9 @@ bool Sensors::SensorsPrivate::GetSensorDataFromECM(
     std::string& sensorName,
     ignition::gazebo::Entity& sensorEntity)
 {
-    // Lambda to tokenize the scoped parent name and extract
-    // the pair <modelName, linkName>
-    auto tokenize =
-        [](const std::string& input,
-           const std::string& delimiter) -> std::vector<std::string> {
-        size_t start = 0;
-        size_t end = input.find(delimiter);
-        std::vector<std::string> tokens;
-
-        while (end != std::string::npos) {
-            tokens.push_back(input.substr(start, end - start));
-            start = end + delimiter.length();
-            end = delimiter.find(delimiter, start);
-        }
-
-        tokens.push_back(input.substr(start, end));
-
-        return tokens;
-    };
-
-    // Tokenize the scoped parent name
-    const auto tokens = tokenize(scopedParentName, "::");
+    // Tokenize the scoped parent name into a vector [modelName, linkName]
+    const auto tokens =
+        scenario::gazebo::utils::tokenize(scopedParentName, "::");
 
     if (tokens.size() != 2) {
         ignerr << "Failed to tokenize scoped name of sensor's parent"

--- a/cpp/scenario/plugins/Sensors/Sensors.h
+++ b/cpp/scenario/plugins/Sensors/Sensors.h
@@ -53,10 +53,11 @@ private:
     /// \brief Create a rendering sensor from sdf
     /// \param[in] _sdf SDF description of the sensor
     /// \param[in] _parentName Name of parent that the sensor is attached to
+    /// \param[in] _ecm The EntityComponentManager of the simulation instance
     /// \return Sensor name
     std::string CreateSensor(const sdf::Sensor& _sdf,
-                             const std::string& _parentName);
-
+                             const std::string& _parentName,
+                             ignition::gazebo::EntityComponentManager& _ecm);
 
     /// \brief Private data pointer.
     class SensorsPrivate;

--- a/cpp/scenario/plugins/Sensors/Sensors.h
+++ b/cpp/scenario/plugins/Sensors/Sensors.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2018 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef SCENARIO_PLUGINS_GAZEBO_SENSORS_H
+#define SCENARIO_PLUGINS_GAZEBO_SENSORS_H
+
+#include <ignition/gazebo/Export.hh>
+#include <ignition/gazebo/System.hh>
+#include <ignition/gazebo/config.hh>
+#include <ignition/sensors/Sensor.hh>
+#include <sdf/Sensor.hh>
+
+#include <memory>
+#include <string>
+
+namespace scenario::plugins::gazebo {
+    class Sensors;
+} // namespace scenario::plugins::gazebo
+
+class scenario::plugins::gazebo::Sensors
+    : public ignition::gazebo::System
+    , public ignition::gazebo::ISystemConfigure
+    , public ignition::gazebo::ISystemPostUpdate
+{
+public:
+    explicit Sensors();
+
+    ~Sensors() override;
+
+    void Configure(const ignition::gazebo::Entity& id,
+                   const std::shared_ptr<const sdf::Element>& sdf,
+                   ignition::gazebo::EntityComponentManager& ecm,
+                   ignition::gazebo::EventManager& eventMgr) final;
+
+    void PostUpdate(const ignition::gazebo::UpdateInfo& info,
+                    const ignition::gazebo::EntityComponentManager& ecm) final;
+
+private:
+    /// \brief Create a rendering sensor from sdf
+    /// \param[in] _sdf SDF description of the sensor
+    /// \param[in] _parentName Name of parent that the sensor is attached to
+    /// \return Sensor name
+    std::string CreateSensor(const sdf::Sensor& _sdf,
+                             const std::string& _parentName);
+
+
+    /// \brief Private data pointer.
+    class SensorsPrivate;
+    std::unique_ptr<SensorsPrivate> dataPtr;
+};
+
+#endif // SCENARIO_PLUGINS_GAZEBO_SENSORS_H

--- a/python/gym_ignition/context/gazebo/__init__.py
+++ b/python/gym_ignition/context/gazebo/__init__.py
@@ -3,4 +3,6 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 from . import plugin
+from . import shapes
+from . import sensors
 from . import controllers

--- a/python/gym_ignition/context/gazebo/sensors.py
+++ b/python/gym_ignition/context/gazebo/sensors.py
@@ -1,0 +1,59 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+from dataclasses import dataclass
+from gym_ignition.context import plugin
+
+
+@dataclass
+class DepthCamera(plugin.Plugin):  # TODO: this is not a plugin, make a sensor template?
+
+    name: str
+    width: int = 256
+    height: int = 256
+    fov: float = 1.05
+
+    topic: str = ""
+    # TODO: static
+
+    def to_xml(self) -> str:  # .sdf()?
+        xml = f"""
+        <model name="{self.model_name}">
+          <static>true</static>
+    
+          <link name="{self.name}_link">
+            <sensor name="{self.name}" type="depth_camera">
+              <always_on>1</always_on>
+              <visualize>true</visualize>
+              <topic>{self.topic}</topic>
+              <camera>
+                <horizontal_fov>{self.fov}</horizontal_fov>
+                <image>
+                  <width>{self.width}</width>
+                  <height>{self.height}</height>
+                  <format>R_FLOAT32</format>
+                </image>
+                <clip>
+                  <near>0.1</near>
+                  <far>10.0</far>
+                </clip>
+              </camera>
+            </sensor>
+            <visual name="visual">
+              <geometry>
+                <box>
+                  <size>0.1 0.1 0.1</size>
+                </box>
+              </geometry>
+            </visual>
+          </link>
+
+        </model>
+        """
+
+        return DepthCamera.wrap_in_sdf(xml)
+
+    @property
+    def model_name(self) -> str:
+        return f"{self.name}_model"

--- a/python/gym_ignition/context/gazebo/shapes.py
+++ b/python/gym_ignition/context/gazebo/shapes.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+# TODO: urdf or sdf? Urdf for iDynTree, otherwise SDF.
+
+
+@dataclass
+class BoxURDF:
+
+    mass: float = 5.0
+    edge: float = 0.2
+    name: str = "cube_robot"
+
+    def urdf(self) -> str:
+
+        i = 1.0 / 12 * self.mass * (self.edge ** 2 + self.edge ** 2)
+        urdf = f"""
+        <robot name="{self.name}" xmlns:xacro="http://www.ros.org/wiki/xacro">
+            <link name="cube">
+                <inertial>
+                  <origin rpy="0 0 0" xyz="0 0 0"/>
+                  <mass value="{self.mass}"/>
+                  <inertia ixx="{i}" ixy="0" ixz="0" iyy="{i}" iyz="0" izz="{i}"/>
+                </inertial>
+                <visual>
+                  <geometry>
+                    <box size="{self.edge} {self.edge} {self.edge}"/>
+                  </geometry>
+                  <origin rpy="0 0 0" xyz="0 0 0"/>
+                </visual>
+                <collision>
+                  <geometry>
+                    <box size="{self.edge} {self.edge} {self.edge}"/>
+                  </geometry>
+                  <origin rpy="0 0 0" xyz="0 0 0"/>
+                </collision>
+            </link>
+        </robot>"""
+
+        return urdf

--- a/tests/test_scenario/test_depth_camera.py
+++ b/tests/test_scenario/test_depth_camera.py
@@ -1,0 +1,118 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import pytest
+pytestmark = pytest.mark.scenario
+
+import numpy as np
+from typing import Tuple
+from ..common import utils
+from scenario import core as scenario_core
+from scenario import gazebo as scenario_gazebo
+from gym_ignition.context import sensors, shapes
+from ..common.utils import default_world_fixture as default_world
+
+# Set the verbosity
+scenario_gazebo.set_verbosity(scenario_gazebo.Verbosity_debug)
+
+
+@pytest.mark.parametrize("default_world", [(1.0 / 1_000, 1.0, 1)], indirect=True)
+def test_depth_camera(default_world: Tuple[scenario_gazebo.GazeboSimulator,
+                                           scenario_gazebo.World]):
+
+    # Get the simulator and the world
+    gazebo, world = default_world
+
+    # Insert a cube floating in the air
+    cube_pose = scenario_core.Pose([0, 0, 2.], [1, 0, 0, 0])
+    cube_shape = shapes.BoxURDF(mass=1.0, edge=0.1)
+    cube_file = utils.misc.string_to_file(cube_shape.urdf())
+    assert world.insert_model(cube_file, cube_pose)
+
+    # Get the cube model
+    assert cube_shape.name in world.model_names()
+    cube = world.get_model(model_name=cube_shape.name)
+
+    # Enable the sensors system
+    assert world.enable_sensors(enable=True)
+
+    # Configure depth camera context
+    camera_name = "my_camera"
+    camera_context = sensors.DepthCamera(name=camera_name)
+
+    # Insert a down-facing camera above the cube
+    camera_pose = scenario_core.Pose([0, 0, 3.], [0.707, 0, 0.707, 0])
+    camera_file = utils.misc.string_to_file(camera_context.to_xml())
+    assert world.insert_model(camera_file, camera_pose)
+
+    # Get the model that contains the camera
+    assert camera_context.model_name in world.model_names()
+    camera_model = world.get_model(model_name=camera_context.model_name)
+    assert camera_model.valid()
+
+    # Getting the camera without a run (possibly paused) would run an exception.
+    # The sensor has to be processed before being able to gather it.
+    with pytest.raises(RuntimeError):
+        _ = camera_model.to_gazebo().depth_camera(name=camera_context.name)
+
+    # Trigger camera insertion with a paused step
+    assert gazebo.run(paused=True)
+
+    # Get the depth camera
+    depth_camera = camera_model.to_gazebo().depth_camera(name=camera_context.name)
+
+    # The camera will generate an image only after the first unpaused step
+    assert depth_camera.image() == tuple()
+
+    # Run the simulator, triggering the generation of an image
+    assert gazebo.run()
+
+    # Get the image
+    img = depth_camera.image()
+    assert len(img) == camera_context.height * camera_context.width
+
+    # Reshape the image to a numpy matrix
+    img = np.reshape(img, newshape=(camera_context.height, camera_context.width))
+
+    # Check that the edges of the image are as distant as the ground plane...
+    camera_z_position = camera_pose.position[2]
+    assert img[0, 0] == pytest.approx(camera_z_position, abs=0.01)
+    assert img[0, -1] == pytest.approx(camera_z_position, abs=0.01)
+    assert img[-1, 0] == pytest.approx(camera_z_position, abs=0.01)
+    assert img[-1, -1] == pytest.approx(camera_z_position, abs=0.01)
+
+    # ... and the center as distant as the cube
+    center = int(camera_context.height / 2), int(camera_context.width / 2)
+    cube_upper_face_z = cube.base_position()[2] + cube_shape.edge / 2
+    assert img[center] == pytest.approx(camera_z_position - cube_upper_face_z, abs=0.01)
+
+    # Make the cube fall on the ground
+    cube.enable_contacts(enable=True)
+
+    import time
+    now = time.time()
+    # TODO: check efficiency, should it be almost one second? we got ~3 now w/o logs in release
+    for _ in range(1_000):
+        gazebo.run()
+    print(time.time() - now)
+
+    # Check that the cube is on the ground
+    assert len(cube.links_in_contact()) != 0
+
+    # Get and reshape the image
+    img = depth_camera.image()
+    assert len(img) == camera_context.height * camera_context.width
+    img = np.reshape(img, newshape=(camera_context.height, camera_context.width))
+
+    # Check that the edges of the image are as distant as the ground plane...
+    camera_z_position = camera_pose.position[2]
+    assert img[0, 0] == pytest.approx(camera_z_position, abs=0.01)
+    assert img[0, -1] == pytest.approx(camera_z_position, abs=0.01)
+    assert img[-1, 0] == pytest.approx(camera_z_position, abs=0.01)
+    assert img[-1, -1] == pytest.approx(camera_z_position, abs=0.01)
+
+    # ... and the center as distant as the cube, this time not using the base position
+    cube_upper_face_z = cube_shape.edge
+    center = int(camera_context.height / 2), int(camera_context.width / 2)
+    assert img[center] == pytest.approx(camera_z_position - cube_upper_face_z, abs=0.01)

--- a/tests/test_scenario/test_depth_camera.py
+++ b/tests/test_scenario/test_depth_camera.py
@@ -90,12 +90,9 @@ def test_depth_camera(default_world: Tuple[scenario_gazebo.GazeboSimulator,
     # Make the cube fall on the ground
     cube.enable_contacts(enable=True)
 
-    import time
-    now = time.time()
     # TODO: check efficiency, should it be almost one second? we got ~3 now w/o logs in release
     for _ in range(1_000):
         gazebo.run()
-    print(time.time() - now)
 
     # Check that the cube is on the ground
     assert len(cube.links_in_contact()) != 0


### PR DESCRIPTION
This PR provides the initial support to rendering-based sensors #199. This implementation has not been really straightforward and it required quite a lot of time to understand the multithreading implementation of upstream's Sensors system and rendering stack. In particular, it does not seem to me that the simulator ensures a prompt image generation right after a single run and I had to enhance the synchronization mechanism to lock execution when needed. 

In more detail, this PR:

- Vendors the upstream [`Sensors` system](https://github.com/ignitionrobotics/ign-gazebo/tree/fac36a4b06c3ba45b14c72163f9b390721edbda6/src/systems/sensors).
- Customizes the vendored `Sensors` system to be compatible with reproducible execution, i.e. being able to extract sensory data right after a simulator run.
- Enables loading the `Sensors` system with `World::enableSensors`.
- Adds new `DepthCamera` class.
- Allows extracting a depth camera object from a model with `Model::depthCamera`.
- Adds a new test for the depth camera.

Caveats and WIPs;

- In the `DepthCamera` class we need to know what's the rate of the server in order to prepare the images. Right now it's hardcoded. We should create a new component for the World entity with this information.
- For being more efficient, the processing of the image runs asynchronously than caller code. I played with `std::promise` and `std::future` for locking the caller execution only if data is required.
- Caveat: I use an unordered map with simulation time as key. Using double is a very bad idea, so I converted the time to nanoseconds. It should provide a decent tradeoff.
- Comment: I tried to reduce copies of the image as much as possible. The image callback fills a buffer in the `DepthCamera` class, that is returned to the user as const reference. The same buffer is moved from promise to promise as time passes. This approach is not bullet-proof and should be further tested.
- Caveat: it's possible that multiple image callbacks are called concurrently in different threads. Due to the buffer handling, the callback code is protected with a mutex. The problem is that the mutex is not assured to preserve the order of acquisition. We should keep this in mind and find better solutions. 
- The execution is terribly slow. In the test and compiling in Release, 1 second of simulation with a single cube falling and a depth camera that does not get any image takes roughly 2.5 seconds. It's a start, though :) 

This PR is the first step to get a heightmap of the terrain https://github.com/ignitionrobotics/ign-gazebo/issues/337. It's not directly related to that, being more general to the supported sensors, but it allowed me to study the rendering stack and it was natural to put an extra effort and integrate it into gym-ignition.

cc @traversaro early feedback is welcome