### PR TITLE
Update APIs: joint friction, joint acceleration, link wrench

### DIFF
--- a/bindings/gazebo/gazebo.i
+++ b/bindings/gazebo/gazebo.i
@@ -30,6 +30,7 @@ namespace scenario::gazebo::utils {
 %template(ToGazeboWorld) scenario::gazebo::utils::ToGazebo<scenario::core::World, scenario::gazebo::World>;
 %template(ToGazeboModel) scenario::gazebo::utils::ToGazebo<scenario::core::Model, scenario::gazebo::Model>;
 %template(ToGazeboJoint) scenario::gazebo::utils::ToGazebo<scenario::core::Joint, scenario::gazebo::Joint>;
+%template(ToGazeboLink) scenario::gazebo::utils::ToGazebo<scenario::core::Link, scenario::gazebo::Link>;
 
 // STL classes
 %include <stdint.i>

--- a/bindings/gazebo/to_gazebo.i
+++ b/bindings/gazebo/to_gazebo.i
@@ -23,3 +23,10 @@ import scenario.bindings.gazebo
         return scenario.bindings.gazebo.ToGazeboJoint(self)
   %}
 }
+
+%extend scenario::core::Link {
+  %pythoncode %{
+    def to_gazebo(self) -> Union["scenario.bindings.gazebo.Link", "scenario.bindings.core.Link"]:
+        return scenario.bindings.gazebo.ToGazeboLink(self)
+  %}
+}

--- a/cpp/scenario/core/include/scenario/core/Joint.h
+++ b/cpp/scenario/core/include/scenario/core/Joint.h
@@ -239,6 +239,15 @@ public:
     virtual double acceleration(const size_t dof = 0) const = 0;
 
     /**
+     * Get the generalized force of a joint DOF.
+     *
+     * @param dof The index of the DOF.
+     * @throw std::runtime_error if the DOF is not valid.
+     * @return The generalized force of the joint DOF.
+     */
+    virtual double generalizedForce(const size_t dof = 0) const = 0;
+
+    /**
      * Set the position target of a joint DOF.
      *
      * The target is processed by a joint controller, if enabled.
@@ -379,6 +388,13 @@ public:
      * @return The acceleration of the joint.
      */
     virtual std::vector<double> jointAcceleration() const = 0;
+
+    /**
+     * Get the generalized force of the joint.
+     *
+     * @return The generalized force of the joint.
+     */
+    virtual std::vector<double> jointGeneralizedForce() const = 0;
 
     /**
      * Set the position target of the joint.

--- a/cpp/scenario/core/include/scenario/core/Joint.h
+++ b/cpp/scenario/core/include/scenario/core/Joint.h
@@ -230,6 +230,15 @@ public:
     virtual double velocity(const size_t dof = 0) const = 0;
 
     /**
+     * Get the acceleration of a joint DOF.
+     *
+     * @param dof The index of the DOF.
+     * @throw std::runtime_error if the DOF is not valid.
+     * @return The acceleration of the joint DOF.
+     */
+    virtual double acceleration(const size_t dof = 0) const = 0;
+
+    /**
      * Set the position target of a joint DOF.
      *
      * The target is processed by a joint controller, if enabled.
@@ -363,6 +372,13 @@ public:
      * @return The velocity of the joint.
      */
     virtual std::vector<double> jointVelocity() const = 0;
+
+    /**
+     * Get the acceleration of the joint.
+     *
+     * @return The acceleration of the joint.
+     */
+    virtual std::vector<double> jointAcceleration() const = 0;
 
     /**
      * Set the position target of the joint.

--- a/cpp/scenario/core/include/scenario/core/Joint.h
+++ b/cpp/scenario/core/include/scenario/core/Joint.h
@@ -151,6 +151,30 @@ public:
      */
     virtual std::vector<double> historyOfAppliedJointForces() const = 0;
 
+    /**
+     * Get the Coulomb friction of the joint.
+     *
+     * If \f$ K_c \f$ is the Coulomb friction parameter, and \f$ \dot{q} \f$
+     * the joint velocity, the corresponding torque is often modelled as:
+     *
+     * \f$ \tau_{static} = sign(\dot{q}) K_c \f$
+     *
+     * @return The Coulomb friction parameter of the joint.
+     */
+    virtual double coulombFriction() const = 0;
+
+    /**
+     * Get the viscous friction of the joint.
+     *
+     * If \f$ K_v \f$ is the viscous friction parameter, and \f$ \dot{q} \f$
+     * the joint velocity, the corresponding torque is often modelled as:
+     *
+     * \f$ \tau_{static} = K_v \dot{q} \f$
+     *
+     * @return The viscous friction parameter of the joint.
+     */
+    virtual double viscousFriction() const = 0;
+
     // ==================
     // Single DOF methods
     // ==================

--- a/cpp/scenario/core/include/scenario/core/Link.h
+++ b/cpp/scenario/core/include/scenario/core/Link.h
@@ -182,41 +182,6 @@ public:
      * @return The total wrench of the active contacts.
      */
     virtual std::array<double, 6> contactWrench() const = 0;
-
-    /**
-     * Apply a force to the CoM of the link.
-     *
-     * @param force The force to apply expressed in world coordinates.
-     * @param duration The duration of the application of the force.
-     * By default the force is applied for a single physics step.
-     * @return True for success, false otherwise.
-     */
-    virtual bool applyWorldForce(const std::array<double, 3>& force,
-                                 const double duration = 0.0) = 0;
-
-    /**
-     * Apply a torque to the CoM of the link.
-     *
-     * @param torque The torque to apply expressed in world coordinates.
-     * @param duration The duration of the application of the torque.
-     * By default the torque is applied for a single physics step.
-     * @return True for success, false otherwise.
-     */
-    virtual bool applyWorldTorque(const std::array<double, 3>& torque,
-                                  const double duration = 0.0) = 0;
-
-    /**
-     * Apply a wrench to the CoM of the link.
-     *
-     * @param force The force to apply expressed in world coordinates.
-     * @param torque The torque to apply expressed in world coordinates.
-     * @param duration The duration of the application of the wrench.
-     * By default the wrench is applied for a single physics step.
-     * @return True for success, false otherwise.
-     */
-    virtual bool applyWorldWrench(const std::array<double, 3>& force,
-                                  const std::array<double, 3>& torque,
-                                  const double duration = 0.0) = 0;
 };
 
 struct scenario::core::Pose

--- a/cpp/scenario/core/include/scenario/core/Model.h
+++ b/cpp/scenario/core/include/scenario/core/Model.h
@@ -282,6 +282,18 @@ public:
         const std::vector<std::string>& jointNames = {}) const = 0;
 
     /**
+     * Get the joint generalized forces.
+     *
+     * @param jointNames Optional vector of considered joints that also
+     * defines the joint serialization. By default, ``Model::jointNames`` is
+     * used.
+     * @return The serialization of joint forces. The vector has as many
+     * elements as DoFs of the considered joints.
+     */
+    virtual std::vector<double> jointGeneralizedForces( //
+        const std::vector<std::string>& jointNames = {}) const = 0;
+
+    /**
      * Get the joint limits of the model.
      *
      * @param jointNames Optional vector of considered joints that also

--- a/cpp/scenario/core/include/scenario/core/Model.h
+++ b/cpp/scenario/core/include/scenario/core/Model.h
@@ -270,6 +270,18 @@ public:
         const std::vector<std::string>& jointNames = {}) const = 0;
 
     /**
+     * Get the joint accelerations.
+     *
+     * @param jointNames Optional vector of considered joints that also
+     * defines the joint serialization. By default, ``Model::jointNames`` is
+     * used.
+     * @return The serialization of joint accelerations. The vector has as many
+     * elements as DoFs of the considered joints.
+     */
+    virtual std::vector<double> jointAccelerations( //
+        const std::vector<std::string>& jointNames = {}) const = 0;
+
+    /**
      * Get the joint limits of the model.
      *
      * @param jointNames Optional vector of considered joints that also

--- a/cpp/scenario/gazebo/CMakeLists.txt
+++ b/cpp/scenario/gazebo/CMakeLists.txt
@@ -42,7 +42,9 @@ set(EXTRA_COMPONENTS_PUBLIC_HEADERS
     include/scenario/gazebo/components/HistoryOfAppliedJointForces.h
     include/scenario/gazebo/components/ExternalWorldWrenchCmdWithDuration.h
     include/scenario/gazebo/components/Timestamp.h
-    include/scenario/gazebo/components/JointControllerPeriod.h)
+    include/scenario/gazebo/components/JointControllerPeriod.h
+    include/scenario/gazebo/components/JointAcceleration.h
+    )
 
 add_library(ExtraComponents INTERFACE)
 add_library(ScenarioGazebo::ExtraComponents ALIAS ExtraComponents)

--- a/cpp/scenario/gazebo/include/scenario/gazebo/Joint.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/Joint.h
@@ -204,6 +204,8 @@ public:
 
     double acceleration(const size_t dof = 0) const override;
 
+    double generalizedForce(const size_t dof = 0) const override;
+
     bool setPositionTarget(const double position,
                            const size_t dof = 0) override;
 
@@ -240,6 +242,8 @@ public:
     std::vector<double> jointVelocity() const override;
 
     std::vector<double> jointAcceleration() const override;
+
+    std::vector<double> jointGeneralizedForce() const override;
 
     bool setJointPositionTarget(const std::vector<double>& position) override;
 

--- a/cpp/scenario/gazebo/include/scenario/gazebo/Joint.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/Joint.h
@@ -161,6 +161,10 @@ public:
 
     std::vector<double> historyOfAppliedJointForces() const override;
 
+    double coulombFriction() const override;
+
+    double viscousFriction() const override;
+
     // ==================
     // Single DOF methods
     // ==================

--- a/cpp/scenario/gazebo/include/scenario/gazebo/Joint.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/Joint.h
@@ -131,6 +131,28 @@ public:
     bool resetJoint(const std::vector<double>& position,
                     const std::vector<double>& velocity);
 
+    /**
+     * Set the Coulomb friction parameter of the joint.
+     *
+     * @note Friction can be changed only before the first simulated step
+     * after model insertion.
+     *
+     * @param value The new Coulomb friction value.
+     * @return True for success, false otherwise.
+     */
+    bool setCoulombFriction(const double value);
+
+    /**
+     * Set the viscous friction parameter of the joint.
+     *
+     * @note Friction can be changed only before the first simulated step
+     * after model insertion.
+     *
+     * @param value The new viscous friction value.
+     * @return True for success, false otherwise.
+     */
+    bool setViscousFriction(const double value);
+
     // ==========
     // Joint Core
     // ==========

--- a/cpp/scenario/gazebo/include/scenario/gazebo/Joint.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/Joint.h
@@ -202,6 +202,8 @@ public:
 
     double velocity(const size_t dof = 0) const override;
 
+    double acceleration(const size_t dof = 0) const override;
+
     bool setPositionTarget(const double position,
                            const size_t dof = 0) override;
 
@@ -236,6 +238,8 @@ public:
     std::vector<double> jointPosition() const override;
 
     std::vector<double> jointVelocity() const override;
+
+    std::vector<double> jointAcceleration() const override;
 
     bool setJointPositionTarget(const std::vector<double>& position) override;
 

--- a/cpp/scenario/gazebo/include/scenario/gazebo/Link.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/Link.h
@@ -150,6 +150,25 @@ public:
                           const std::array<double, 3>& torque,
                           const double duration = 0.0);
 
+    /**
+     * Apply a wrench to the CoM of the link.
+     *
+     * @note This method considers the CoM being positioned in the origin of
+     * the inertial frame as it is defined in the SDF description of the model.
+     * Note that if not explicitly specified, inertial and link frames match.
+     * In this case, `applyWorldWrench` and `applyWorldWrenchToCoM` effects
+     * will be the same.
+     *
+     * @param force The force to apply expressed in world coordinates.
+     * @param torque The torque to apply expressed in world coordinates.
+     * @param duration The duration of the application of the wrench.
+     * By default the wrench is applied for a single physics step.
+     * @return True for success, false otherwise.
+     */
+    bool applyWorldWrenchToCoM(const std::array<double, 3>& force,
+                               const std::array<double, 3>& torque,
+                               const double duration = 0.0);
+
 private:
     class Impl;
     std::unique_ptr<Impl> pImpl;

--- a/cpp/scenario/gazebo/include/scenario/gazebo/Link.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/Link.h
@@ -105,15 +105,50 @@ public:
 
     std::array<double, 6> contactWrench() const override;
 
+    // ===========
+    // Gazebo Link
+    // ===========
+
+    /**
+     * Apply a force to the link.
+     *
+     * The force is applied to the origin of the link frame.
+     *
+     * @param force The force to apply expressed in world coordinates.
+     * @param duration The duration of the application of the force.
+     * By default the force is applied for a single physics step.
+     * @return True for success, false otherwise.
+     */
     bool applyWorldForce(const std::array<double, 3>& force,
-                         const double duration = 0.0) override;
+                         const double duration = 0.0);
 
+    /**
+     * Apply a torque to the link.
+     *
+     * The force is applied to the origin of the link frame.
+     *
+     * @param torque The torque to apply expressed in world coordinates.
+     * @param duration The duration of the application of the torque.
+     * By default the torque is applied for a single physics step.
+     * @return True for success, false otherwise.
+     */
     bool applyWorldTorque(const std::array<double, 3>& torque,
-                          const double duration = 0.0) override;
+                          const double duration = 0.0);
 
+    /**
+     * Apply a wrench to the link.
+     *
+     * The force is applied to the origin of the link frame.
+     *
+     * @param force The force to apply expressed in world coordinates.
+     * @param torque The torque to apply expressed in world coordinates.
+     * @param duration The duration of the application of the wrench.
+     * By default the wrench is applied for a single physics step.
+     * @return True for success, false otherwise.
+     */
     bool applyWorldWrench(const std::array<double, 3>& force,
                           const std::array<double, 3>& torque,
-                          const double duration = 0.0) override;
+                          const double duration = 0.0);
 
 private:
     class Impl;

--- a/cpp/scenario/gazebo/include/scenario/gazebo/Model.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/Model.h
@@ -235,6 +235,9 @@ public:
     std::vector<double> jointAccelerations( //
         const std::vector<std::string>& jointNames = {}) const override;
 
+    std::vector<double> jointGeneralizedForces( //
+        const std::vector<std::string>& jointNames = {}) const override;
+
     core::JointLimit jointLimits( //
         const std::vector<std::string>& jointNames = {}) const override;
 

--- a/cpp/scenario/gazebo/include/scenario/gazebo/Model.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/Model.h
@@ -232,6 +232,9 @@ public:
     std::vector<double> jointVelocities( //
         const std::vector<std::string>& jointNames = {}) const override;
 
+    std::vector<double> jointAccelerations( //
+        const std::vector<std::string>& jointNames = {}) const override;
+
     core::JointLimit jointLimits( //
         const std::vector<std::string>& jointNames = {}) const override;
 

--- a/cpp/scenario/gazebo/include/scenario/gazebo/components/JointAcceleration.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/components/JointAcceleration.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This project is dual licensed under LGPL v2.1+ or Apache License.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IGNITION_GAZEBO_COMPONENTS_JOINTACCELERATION_H
+#define IGNITION_GAZEBO_COMPONENTS_JOINTACCELERATION_H
+
+#include <vector>
+
+#include <ignition/gazebo/components/Component.hh>
+#include <ignition/gazebo/components/Factory.hh>
+#include <ignition/gazebo/components/Serialization.hh>
+#include <ignition/gazebo/config.hh>
+
+namespace ignition {
+    namespace gazebo {
+        // Inline bracket to help doxygen filtering.
+        inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
+            namespace components {
+                /// \brief Joint acceleration in SI units (rad/s/s for revolute,
+                /// m/s/s for prismatic). The component wraps a std::vector of
+                /// size equal to the degrees of freedom of the joint.
+                using JointAcceleration =
+                    Component<std::vector<double>,
+                              class JointAccelerationTag,
+                              serializers::VectorDoubleSerializer>;
+                IGN_GAZEBO_REGISTER_COMPONENT(
+                    "ign_gazebo_components.JointAcceleration",
+                    JointAcceleration)
+            } // namespace components
+        } // namespace IGNITION_GAZEBO_VERSION_NAMESPACE
+    } // namespace gazebo
+} // namespace ignition
+
+#endif // IGNITION_GAZEBO_COMPONENTS_JOINTACCELERATION_H

--- a/cpp/scenario/gazebo/src/Joint.cpp
+++ b/cpp/scenario/gazebo/src/Joint.cpp
@@ -514,6 +514,48 @@ std::vector<double> Joint::historyOfAppliedJointForces() const
     return fixedSizeQueue.toStdVector();
 }
 
+double Joint::coulombFriction() const
+{
+    switch (this->type()) {
+        case core::JointType::Revolute:
+        case core::JointType::Prismatic:
+        case core::JointType::Ball: {
+            const sdf::JointAxis& axis = utils::getExistingComponentData< //
+                ignition::gazebo::components::JointAxis>(m_ecm, m_entity);
+            return axis.Friction();
+        }
+        case core::JointType::Fixed:
+        case core::JointType::Invalid:
+            sWarning << "Fixed and Invalid joints have no friction defined."
+                     << std::endl;
+            return 0.0;
+    }
+
+    assert(false);
+    return 0.0;
+}
+
+double Joint::viscousFriction() const
+{
+    switch (this->type()) {
+        case core::JointType::Revolute:
+        case core::JointType::Prismatic:
+        case core::JointType::Ball: {
+            const sdf::JointAxis& axis = utils::getExistingComponentData< //
+                ignition::gazebo::components::JointAxis>(m_ecm, m_entity);
+            return axis.Damping();
+        }
+        case core::JointType::Fixed:
+        case core::JointType::Invalid:
+            sWarning << "Fixed and Invalid joints have no friction defined."
+                     << std::endl;
+            return 0.0;
+    }
+
+    assert(false);
+    return 0.0;
+}
+
 scenario::core::Limit Joint::positionLimit(const size_t dof) const
 {
     if (dof >= this->dofs()) {

--- a/cpp/scenario/gazebo/src/Joint.cpp
+++ b/cpp/scenario/gazebo/src/Joint.cpp
@@ -704,6 +704,16 @@ double Joint::acceleration(const size_t dof) const
     return acceleration[dof];
 }
 
+double Joint::generalizedForce(const size_t dof) const
+{
+    if (dof >= this->dofs()) {
+        throw exceptions::DOFMismatch(this->dofs(), dof, this->name());
+    }
+
+    const std::vector<double>& force = this->jointGeneralizedForce();
+    return force[dof];
+}
+
 bool Joint::setPositionTarget(const double position, const size_t dof)
 {
     const std::vector<core::JointControlMode> allowedControlModes = {
@@ -968,6 +978,20 @@ std::vector<double> Joint::jointAcceleration() const
     }
 
     return jointAcceleration;
+}
+
+std::vector<double> Joint::jointGeneralizedForce() const
+{
+    const std::vector<double>& jointGeneralizedForce =
+        utils::getExistingComponentData<
+            ignition::gazebo::components::JointForce>(m_ecm, m_entity);
+
+    if (jointGeneralizedForce.size() != this->dofs()) {
+        throw exceptions::DOFMismatch(
+            this->dofs(), jointGeneralizedForce.size(), this->name());
+    }
+
+    return jointGeneralizedForce;
 }
 
 bool Joint::setJointPositionTarget(const std::vector<double>& position)

--- a/cpp/scenario/gazebo/src/Model.cpp
+++ b/cpp/scenario/gazebo/src/Model.cpp
@@ -756,6 +756,16 @@ Model::jointVelocities(const std::vector<std::string>& jointNames) const
     return Impl::getJointDataSerialized(this, jointNames, lambda);
 }
 
+std::vector<double>
+Model::jointAccelerations(const std::vector<std::string>& jointNames) const
+{
+    auto lambda = [](core::JointPtr joint, const size_t dof) -> double {
+        return joint->acceleration(dof);
+    };
+
+    return Impl::getJointDataSerialized(this, jointNames, lambda);
+}
+
 scenario::core::JointLimit
 Model::jointLimits(const std::vector<std::string>& jointNames) const
 {

--- a/cpp/scenario/gazebo/src/Model.cpp
+++ b/cpp/scenario/gazebo/src/Model.cpp
@@ -766,6 +766,16 @@ Model::jointAccelerations(const std::vector<std::string>& jointNames) const
     return Impl::getJointDataSerialized(this, jointNames, lambda);
 }
 
+std::vector<double>
+Model::jointGeneralizedForces(const std::vector<std::string>& jointNames) const
+{
+    auto lambda = [](core::JointPtr joint, const size_t dof) -> double {
+        return joint->generalizedForce(dof);
+    };
+
+    return Impl::getJointDataSerialized(this, jointNames, lambda);
+}
+
 scenario::core::JointLimit
 Model::jointLimits(const std::vector<std::string>& jointNames) const
 {

--- a/tests/test_scenario/test_custom_controllers.py
+++ b/tests/test_scenario/test_custom_controllers.py
@@ -97,7 +97,7 @@ def test_computed_torque_fixed_base(gazebo: scenario.GazeboSimulator):
                                                      abs=0.05)
 
     # Apply an external force
-    assert panda.get_link("panda_link4").apply_world_force([100.0, 0, 0], 0.5)
+    assert panda.get_link("panda_link4").to_gazebo().apply_world_force([100.0, 0, 0], 0.5)
 
     for _ in range(4000):
         assert gazebo.run()


### PR DESCRIPTION
- Get joint friction: interface a77c531, gazebo implementation 18ebe47
- Set joint friction: only gazebo implementation d6cf9eb 
- Get joint acceleration: interface c8834d1, gazebo implementation 7f07226
- Get joint forces: ee631bb, gazebo implementation b2e45ba 
- Remove link wrench application from interface 6662219 since it's a simulated-only feature, and moved to the gazebo implementation c1eb04e 
- Add a gazebo method to apply wrench to link's CoM 65d9927 
- Update physics system to fill components with joint acceleration and forces 5bf1b4b 

Note that currently the DART physics plugin does not provide joint forces. This PR only prepares the API.

Note that the history of joint forces will continue to provide joint force targets, waiting to get joint forces from the physics.