### PR TITLE
Update to Ignition Dome

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     build:
       args:
         from: diegoferigo/gym-ignition:base
-        ignition_codename: citadel
+        ignition_codename: dome
       context: .
       dockerfile: cicd-master.Dockerfile
     image: diegoferigo/gym-ignition:ci-master
@@ -27,7 +27,7 @@ services:
     build:
       args:
         from: diegoferigo/gym-ignition:base
-        ignition_codename: citadel
+        ignition_codename: dome
       context: .
       dockerfile: cicd-master.Dockerfile
     image: diegoferigo/gym-ignition:pypi-master
@@ -40,7 +40,7 @@ services:
     build:
       args:
         from: diegoferigo/gym-ignition:base
-        ignition_codename: citadel
+        ignition_codename: dome
         CMAKE_BUILD_TYPE: Debug
       context: .
       dockerfile: cicd-devel.Dockerfile
@@ -50,7 +50,7 @@ services:
     build:
       args:
         from: diegoferigo/gym-ignition:base
-        ignition_codename: citadel
+        ignition_codename: dome
         CMAKE_BUILD_TYPE: Release
       context: .
       dockerfile: cicd-devel.Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,23 +6,22 @@ on:
 
 jobs:
 
-  # ===============================
-  # DEVELOPER INSTALLATION [master]
-  # ===============================
-
-  developer-master:
-    name: master@developer
-#    if: |
-#      (github.event_name == 'push' && github.ref != 'refs/heads/master') ||
-#      (github.event_name == 'pull_request' && github.event.pull_request.head.ref != 'refs/heads/master')
+  build-and-test:
+    name: Build and Test
     runs-on: ubuntu-latest
     container: 'ubuntu:focal'
     strategy:
       matrix:
-        build_type: [ Debug ]
+        type:
+          - User
+          - Developer
         ignition:
-          # - citadel
           - dome
+          - citadel
+        # Waiting the new minor release
+        exclude:
+          - type: User
+            ignition: citadel
 
     steps:
 
@@ -38,22 +37,78 @@ jobs:
             software-properties-common \
             python3 \
             python3-pip \
-            python3-wheel \
-            python3-pytest \
-            python3-pytest-xvfb
+            python3-wheel
+          pip3 install pytest pytest-xvfb
         env:
           DEBIAN_FRONTEND: noninteractive
 
       - uses: actions/checkout@master
       - run: git fetch --prune --unshallow
 
-      - name: Install Ignition [${{ matrix.ignition }}]
+      - name: Compilation cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.ccache
+          # We include the commit sha in the cache key, as new cache entries are
+          # only created if there is no existing entry for the key yet.
+          key: ${{ runner.os }}-ccache-${{ matrix.ignition }}-${{ github.sha }}
+          # Restore any ccache cache entry, if none for the key above exists
+          restore-keys: |
+            ${{ runner.os }}-ccache-${{ matrix.ignition }}
+
+      - name: Enable ccache
+        run: |
+          apt-get update
+          apt-get install -y ccache
+          echo "/usr/lib/ccache" >> $GITHUB_PATH
+          mkdir -p ~/.ccache
+          echo "max_size = 5.0G" > ~/.ccache/ccache.conf
+
+      # ================
+      # Install Ignition
+      # ================
+
+      - name: '[Stable Channel] Install Ignition ${{ matrix.ignition }}'
+        if: |
+          github.ref == 'refs/heads/master' ||
+          (github.event_name == 'pull_request' && github.event.pull_request.head.ref == 'refs/heads/master')
         run: |
           sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" >\
             /etc/apt/sources.list.d/gazebo-stable.list'
           wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
           apt-get update
           apt-get install -y --no-install-recommends ignition-${{ matrix.ignition }}
+
+      - name: '[Nightly Channel] Install Ignition ${{ matrix.ignition }}'
+        if: |
+          (github.event_name == 'push' && github.ref != 'refs/heads/master') ||
+          (github.event_name == 'pull_request' && github.event.pull_request.head.ref != 'refs/heads/master')
+        run: |
+          sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" >\
+            /etc/apt/sources.list.d/gazebo-stable.list'
+          wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
+          apt-get update
+          pip3 install vcstool colcon-common-extensions
+          mkdir -p /workspace/src
+          cd /workspace/src
+          wget -O - ${TAGS_YAML} | vcs import
+          SYSTEM_VERSION=$(lsb_release -cs)
+          apt-get -y install $(sort -u $(find . -iname 'packages-'$SYSTEM_VERSION'.apt' -o -iname 'packages.apt') | tr '\n' ' ')
+          cd /workspace
+          colcon graph
+          colcon build \
+              --cmake-args \
+                  -GNinja \
+                  -DBUILD_TESTING:BOOL=OFF \
+                  -DCMAKE_BUILD_TYPE=Debug \
+              --merge-install
+          echo "source /workspace/install/setup.bash" >> /etc/bash.bashrc
+        env:
+          TAGS_YAML: https://raw.githubusercontent.com/ignition-tooling/gazebodistro/master/collection-${{ matrix.ignition }}.yaml
+
+      # ==========================
+      # Install other dependencies
+      # ==========================
 
       - name: Install iDynTree
         run: |
@@ -64,321 +119,60 @@ jobs:
           IDYNTREE_PYTHON_PKG=$(python3 -c 'import idyntree, pathlib; print(pathlib.Path(idyntree.__file__).parent)')
           echo "CMAKE_PREFIX_PATH=$IDYNTREE_PYTHON_PKG" >> $GITHUB_ENV
 
-      - name: Build and Install C++
+      # =============
+      # Build project
+      # =============
+
+      # Note: In order to execute the setup.sh script, the file /etc/bash.bashrc must be sourced.
+      #       To do that, we change the shell to a bash interactive session.
+
+      # Developer installation
+      - name: '[Developer] Build and Install C++'
+        if: matrix.type == 'Developer'
+        shell: bash -i -e {0}
         run: |
           env
           mkdir build && cd build
-          cmake .. -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug
           cmake --build . --target install
-
-      - name: Setup Python Package
+      - name: '[Developer] Setup Python Package'
+        if: matrix.type == 'Developer'
         run: pip3 install -e .
 
-      - name: Python Tests [ScenarI/O]
-        run: |
-          cd tests
-          pytest-3 -m "scenario"
-
-      - name: Python Tests with Valgrind [ScenarI/O]
-        if: failure()
-        run: |
-          apt-get install -y --no-install-recommends valgrind
-          pip3 install colour-valgrind
-          cd tests
-          valgrind --log-file=/tmp/valgrind.log pytest-3 -s -m "scenario" || colour-valgrind -t /tmp/valgrind.log
-
-      - name: Python Tests [gym_ignition]
-        run: |
-          cd tests
-          pytest-3 -m "gym_ignition"
-
-      - name: Python Tests with Valgrind [gym_ignition]
-        if: failure()
-        run: |
-          pip3 install colour-valgrind
-          cd tests
-          valgrind --log-file=/tmp/valgrind.log pytest-3 -s -m "gym_ignition" || colour-valgrind -t /tmp/valgrind.log
-
-  # ==========================
-  # USER INSTALLATION [master]
-  # ==========================
-
-  user-master:
-    name: master@user
-#    if: |
-#      (github.event_name == 'push' && github.ref != 'refs/heads/master') ||
-#      (github.event_name == 'pull_request' && github.event.pull_request.head.ref != 'refs/heads/master')
-    runs-on: ubuntu-latest
-    container: 'ubuntu:focal'
-    strategy:
-      matrix:
-        build_type: [ Debug ]
-        ignition:
-          # - citadel
-          - dome
-
-    steps:
-
-      - name: Install dependencies
-        run: |
-          apt-get update
-          apt-get install -y --no-install-recommends \
-            wget \
-            git \
-            gpg-agent \
-            ninja-build \
-            build-essential \
-            software-properties-common \
-            python3 \
-            python3-pip \
-            python3-wheel \
-            python3-pytest \
-            python3-pytest-xvfb
-        env:
-          DEBIAN_FRONTEND: noninteractive
-
-      - uses: actions/checkout@master
-      - run: git fetch --prune --unshallow
-
-      - name: Install Ignition [${{ matrix.ignition }}]
-        run: |
-          sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" >\
-            /etc/apt/sources.list.d/gazebo-stable.list'
-          wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
-          apt-get update
-          apt-get install -y --no-install-recommends ignition-${{ matrix.ignition }}
-
-      - name: Install iDynTree
-        run: |
-          apt-get update
-          apt-get install -y --no-install-recommends \
-            python3-numpy libxml2-dev coinor-libipopt-dev libeigen3-dev libassimp-dev swig
-          pip3 install git+https://github.com/robotology/idyntree@devel
-          IDYNTREE_PYTHON_PKG=$(python3 -c 'import idyntree, pathlib; print(pathlib.Path(idyntree.__file__).parent)')
-          echo "CMAKE_PREFIX_PATH=$IDYNTREE_PYTHON_PKG" >> $GITHUB_ENV
-
-      - name: Create wheel
+      # User installation
+      - name: '[User] Create wheel'
+        if: matrix.type == 'User'
+        shell: bash -i -e {0}
         run: python3 setup.py bdist_wheel
-
-      - name: Install local wheel
+      - name: '[User] Install local wheel'
+        if: matrix.type == 'User'
         run: |
           cd dist
           pip3 install -v *.whl
 
-      - name: Python Tests [ScenarI/O]
+      # ============
+      # Test project
+      # ============
+
+      - name: '[ScenarI/O] Python Tests'
         run: |
           cd tests
-          pytest-3 -m "scenario"
+          pytest -m "scenario"
 
-      - name: Python Tests with Valgrind [ScenarI/O]
+      - name: '[ScenarI/O] Python Tests with Valgrind'
         if: failure()
         run: |
           apt-get install -y --no-install-recommends valgrind
           pip3 install colour-valgrind
           cd tests
-          valgrind --log-file=/tmp/valgrind.log pytest-3 -s -m "scenario" || colour-valgrind -t /tmp/valgrind.log
-
-      - name: Python Tests [gym_ignition]
-        run: |
-          cd tests
-          pytest-3 -m "gym_ignition"
-
-      - name: Python Tests with Valgrind [gym_ignition]
-        if: failure()
-        run: |
-          pip3 install colour-valgrind
-          cd tests
-          valgrind --log-file=/tmp/valgrind.log pytest-3 -s -m "gym_ignition" || colour-valgrind -t /tmp/valgrind.log
-
-  # ==============================
-  # DEVELOPER INSTALLATION [other]
-  # ==============================
-
-  developer-other:
-    name: other@developer
-    if: |
-      (github.event_name == 'push' && github.ref != 'refs/heads/master') ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.ref != 'refs/heads/master')
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: [3.8]
-        build_type: [Debug]
-        compiler:
-          #- gcc7
-          #- gcc8
-          - gcc9
-          #- clang9
-          #- clang10
-          #- clang11
-
-    steps:
-
-      - uses: actions/checkout@master
-      - run: git fetch --prune --unshallow
-
-      - name: Setup Environment
-        run: |
-          case ${{ matrix.compiler }} in
-            gcc7)   CC=gcc-7 ;  CXX=g++-7 ;;
-            gcc8)   CC=gcc-8 ;  CXX=g++-8 ;;
-            gcc9)   CC=gcc   ;  CXX=g++   ;;
-            clang6) CC=clang;   CXX=clang++ ;;
-            clang7) CC=clang-7; CXX=clang++-7 ;;
-            clang8) CC=clang-8; CXX=clang++-8 ;;
-            *) echo "Compiler not supported" && exit 1 ;;
-          esac
-          echo "::set-env name=CC::$CC"
-          echo "::set-env name=CXX::$CXX"
-          echo "::set-env name=PYTHON_VERSION::${{ matrix.python }}"
-          env
-
-      - name: Setup docker image [master]
-        if: |
-          github.ref == 'refs/heads/master' ||
-          (github.event_name == 'pull_request' && github.event.pull_request.head.ref == 'refs/heads/master')
-        run: |
-          docker run -d -i --name ci -v $(pwd):/github -w /github \
-            -v /home/runner/work/_temp/:/home/runner/work/_temp/:rw \
-            -e PYTHON_VERSION=${{ matrix.python }} -e CC=$CC -e CXX=$CXX \
-            diegoferigo/gym-ignition:ci-master bash
-
-      - name: Setup docker image [other]
-        if: |
-          (github.event_name == 'push' && github.ref != 'refs/heads/master') ||
-          (github.event_name == 'pull_request' && github.event.pull_request.head.ref != 'refs/heads/master')
-        run: |
-          docker run -d -i --name ci -v $(pwd):/github -w /github \
-            -v /home/runner/work/_temp/:/home/runner/work/_temp/:rw \
-            -e PYTHON_VERSION=${{ matrix.python }} -e CC=$CC -e CXX=$CXX \
-            diegoferigo/gym-ignition:ci-devel bash
-
-      - name: Wait entrypoint
-        run: sleep 30
-
-      - name: Build and Install C++
-        shell: docker exec -i ci bash -i -e {0}
-        run: |
-          env
-          mkdir build && cd build
-          cmake .. -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-          cmake --build . --target install
-
-      - name: Setup Python Package
-        shell: docker exec -i ci bash -i -e {0}
-        run: pip install -e .
-
-      - name: Python Tests [ScenarI/O]
-        shell: docker exec -i ci bash -i -e {0}
-        run: |
-          cd tests
-          pytest -m "scenario"
-
-      - name: Python Tests with Valgrind [ScenarI/O]
-        shell: docker exec -i ci bash -i -e {0}
-        if: failure()
-        run: |
-          pip install colour-valgrind
-          cd tests
           valgrind --log-file=/tmp/valgrind.log pytest -s -m "scenario" || colour-valgrind -t /tmp/valgrind.log
 
-      - name: Python Tests [gym_ignition]
-        shell: docker exec -i ci bash -i -e {0}
+      - name: '[gym_ignition] Python Tests'
         run: |
           cd tests
           pytest -m "gym_ignition"
 
-      - name: Python Tests with Valgrind [gym_ignition]
-        shell: docker exec -i ci bash -i -e {0}
-        if: failure()
-        run: |
-          pip install colour-valgrind
-          cd tests
-          valgrind --log-file=/tmp/valgrind.log pytest -s -m "gym_ignition" || colour-valgrind -t /tmp/valgrind.log
-
-  # =========================
-  # USER INSTALLATION [other]
-  # =========================
-
-  user-other:
-    name: other@user
-    if: |
-      (github.event_name == 'push' && github.ref != 'refs/heads/master') ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.ref != 'refs/heads/master')
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        python:
-          - 3.8
-        os:
-          - ubuntu-latest
-
-    steps:
-
-      - uses: actions/checkout@master
-      - run: git fetch --prune --unshallow
-
-      - name: Setup docker image [master]
-        if: |
-          github.ref == 'refs/heads/master' ||
-          (github.event_name == 'pull_request' && github.event.pull_request.head.ref == 'refs/heads/master')
-        run: |
-          docker run -d -i --name ci -v $(pwd):/github -w /github \
-            -v /home/runner/work/_temp/:/home/runner/work/_temp/:rw \
-            -e PYTHON_VERSION=${{ matrix.python }} -e CC=$CC -e CXX=$CXX \
-            diegoferigo/gym-ignition:ci-master bash
-        env:
-          CC: gcc
-          CXX: g++
-
-      - name: Setup docker image [other]
-        if: |
-          (github.event_name == 'push' && github.ref != 'refs/heads/master') ||
-          (github.event_name == 'pull_request' && github.event.pull_request.head.ref != 'refs/heads/master')
-        run: |
-          docker run -d -i --name ci -v $(pwd):/github -w /github \
-            -v /home/runner/work/_temp/:/home/runner/work/_temp/:rw \
-            -e PYTHON_VERSION=${{ matrix.python }} -e CC=$CC -e CXX=$CXX \
-            diegoferigo/gym-ignition:ci-devel bash
-        env:
-          CC: gcc
-          CXX: g++
-
-      - name: Wait entrypoint
-        run: sleep 30
-
-      - name: Create wheel
-        shell: docker exec -i ci bash -i -e {0}
-        run: python setup.py bdist_wheel
-
-      - name: Install local wheel
-        shell: docker exec -i ci bash -i -e {0}
-        run: |
-          cd dist
-          pip install -v *.whl
-
-      - name: Python Tests [ScenarI/O]
-        shell: docker exec -i ci bash -i -e {0}
-        run: |
-          cd tests
-          pytest -m "scenario"
-
-      - name: Python Tests with Valgrind [ScenarI/O]
-        shell: docker exec -i ci bash -i -e {0}
-        if: failure()
-        run: |
-          pip3 install colour-valgrind
-          cd tests
-          valgrind --log-file=/tmp/valgrind.log pytest -s -m "scenario" || colour-valgrind -t /tmp/valgrind.log
-
-      - name: Python Tests [gym_ignition]
-        shell: docker exec -i ci bash -i -e {0}
-        run: |
-          cd tests
-          pytest -m "gym_ignition"
-
-      - name: Python Tests with Valgrind [gym_ignition]
-        shell: docker exec -i ci bash -i -e {0}
+      - name: '[gym_ignition] Python Tests with Valgrind'
         if: failure()
         run: |
           pip3 install colour-valgrind

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,9 @@ jobs:
             software-properties-common \
             python3 \
             python3-pip \
-            python3-wheel
+            python3-wheel \
+            libxslt-dev \
+            libopenblas-dev
           pip3 install pytest pytest-xvfb
         env:
           DEBIAN_FRONTEND: noninteractive
@@ -143,13 +145,15 @@ jobs:
         run: pip3 install -e .
 
       # User installation
+      # Note: using "pip wheel" with "--global-option" forces pip to build dependencies from
+      #       their sdist instead of using wheels.
       - name: '[User] Create wheel'
         if: matrix.type == 'User'
         shell: bash -i -e {0}
         run: |
-          python3 setup.py \
-            bdist_wheel \
-            build_ext -DIGNITION_DISTRIBUTION=$(python3 -c "print('${{ matrix.ignition }}'.capitalize())")
+          pip3 wheel -w dist/ \
+            --global-option="build_ext" \
+            --global-option="-DIGNITION_DISTRIBUTION=$(python3 -c "print('${{ matrix.ignition }}'.capitalize())")" .
       - name: '[User] Install local wheel'
         if: matrix.type == 'User'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,200 @@ on:
   pull_request:
 
 jobs:
-  developer:
-    name: Developer installation
+
+  # ===============================
+  # DEVELOPER INSTALLATION [master]
+  # ===============================
+
+  developer-master:
+    name: master@developer
+#    if: |
+#      (github.event_name == 'push' && github.ref != 'refs/heads/master') ||
+#      (github.event_name == 'pull_request' && github.event.pull_request.head.ref != 'refs/heads/master')
+    runs-on: ubuntu-latest
+    container: 'ubuntu:focal'
+    strategy:
+      matrix:
+        build_type: [ Debug ]
+        ignition:
+          # - citadel
+          - dome
+
+    steps:
+
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            wget \
+            git \
+            gpg-agent \
+            ninja-build \
+            build-essential \
+            software-properties-common \
+            python3 \
+            python3-pip \
+            python3-wheel \
+            python3-pytest \
+            python3-pytest-xvfb
+        env:
+          DEBIAN_FRONTEND: noninteractive
+
+      - uses: actions/checkout@master
+      - run: git fetch --prune --unshallow
+
+      - name: Install Ignition [${{ matrix.ignition }}]
+        run: |
+          sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" >\
+            /etc/apt/sources.list.d/gazebo-stable.list'
+          wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
+          apt-get update
+          apt-get install -y --no-install-recommends ignition-${{ matrix.ignition }}
+
+      - name: Install iDynTree
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            python3-numpy libxml2-dev coinor-libipopt-dev libeigen3-dev libassimp-dev swig
+          pip3 install git+https://github.com/robotology/idyntree@devel
+          IDYNTREE_PYTHON_PKG=$(python3 -c 'import idyntree, pathlib; print(pathlib.Path(idyntree.__file__).parent)')
+          echo "CMAKE_PREFIX_PATH=$IDYNTREE_PYTHON_PKG" >> $GITHUB_ENV
+
+      - name: Build and Install C++
+        run: |
+          env
+          mkdir build && cd build
+          cmake .. -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          cmake --build . --target install
+
+      - name: Setup Python Package
+        run: pip3 install -e .
+
+      - name: Python Tests [ScenarI/O]
+        run: |
+          cd tests
+          pytest-3 -m "scenario"
+
+      - name: Python Tests with Valgrind [ScenarI/O]
+        if: failure()
+        run: |
+          apt-get install -y --no-install-recommends valgrind
+          pip3 install colour-valgrind
+          cd tests
+          valgrind --log-file=/tmp/valgrind.log pytest-3 -s -m "scenario" || colour-valgrind -t /tmp/valgrind.log
+
+      - name: Python Tests [gym_ignition]
+        run: |
+          cd tests
+          pytest-3 -m "gym_ignition"
+
+      - name: Python Tests with Valgrind [gym_ignition]
+        if: failure()
+        run: |
+          pip3 install colour-valgrind
+          cd tests
+          valgrind --log-file=/tmp/valgrind.log pytest-3 -s -m "gym_ignition" || colour-valgrind -t /tmp/valgrind.log
+
+  # ==========================
+  # USER INSTALLATION [master]
+  # ==========================
+
+  user-master:
+    name: master@user
+#    if: |
+#      (github.event_name == 'push' && github.ref != 'refs/heads/master') ||
+#      (github.event_name == 'pull_request' && github.event.pull_request.head.ref != 'refs/heads/master')
+    runs-on: ubuntu-latest
+    container: 'ubuntu:focal'
+    strategy:
+      matrix:
+        build_type: [ Debug ]
+        ignition:
+          # - citadel
+          - dome
+
+    steps:
+
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            wget \
+            git \
+            gpg-agent \
+            ninja-build \
+            build-essential \
+            software-properties-common \
+            python3 \
+            python3-pip \
+            python3-wheel \
+            python3-pytest \
+            python3-pytest-xvfb
+        env:
+          DEBIAN_FRONTEND: noninteractive
+
+      - uses: actions/checkout@master
+      - run: git fetch --prune --unshallow
+
+      - name: Install Ignition [${{ matrix.ignition }}]
+        run: |
+          sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" >\
+            /etc/apt/sources.list.d/gazebo-stable.list'
+          wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
+          apt-get update
+          apt-get install -y --no-install-recommends ignition-${{ matrix.ignition }}
+
+      - name: Install iDynTree
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            python3-numpy libxml2-dev coinor-libipopt-dev libeigen3-dev libassimp-dev swig
+          pip3 install git+https://github.com/robotology/idyntree@devel
+          IDYNTREE_PYTHON_PKG=$(python3 -c 'import idyntree, pathlib; print(pathlib.Path(idyntree.__file__).parent)')
+          echo "CMAKE_PREFIX_PATH=$IDYNTREE_PYTHON_PKG" >> $GITHUB_ENV
+
+      - name: Create wheel
+        run: python3 setup.py bdist_wheel
+
+      - name: Install local wheel
+        run: |
+          cd dist
+          pip3 install -v *.whl
+
+      - name: Python Tests [ScenarI/O]
+        run: |
+          cd tests
+          pytest-3 -m "scenario"
+
+      - name: Python Tests with Valgrind [ScenarI/O]
+        if: failure()
+        run: |
+          apt-get install -y --no-install-recommends valgrind
+          pip3 install colour-valgrind
+          cd tests
+          valgrind --log-file=/tmp/valgrind.log pytest-3 -s -m "scenario" || colour-valgrind -t /tmp/valgrind.log
+
+      - name: Python Tests [gym_ignition]
+        run: |
+          cd tests
+          pytest-3 -m "gym_ignition"
+
+      - name: Python Tests with Valgrind [gym_ignition]
+        if: failure()
+        run: |
+          pip3 install colour-valgrind
+          cd tests
+          valgrind --log-file=/tmp/valgrind.log pytest-3 -s -m "gym_ignition" || colour-valgrind -t /tmp/valgrind.log
+
+  # ==============================
+  # DEVELOPER INSTALLATION [other]
+  # ==============================
+
+  developer-other:
+    name: other@developer
+    if: |
+      (github.event_name == 'push' && github.ref != 'refs/heads/master') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.ref != 'refs/heads/master')
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -104,8 +296,15 @@ jobs:
           cd tests
           valgrind --log-file=/tmp/valgrind.log pytest -s -m "gym_ignition" || colour-valgrind -t /tmp/valgrind.log
 
-  user:
-    name: User installation
+  # =========================
+  # USER INSTALLATION [other]
+  # =========================
+
+  user-other:
+    name: other@user
+    if: |
+      (github.event_name == 'push' && github.ref != 'refs/heads/master') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.ref != 'refs/heads/master')
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,10 @@ jobs:
         run: |
           env
           mkdir build && cd build
-          cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug
+          cmake .. \
+            -GNinja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DIGNITION_DISTRIBUTION=$(python3 -c "print('${{ matrix.ignition }}'.capitalize())")
           cmake --build . --target install
       - name: '[Developer] Setup Python Package'
         if: matrix.type == 'Developer'
@@ -143,7 +146,10 @@ jobs:
       - name: '[User] Create wheel'
         if: matrix.type == 'User'
         shell: bash -i -e {0}
-        run: python3 setup.py bdist_wheel
+        run: |
+          python3 setup.py \
+            bdist_wheel \
+            build_ext -DIGNITION_DISTRIBUTION=$(python3 -c "print('${{ matrix.ignition }}'.capitalize())")
       - name: '[User] Install local wheel'
         if: matrix.type == 'User'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           apt-get install -y ccache
           echo "/usr/lib/ccache" >> $GITHUB_PATH
           mkdir -p ~/.ccache
-          echo "max_size = 5.0G" > ~/.ccache/ccache.conf
+          echo "max_size = 1.0G" > ~/.ccache/ccache.conf
 
       # ================
       # Install Ignition

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,15 +150,50 @@ add_install_rpath_support(
     DEPENDS ENABLE_RPATH
     USE_LINK_PATH)
 
-# Find Ignition Gazebo
-if(NOT CMAKE_BUILD_TYPE STREQUAL "PyPI")
-    find_package(ignition-gazebo3)
+# Find a supported Ignition distribution
+if(NOT IGNITION_DISTRIBUTION)
+
+    include(FindIgnitionDistribution)
+    set(SUPPORTED_IGNITION_DISTRIBUTIONS "Dome" "Citadel")
+
+    foreach(distribution IN LISTS SUPPORTED_IGNITION_DISTRIBUTIONS)
+
+        find_ignition_distribution(
+            CODENAME ${distribution}
+            PACKAGES
+            ignition-gazebo
+            REQUIRED FALSE)
+
+        if(${${distribution}_FOUND})
+            message(STATUS "Found Ignition ${distribution}")
+
+            # Select Ignition distribution
+            set(IGNITION_DISTRIBUTION "${distribution}" CACHE
+                STRING "The Ignition distribution found in the system")
+            set_property(CACHE IGNITION_DISTRIBUTION PROPERTY
+                STRINGS ${SUPPORTED_IGNITION_DISTRIBUTIONS})
+
+            break()
+        endif()
+
+    endforeach()
+
+endif()
+
+if(NOT IGNITION_DISTRIBUTION)
+    set(USE_IGNITION FALSE)
 else()
-    find_package(ignition-gazebo3 REQUIRED)
+    set(USE_IGNITION TRUE)
 endif()
 
 option(GYMIGNITION_USE_IGNITION
-    "Build C++ code depending on Ignition Robotics" ${ignition-gazebo3_FOUND})
+       "Build C++ code depending on Ignition"
+       ${USE_IGNITION})
+
+# Alias the targets
+if(${GYMIGNITION_USE_IGNITION})
+    include(ImportTargets${IGNITION_DISTRIBUTION})
+endif()
 
 # Helper for exporting targets
 include(InstallBasicPackageFiles)
@@ -194,6 +229,11 @@ endif()
 # ========
 # BINDINGS
 # ========
+
+# Require to find Ignition libraries when packaging for PyPI
+if(CMAKE_BUILD_TYPE STREQUAL "PyPI" AND NOT USE_IGNITION)
+    message(FATAL_ERROR "Found no Ignition distribution for PyPI package")
+endif()
 
 option(GYMIGNITION_ENABLE_BINDINGS "Enable SWIG bindings" ON)
 

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -69,5 +69,3 @@ install(
 if(GYMIGNITION_ENABLE_GYMPP)
     add_subdirectory(gympp)
 endif()
-
-

--- a/cmake/AliasImportedTarget.cmake
+++ b/cmake/AliasImportedTarget.cmake
@@ -1,0 +1,96 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+macro(alias_imported_target)
+
+    set(_prefix "ait")
+    string(TOUPPER ${_prefix} _prefix)
+
+    set(_oneValueArgs
+        PACKAGE
+        NAMESPACE_ORIG
+        NAMESPACE_DEST
+        REQUIRED)
+
+    set(_multiValueArgs
+        COMPONENTS
+        TARGETS_ORIG
+        TARGETS_DEST)
+
+    set(_options)
+
+    # For each {one,multi}value variable FOO, this command creates
+    # the variable ${_prefix}_FOO with the passed arg(s)
+    cmake_parse_arguments(${_prefix}
+        "${_options}"
+        "${_oneValueArgs}"
+        "${_multiValueArgs}"
+        "${ARGN}")
+
+    unset(_options)
+    unset(_oneValueArgs)
+    unset(_multiValueArgs)
+
+    if(${${_prefix}_REQUIRED})
+        find_package(
+            ${${_prefix}_PACKAGE}
+            COMPONENTS ${${_prefix}_COMPONENTS}
+            REQUIRED)
+    else()
+        find_package(
+            ${${_prefix}_PACKAGE}
+            COMPONENTS ${${_prefix}_COMPONENTS}
+            QUIET)
+    endif()
+
+    if(${${_prefix}_PACKAGE}_FOUND)
+
+        message(DEBUG "Processing package: ${${_prefix}_PACKAGE}")
+
+        # Check length of lists
+        list(LENGTH ${_prefix}_TARGETS_ORIG _num_targets_orig)
+        list(LENGTH ${_prefix}_TARGETS_DEST _num_targets_dest)
+        math(EXPR _comparison "${_num_targets_orig} - ${_num_targets_dest}"
+             OUTPUT_FORMAT DECIMAL)
+
+         if(${_num_targets_orig} STREQUAL 0)
+             message(FATAL_ERROR "No targets passed")
+         endif()
+
+        if(NOT ${_comparison} STREQUAL 0)
+            message(FATAL_ERROR "Number or TARGETS_ elements do not match")
+        endif()
+
+        # TODO Use ZIP_LISTS with CMake > 3.17
+        math(EXPR _num_targets "${_num_targets_orig} - 1")
+        foreach(idx RANGE ${_num_targets})
+
+            list(GET ${_prefix}_TARGETS_ORIG ${idx} _target_orig)
+            list(GET ${_prefix}_TARGETS_DEST ${idx} _target_dest)
+
+            set(_target_name ${${_prefix}_NAMESPACE_ORIG}::${_target_orig})
+            set(_variable_name ${${_prefix}_NAMESPACE_DEST}.${_target_dest})
+
+            if(NOT TARGET ${_target_name})
+                message(FATAL_ERROR "Could not find target ${_target_name}")
+            endif()
+
+            message(DEBUG "  Setting: ${_variable_name}=${_target_name}")
+            set(${_variable_name} ${_target_name})
+
+        endforeach()
+
+    endif()
+
+    unset(_prefix)
+    unset(_num_targets_orig)
+    unset(_num_targets_dest)
+    unset(_comparison)
+    unset(_num_targets)
+    unset(_target_orig)
+    unset(_target_dest)
+    unset(_target_name)
+    unset(_variable_name)
+
+endmacro()

--- a/cmake/AliasImportedTarget.cmake
+++ b/cmake/AliasImportedTarget.cmake
@@ -8,7 +8,8 @@ macro(alias_imported_target)
     string(TOUPPER ${_prefix} _prefix)
 
     set(_oneValueArgs
-        PACKAGE
+        PACKAGE_ORIG
+        PACKAGE_DEST
         NAMESPACE_ORIG
         NAMESPACE_DEST
         REQUIRED)
@@ -34,19 +35,21 @@ macro(alias_imported_target)
 
     if(${${_prefix}_REQUIRED})
         find_package(
-            ${${_prefix}_PACKAGE}
+            ${${_prefix}_PACKAGE_ORIG}
             COMPONENTS ${${_prefix}_COMPONENTS}
             REQUIRED)
     else()
         find_package(
-            ${${_prefix}_PACKAGE}
+            ${${_prefix}_PACKAGE_ORIG}
             COMPONENTS ${${_prefix}_COMPONENTS}
             QUIET)
     endif()
 
-    if(${${_prefix}_PACKAGE}_FOUND)
+    # Example:
+    #  ${${_prefix}_PACKAGE_ORIG} = ign-gazebo3
+    if(${${_prefix}_PACKAGE_ORIG}_FOUND)
 
-        message(DEBUG "Processing package: ${${_prefix}_PACKAGE}")
+        message(DEBUG "Processing package: ${${_prefix}_PACKAGE_ORIG}")
 
         # Check length of lists
         list(LENGTH ${_prefix}_TARGETS_ORIG _num_targets_orig)
@@ -62,6 +65,17 @@ macro(alias_imported_target)
             message(FATAL_ERROR "Number or TARGETS_ elements do not match")
         endif()
 
+        # Example:
+        # ${_package_name} = ignition-gazebo3
+        set(_package_name ${${_prefix}_PACKAGE_ORIG})
+
+        # Example:
+        # ${_variable_name} = ignition-gazebo
+        set(_variable_name ${${_prefix}_PACKAGE_DEST})
+
+        message(DEBUG "  Setting: ${_variable_name}=${_package_name}")
+        set(${_variable_name} ${_package_name})
+
         # TODO Use ZIP_LISTS with CMake > 3.17
         math(EXPR _num_targets "${_num_targets_orig} - 1")
         foreach(idx RANGE ${_num_targets})
@@ -69,7 +83,12 @@ macro(alias_imported_target)
             list(GET ${_prefix}_TARGETS_ORIG ${idx} _target_orig)
             list(GET ${_prefix}_TARGETS_DEST ${idx} _target_dest)
 
+            # Example:
+            # ${_target_name} = ignition-gazebo3::core
             set(_target_name ${${_prefix}_NAMESPACE_ORIG}::${_target_orig})
+
+            # Example:
+            # ${_target_name} = ignition-gazebo.core
             set(_variable_name ${${_prefix}_NAMESPACE_DEST}.${_target_dest})
 
             if(NOT TARGET ${_target_name})
@@ -87,6 +106,7 @@ macro(alias_imported_target)
     unset(_num_targets_orig)
     unset(_num_targets_dest)
     unset(_comparison)
+    unset(_package_name)
     unset(_num_targets)
     unset(_target_orig)
     unset(_target_dest)

--- a/cmake/FindIgnitionDistribution.cmake
+++ b/cmake/FindIgnitionDistribution.cmake
@@ -1,0 +1,101 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+# In this initial implementation, we support only specifying
+# the Ignition Gazebo version to determine the Ignition distribution.
+# In the future we could pull and parse the tags.yaml file.
+set(IGNITION-GAZEBO_CITADEL_VER 3)
+set(IGNITION-GAZEBO_DOME_VER 4)
+
+macro(find_ignition_distribution)
+
+    set(_prefix "fid")
+    string(TOUPPER ${_prefix} _prefix)
+
+    set(_oneValueArgs
+        CODENAME
+        REQUIRED)
+
+    set(_multiValueArgs
+        PACKAGES)
+
+    # For each {one,multi}value variable FOO, this command creates
+    # the variable ${_prefix}_FOO with the passed arg(s)
+    cmake_parse_arguments(${_prefix}
+        "${_options}"
+        "${_oneValueArgs}"
+        "${_multiValueArgs}"
+        "${ARGN}")
+
+    unset(_options)
+    unset(_oneValueArgs)
+    unset(_multiValueArgs)
+
+    # Example:
+    # ${Citadel_FOUND}=TRUE
+    set(${${_prefix}_CODENAME}_FOUND TRUE)
+    set(IGNITION_FOUND FALSE)
+
+    set(_pkgs_not_found)
+
+    # Example:
+    # ${PKG}=ignition-gazebo
+    foreach(PKG IN LISTS ${_prefix}_PACKAGES)
+
+        # Example:
+        # ${_codename_upper}=CITADEL
+        string(TOUPPER ${${_prefix}_CODENAME} _codename_upper)
+
+        # Example:
+        # ${_pkg_upper}=IGNITION-GAZEBO
+        string(TOUPPER ${PKG} _pkg_upper)
+
+        # Example:
+        # ${_rel_variable_name}=IGNITION-GAZEBO_CITADEL_VER
+        set(_rel_variable_name ${_pkg_upper}_${_codename_upper}_VER)
+
+        if(NOT ${_rel_variable_name})
+            message(FATAL_ERROR "Failed to find variable ${_rel_variable_name}")
+        endif()
+
+        # Example:
+        # ${_pkg_name}=ignition-gazebo3
+        set(_pkg_name ${PKG}${${_rel_variable_name}})
+
+        # Find the package
+        if(${${_prefix}_REQUIRED})
+            find_package(${_pkg_name} REQUIRED)
+        else()
+            find_package(${_pkg_name} QUIET)
+        endif()
+
+        if(NOT ${_pkg_name}_FOUND)
+            # Example:
+            # ${Citadel_FOUND}=FALSE
+            set(${${_prefix}_CODENAME}_FOUND FALSE)
+            list(APPEND _pkgs_not_found ${_pkg_name})
+        endif()
+
+    endforeach()
+
+    # Print missing packages
+    if(NOT ${${_prefix}_CODENAME}_FOUND)
+        message(DEBUG "Missing packages of Ignition ${${_prefix}_CODENAME}:")
+        foreach(PKG IN LISTS _pkgs_not_found)
+            message(DEBUG "  ${PKG}")
+        endforeach()
+    endif()
+
+    if(${${_prefix}_CODENAME}_FOUND)
+        set(IGNITION_FOUND TRUE)
+    endif()
+
+    unset(_prefix)
+    unset(_codename_upper)
+    unset(_pkg_upper)
+    unset(_rel_variable_name)
+    unset(_pkg_name)
+    unset(_pkgs_not_found)
+
+endmacro()

--- a/cmake/ImportTargetsCitadel.cmake
+++ b/cmake/ImportTargetsCitadel.cmake
@@ -1,0 +1,66 @@
+include(AliasImportedTarget)
+
+# https://ignitionrobotics.org/docs/citadel/install#citadel-libraries
+
+alias_imported_target(
+    PACKAGE sdformat9
+    TARGETS_ORIG sdformat9
+    TARGETS_DEST sdformat
+    NAMESPACE_ORIG sdformat9
+    NAMESPACE_DEST sdformat
+    REQUIRED TRUE
+    )
+
+alias_imported_target(
+    PACKAGE ignition-gazebo3
+    TARGETS_ORIG ignition-gazebo3 core
+    TARGETS_DEST ignition-gazebo  core
+    NAMESPACE_ORIG ignition-gazebo3
+    NAMESPACE_DEST ignition-gazebo
+    REQUIRED TRUE
+    )
+
+alias_imported_target(
+    PACKAGE ignition-common3
+    TARGETS_ORIG ignition-common3
+    TARGETS_DEST ignition-common
+    NAMESPACE_ORIG ignition-common3
+    NAMESPACE_DEST ignition-common
+    REQUIRED TRUE
+    )
+
+alias_imported_target(
+    PACKAGE ignition-sensors3-all
+    TARGETS_ORIG ignition-sensors3-all
+    TARGETS_DEST ignition-sensors-all
+    NAMESPACE_ORIG ignition-sensors3
+    NAMESPACE_DEST ignition-sensors
+    REQUIRED TRUE
+    )
+
+alias_imported_target(
+    PACKAGE ignition-rendering3
+    TARGETS_ORIG ignition-rendering3
+    TARGETS_DEST ignition-rendering
+    NAMESPACE_ORIG ignition-rendering3
+    NAMESPACE_DEST ignition-rendering
+    REQUIRED TRUE
+    )
+
+alias_imported_target(
+    PACKAGE ignition-gazebo3-rendering
+    TARGETS_ORIG ignition-gazebo3-rendering
+    TARGETS_DEST ignition-gazebo-rendering
+    NAMESPACE_ORIG ignition-gazebo3
+    NAMESPACE_DEST ignition-gazebo
+    REQUIRED TRUE
+    )
+
+alias_imported_target(
+    PACKAGE ignition-physics2
+    TARGETS_ORIG ignition-physics2
+    TARGETS_DEST ignition-physics
+    NAMESPACE_ORIG ignition-physics2
+    NAMESPACE_DEST ignition-physics
+    REQUIRED TRUE
+    )

--- a/cmake/ImportTargetsCitadel.cmake
+++ b/cmake/ImportTargetsCitadel.cmake
@@ -3,7 +3,8 @@ include(AliasImportedTarget)
 # https://ignitionrobotics.org/docs/citadel/install#citadel-libraries
 
 alias_imported_target(
-    PACKAGE sdformat9
+    PACKAGE_ORIG sdformat9
+    PACKAGE_DEST sdformat
     TARGETS_ORIG sdformat9
     TARGETS_DEST sdformat
     NAMESPACE_ORIG sdformat9
@@ -12,7 +13,8 @@ alias_imported_target(
     )
 
 alias_imported_target(
-    PACKAGE ignition-gazebo3
+    PACKAGE_ORIG ignition-gazebo3
+    PACKAGE_DEST ignition-gazebo
     TARGETS_ORIG ignition-gazebo3 core
     TARGETS_DEST ignition-gazebo  core
     NAMESPACE_ORIG ignition-gazebo3
@@ -21,7 +23,8 @@ alias_imported_target(
     )
 
 alias_imported_target(
-    PACKAGE ignition-common3
+    PACKAGE_ORIG ignition-common3
+    PACKAGE_DEST ignition-common
     TARGETS_ORIG ignition-common3
     TARGETS_DEST ignition-common
     NAMESPACE_ORIG ignition-common3
@@ -30,7 +33,8 @@ alias_imported_target(
     )
 
 alias_imported_target(
-    PACKAGE ignition-sensors3-all
+    PACKAGE_ORIG ignition-sensors3-all
+    PACKAGE_DEST ignition-sensors-all
     TARGETS_ORIG ignition-sensors3-all
     TARGETS_DEST ignition-sensors-all
     NAMESPACE_ORIG ignition-sensors3
@@ -39,7 +43,8 @@ alias_imported_target(
     )
 
 alias_imported_target(
-    PACKAGE ignition-rendering3
+    PACKAGE_ORIG ignition-rendering3
+    PACKAGE_DEST ignition-rendering
     TARGETS_ORIG ignition-rendering3
     TARGETS_DEST ignition-rendering
     NAMESPACE_ORIG ignition-rendering3
@@ -48,7 +53,8 @@ alias_imported_target(
     )
 
 alias_imported_target(
-    PACKAGE ignition-gazebo3-rendering
+    PACKAGE_ORIG ignition-gazebo3-rendering
+    PACKAGE_DEST ignition-gazebo-rendering
     TARGETS_ORIG ignition-gazebo3-rendering
     TARGETS_DEST ignition-gazebo-rendering
     NAMESPACE_ORIG ignition-gazebo3
@@ -57,7 +63,8 @@ alias_imported_target(
     )
 
 alias_imported_target(
-    PACKAGE ignition-physics2
+    PACKAGE_ORIG ignition-physics2
+    PACKAGE_DEST ignition-physics
     TARGETS_ORIG ignition-physics2
     TARGETS_DEST ignition-physics
     NAMESPACE_ORIG ignition-physics2

--- a/cmake/ImportTargetsDome.cmake
+++ b/cmake/ImportTargetsDome.cmake
@@ -1,0 +1,66 @@
+include(AliasImportedTarget)
+
+# https://ignitionrobotics.org/docs/dome/install#dome-libraries
+
+alias_imported_target(
+    PACKAGE sdformat10
+    TARGETS_ORIG sdformat10
+    TARGETS_DEST sdformat
+    NAMESPACE_ORIG sdformat10
+    NAMESPACE_DEST sdformat
+    REQUIRED TRUE
+    )
+
+alias_imported_target(
+    PACKAGE ignition-gazebo4
+    TARGETS_ORIG ignition-gazebo4 core
+    TARGETS_DEST ignition-gazebo  core
+    NAMESPACE_ORIG ignition-gazebo4
+    NAMESPACE_DEST ignition-gazebo
+    REQUIRED TRUE
+    )
+
+alias_imported_target(
+    PACKAGE ignition-common3
+    TARGETS_ORIG ignition-common3
+    TARGETS_DEST ignition-common
+    NAMESPACE_ORIG ignition-common3
+    NAMESPACE_DEST ignition-common
+    REQUIRED TRUE
+    )
+
+alias_imported_target(
+    PACKAGE ignition-sensors4-all
+    TARGETS_ORIG ignition-sensors4-all
+    TARGETS_DEST ignition-sensors-all
+    NAMESPACE_ORIG ignition-sensors4
+    NAMESPACE_DEST ignition-sensors
+    REQUIRED TRUE
+    )
+
+alias_imported_target(
+    PACKAGE ignition-rendering4
+    TARGETS_ORIG ignition-rendering4
+    TARGETS_DEST ignition-rendering
+    NAMESPACE_ORIG ignition-rendering4
+    NAMESPACE_DEST ignition-rendering
+    REQUIRED TRUE
+    )
+
+alias_imported_target(
+    PACKAGE ignition-gazebo4-rendering
+    TARGETS_ORIG ignition-gazebo4-rendering
+    TARGETS_DEST ignition-gazebo-rendering
+    NAMESPACE_ORIG ignition-gazebo4
+    NAMESPACE_DEST ignition-gazebo
+    REQUIRED TRUE
+    )
+
+alias_imported_target(
+    PACKAGE ignition-physics3
+    TARGETS_ORIG ignition-physics3
+    TARGETS_DEST ignition-physics
+    NAMESPACE_ORIG ignition-physics3
+    NAMESPACE_DEST ignition-physics
+    REQUIRED TRUE
+    )

--- a/cmake/ImportTargetsDome.cmake
+++ b/cmake/ImportTargetsDome.cmake
@@ -3,7 +3,8 @@ include(AliasImportedTarget)
 # https://ignitionrobotics.org/docs/dome/install#dome-libraries
 
 alias_imported_target(
-    PACKAGE sdformat10
+    PACKAGE_ORIG sdformat10
+    PACKAGE_DEST sdformat
     TARGETS_ORIG sdformat10
     TARGETS_DEST sdformat
     NAMESPACE_ORIG sdformat10
@@ -12,7 +13,8 @@ alias_imported_target(
     )
 
 alias_imported_target(
-    PACKAGE ignition-gazebo4
+    PACKAGE_ORIG ignition-gazebo4
+    PACKAGE_DEST ignition-gazebo
     TARGETS_ORIG ignition-gazebo4 core
     TARGETS_DEST ignition-gazebo  core
     NAMESPACE_ORIG ignition-gazebo4
@@ -21,7 +23,8 @@ alias_imported_target(
     )
 
 alias_imported_target(
-    PACKAGE ignition-common3
+    PACKAGE_ORIG ignition-common3
+    PACKAGE_DEST ignition-common
     TARGETS_ORIG ignition-common3
     TARGETS_DEST ignition-common
     NAMESPACE_ORIG ignition-common3
@@ -30,7 +33,8 @@ alias_imported_target(
     )
 
 alias_imported_target(
-    PACKAGE ignition-sensors4-all
+    PACKAGE_ORIG ignition-sensors4-all
+    PACKAGE_DEST ignition-sensors-all
     TARGETS_ORIG ignition-sensors4-all
     TARGETS_DEST ignition-sensors-all
     NAMESPACE_ORIG ignition-sensors4
@@ -39,7 +43,8 @@ alias_imported_target(
     )
 
 alias_imported_target(
-    PACKAGE ignition-rendering4
+    PACKAGE_ORIG ignition-rendering4
+    PACKAGE_DEST ignition-rendering
     TARGETS_ORIG ignition-rendering4
     TARGETS_DEST ignition-rendering
     NAMESPACE_ORIG ignition-rendering4
@@ -48,7 +53,8 @@ alias_imported_target(
     )
 
 alias_imported_target(
-    PACKAGE ignition-gazebo4-rendering
+    PACKAGE_ORIG ignition-gazebo4-rendering
+    PACKAGE_DEST ignition-gazebo-rendering
     TARGETS_ORIG ignition-gazebo4-rendering
     TARGETS_DEST ignition-gazebo-rendering
     NAMESPACE_ORIG ignition-gazebo4
@@ -57,7 +63,8 @@ alias_imported_target(
     )
 
 alias_imported_target(
-    PACKAGE ignition-physics3
+    PACKAGE_ORIG ignition-physics3
+    PACKAGE_DEST ignition-physics
     TARGETS_ORIG ignition-physics3
     TARGETS_DEST ignition-physics
     NAMESPACE_ORIG ignition-physics3

--- a/cpp/scenario/gazebo/CMakeLists.txt
+++ b/cpp/scenario/gazebo/CMakeLists.txt
@@ -51,7 +51,7 @@ target_include_directories(ExtraComponents INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${SCENARIO_INSTALL_INCLUDEDIR}>)
 
-target_link_libraries(ExtraComponents INTERFACE ignition-gazebo3::core)
+target_link_libraries(ExtraComponents INTERFACE ${ignition-gazebo.core})
 
 set_target_properties(ExtraComponents PROPERTIES
     PUBLIC_HEADER "${EXTRA_COMPONENTS_PUBLIC_HEADERS}")
@@ -65,8 +65,6 @@ add_custom_target(GazeboExtraComponents SOURCES ${EXTRA_COMPONENTS_PUBLIC_HEADER
 # ==============
 # ScenarioGazebo
 # ==============
-
-find_package(ignition-common3 REQUIRED)
 
 set(SCENARIO_GAZEBO_PUBLIC_HDRS
     include/scenario/gazebo/GazeboEntity.h
@@ -96,12 +94,11 @@ target_include_directories(ScenarioGazebo PUBLIC
 target_link_libraries(ScenarioGazebo
     PUBLIC
     ScenarioCore::ScenarioABC
-    ignition-gazebo3::core
-    ignition-common3::ignition-common3
+    ${ignition-gazebo.core}
+    ${ignition-common.ignition-common}
     PRIVATE
     ScenarioCore::CoreUtils
-    ScenarioGazebo::ExtraComponents
-    ignition-gazebo3::core)
+    ScenarioGazebo::ExtraComponents)
 
 set_target_properties(ScenarioGazebo PROPERTIES
     PUBLIC_HEADER "${SCENARIO_GAZEBO_PUBLIC_HDRS}")
@@ -124,7 +121,7 @@ target_link_libraries(GazeboSimulator
     ScenarioCore::ScenarioABC
     PRIVATE
     tiny-process-library
-    ignition-gazebo3::core
+    ${ignition-gazebo.core}
     ScenarioCore::CoreUtils
     ScenarioGazebo::ScenarioGazebo
     ScenarioGazebo::ExtraComponents

--- a/cpp/scenario/gazebo/CMakeLists.txt
+++ b/cpp/scenario/gazebo/CMakeLists.txt
@@ -162,7 +162,7 @@ install_basic_package_files(ScenarioGazebo
     VERSION ${PROJECT_VERSION}
     COMPATIBILITY AnyNewerVersion
     EXPORT ScenarioGazeboExport
-    DEPENDENCIES ScenarioCore ScenarioGazeboPlugins ignition-gazebo3 ignition-common3
+    DEPENDENCIES ScenarioCore ScenarioGazeboPlugins ${ignition-gazebo} ${ignition-common}
     NAMESPACE ScenarioGazebo::
     NO_CHECK_REQUIRED_COMPONENTS_MACRO
     INSTALL_DESTINATION

--- a/cpp/scenario/plugins/CMakeLists.txt
+++ b/cpp/scenario/plugins/CMakeLists.txt
@@ -32,7 +32,7 @@ install_basic_package_files(ScenarioGazeboPlugins
     VERSION ${PROJECT_VERSION}
     COMPATIBILITY AnyNewerVersion
     EXPORT ScenarioGazeboPluginsExport
-    DEPENDENCIES ignition-gazebo3
+    DEPENDENCIES ${ignition-gazebo}
     NAMESPACE ScenarioGazeboPlugins::
     NO_CHECK_REQUIRED_COMPONENTS_MACRO
     INSTALL_DESTINATION

--- a/cpp/scenario/plugins/ControllerRunner/CMakeLists.txt
+++ b/cpp/scenario/plugins/ControllerRunner/CMakeLists.txt
@@ -22,8 +22,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-find_package(sdformat9 REQUIRED)
-
 # ==================
 # ControllersFactory
 # ==================
@@ -34,7 +32,7 @@ add_library(ControllersFactory STATIC
 
 target_link_libraries(ControllersFactory
     PUBLIC
-    sdformat9::sdformat9
+    ${sdformat.sdformat}
     ScenarioCore::ScenarioABC
     ScenarioControllers::ControllersABC
     PRIVATE
@@ -54,7 +52,7 @@ add_library(ControllerRunner SHARED
 
 target_link_libraries(ControllerRunner
     PUBLIC
-    ignition-gazebo3::core
+    ${ignition-gazebo.core}
     PRIVATE
     ScenarioGazebo::ScenarioGazebo
     ScenarioGazebo::ExtraComponents

--- a/cpp/scenario/plugins/ECMProvider/CMakeLists.txt
+++ b/cpp/scenario/plugins/ECMProvider/CMakeLists.txt
@@ -32,7 +32,7 @@ add_library(ECMProvider SHARED
 
 target_link_libraries(ECMProvider
     PUBLIC
-    ignition-gazebo3::core
+    ${ignition-gazebo.core}
     PRIVATE
     ECMSingleton
     ScenarioGazebo::ScenarioGazebo
@@ -58,7 +58,7 @@ target_include_directories(ECMSingleton PUBLIC
 
 target_link_libraries(ECMSingleton
     PUBLIC
-    ignition-gazebo3::core
+    ${ignition-gazebo.core}
     PRIVATE
     ScenarioGazebo::ScenarioGazebo)
 

--- a/cpp/scenario/plugins/JointController/CMakeLists.txt
+++ b/cpp/scenario/plugins/JointController/CMakeLists.txt
@@ -32,7 +32,7 @@ add_library(JointController SHARED
 
 target_link_libraries(JointController
     PUBLIC
-    ignition-gazebo3::core
+    ${ignition-gazebo.core}
     PRIVATE
     ScenarioGazebo::ScenarioGazebo
     ScenarioGazebo::ExtraComponents)

--- a/cpp/scenario/plugins/Physics/CMakeLists.txt
+++ b/cpp/scenario/plugins/Physics/CMakeLists.txt
@@ -32,8 +32,8 @@ add_library(PhysicsSystem SHARED
 
 target_link_libraries(PhysicsSystem
     PUBLIC
-    ignition-gazebo3::core
-    ignition-physics2::ignition-physics2
+    ${ignition-gazebo.core}
+    ${ignition-physics.ignition-physics}
     PRIVATE
     ScenarioGazebo::ScenarioGazebo
     ScenarioGazebo::ExtraComponents)

--- a/tests/test_scenario/test_contacts.py
+++ b/tests/test_scenario/test_contacts.py
@@ -113,7 +113,7 @@ def test_cube_contact(gazebo: scenario.GazeboSimulator,
 
     # Check that the contact force matches the weight of the cube
     z_forces = [point.force[2] for point in contact_with_ground.points]
-    assert np.sum(z_forces) == pytest.approx(50, abs=1.0)
+    assert np.sum(z_forces) == pytest.approx(-5 * world.gravity()[2], abs=0.1)
 
     # Forces of all contact points are combined by the following method
     assert cube.get_link("cube").contact_wrench() == \


### PR DESCRIPTION
This PR updates our CI and CD pipelines to Ignition Dome. As stated in our support policy, we officially support the latest Ignition release, that now is Dome. However, while the binaries we distribute through PyPI will be compatible only with the officially release, I want to be more flexible about source installation. If there's no major API breaking, also previous releases could be unofficially used, especially in this case that Citadel is an LTS release.

I updated our CMake project for being compatible with multiple Ignition distributions. Unfortunately, the way the libraries are packaged and distributed in this case created quite a lot of challenges.

This PR contains new CMake macros:

- `FindIgnitionDistribution.cmake`: Looks for Ignition packages and tries to locate all the required one. For the time being, I only search for `ignition-gazeboX`.
- `AliasImportedTarget.cmake`: In the most generic case, allows to find a package e.g. `package3-all` with targets `packagenamespace3::target1` and creates alias variables: 1) `package-all` for the package, and 2) `packagenamespace.target` for the target.
- `ImportTargets{Citadel,Dome}`: Aliases all the Ignition targets required by the project so that out targets can link against them using CMake variables e.g. `${ignition-gazebo.core}`.

Furthermore, I refreshed the CI pipeline to not run in our Docker images. I realized that pulling the images from dockerhub was quite slow and building everything directly in the workflow could not be that much slower if combined with ccache. This new approach greatly simplifies maintaining the CI pipeline and also allows to add new configurations, which can be useful in the period close to new Ignition releases.

While we're not using them anymore for CI, the docker images are still used for CD, Website, and Demo. I updated them to Dome.

---

Notes: the Ignition ppa also has a nightly channel that could substitute building out nightly channel with colcon. However, I still prefer to build from sources in the case we want to temporarily use out forks with new features before they get accepted upstream.
