### PR TITLE
Implement VELOCITY_DIRECT control mode

### DIFF
--- a/cpp/scenario/core/include/scenario/core/Joint.h
+++ b/cpp/scenario/core/include/scenario/core/Joint.h
@@ -40,6 +40,7 @@ namespace scenario::core {
         Idle,
         Force,
         Velocity,
+        VelocityFollowerDart,
         Position,
         PositionInterpolated,
     };

--- a/cpp/scenario/core/include/scenario/core/Joint.h
+++ b/cpp/scenario/core/include/scenario/core/Joint.h
@@ -36,12 +36,41 @@ namespace scenario::core {
      */
     enum class JointControlMode
     {
+        /// Marks the joint to have an invalid control mode.
         Invalid,
+
+        /// Marks the joint to be IDLE. An IDLE joint is equivalent to a joint
+        /// controlled in Force with zero references. The joint shows only
+        /// passive behaviour.
         Idle,
+
+        /// Marks the joint to be controlled in force. A Force joint receives
+        /// generalized force references that are actuated by a force actuator.
+        /// Depending on the active backend, the presence of friction and other
+        /// loss components could be compensated.
         Force,
+
+        /// Marks the joint to be controlled in velocity. A Velocity joint
+        /// receives velocity references that are actuated using a PID
+        /// controller.
         Velocity,
+
+        /// Marks the joint to follow precisely a velocity trajectory. A
+        /// VelocityFollowerDart joint receives velocity references that
+        /// are processed by the physics engine, which computes instantaneously
+        /// the right force to apply to follow the desired trajectory.
+        /// It works only with the DART physics engine.
         VelocityFollowerDart,
+
+        /// Marks the joint to be controlled in position. A Position joint
+        /// receives position references that are actuated using a PID
+        /// controller.
         Position,
+
+        /// Marks the joint to be controlled in position with trajectory
+        /// smoothing. A PositionInterpolated joint receives position references
+        /// that are filtered to get a smooth trajectory. The resulting
+        /// trajectory is then actuated using a position PID controller.
         PositionInterpolated,
     };
     class Joint;

--- a/cpp/scenario/gazebo/src/Joint.cpp
+++ b/cpp/scenario/gazebo/src/Joint.cpp
@@ -460,6 +460,9 @@ bool Joint::setControlMode(const scenario::core::JointControlMode mode)
             break;
         case core::JointControlMode::Idle:
         case core::JointControlMode::Force:
+            utils::setComponentData<
+                ignition::gazebo::components::JointForceCmd>(
+                m_ecm, m_entity, std::vector<double>(this->dofs(), 0.0));
             break;
         case core::JointControlMode::Invalid:
             sError << "You cannot set the Invalid control mode" << std::endl;

--- a/cpp/scenario/plugins/JointController/JointController.cpp
+++ b/cpp/scenario/plugins/JointController/JointController.cpp
@@ -206,9 +206,10 @@ void JointController::PreUpdate(const ignition::gazebo::UpdateInfo& info,
 
         const std::vector<double>& position = joint->jointPosition();
 
-        std::vector<double>& positionTarget = utils::getExistingComponentData<
-            ignition::gazebo::components::JointPositionTarget>(&ecm,
-                                                               jointEntity);
+        const std::vector<double>& positionTarget =
+            utils::getExistingComponentData<
+                ignition::gazebo::components::JointPositionTarget>(&ecm,
+                                                                   jointEntity);
 
         if (!Impl::runPIDController(*jointGazebo,
                                     computeNewForce,
@@ -239,9 +240,10 @@ void JointController::PreUpdate(const ignition::gazebo::UpdateInfo& info,
 
         const std::vector<double>& velocity = joint->jointVelocity();
 
-        std::vector<double>& velocityTarget = utils::getExistingComponentData<
-            ignition::gazebo::components::JointVelocityTarget>(&ecm,
-                                                               jointEntity);
+        const std::vector<double>& velocityTarget =
+            utils::getExistingComponentData<
+                ignition::gazebo::components::JointVelocityTarget>(&ecm,
+                                                                   jointEntity);
 
         if (!Impl::runPIDController(*jointGazebo,
                                     computeNewForce,

--- a/tests/test_scenario/test_model.py
+++ b/tests/test_scenario/test_model.py
@@ -226,6 +226,8 @@ def test_model_references(gazebo: scenario.GazeboSimulator):
     model = get_model(gazebo, gym_ignition_model_name)
     assert gym_ignition_model_name in gazebo.get_world().model_names()
 
+    assert model.set_joint_control_mode(core.JointControlMode_force)
+
     assert model.set_joint_position_targets([0.5, -3])
     assert model.joint_position_targets() == pytest.approx([0.5, -3])
     assert model.joint_position_targets(["pivot"]) == pytest.approx([-3])

--- a/tests/test_scenario/test_velocity_direct.py
+++ b/tests/test_scenario/test_velocity_direct.py
@@ -1,0 +1,82 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import pytest
+pytestmark = pytest.mark.scenario
+
+import numpy as np
+from typing import Tuple
+import gym_ignition_models
+from scenario import core as scenario_core
+from scenario import gazebo as scenario_gazebo
+from ..common.utils import default_world_fixture as default_world
+
+# Set the verbosity
+scenario_gazebo.set_verbosity(scenario_gazebo.Verbosity_debug)
+
+
+@pytest.mark.parametrize("default_world", [(1.0 / 1_000, 1.0, 1)], indirect=True)
+def test_velocity_direct(default_world: Tuple[scenario_gazebo.GazeboSimulator,
+                                              scenario_gazebo.World]):
+
+    # Get the simulator and the world
+    gazebo, world = default_world
+
+    # Get the URDF model
+    pendulum_urdf = gym_ignition_models.get_model_file("pendulum")
+
+    # Insert a pendulum model
+    assert world.insert_model(pendulum_urdf)
+    assert "pendulum" in world.model_names()
+
+    # Get the model and cast it to Gazebo
+    pendulum = world.get_model("pendulum").to_gazebo()
+
+    # Add some friction
+    assert pendulum.get_joint("pivot").to_gazebo().set_coulomb_friction(value=0.01)
+    assert pendulum.get_joint("pivot").to_gazebo().set_viscous_friction(value=0.2)
+
+    # Show the GUI
+    # import time
+    # gazebo.gui()
+    # time.sleep(2)
+
+    # Get the pivot joint
+    assert "pivot" in pendulum.joint_names()
+    pivot = pendulum.get_joint(joint_name="pivot")
+
+    # Reset the joint to 90 degs and make it swing
+    assert pivot.to_gazebo().reset_position(position=np.deg2rad(90))
+    [gazebo.run() for _ in range(5_000)]
+
+    # It should rest in its stable equilibrium point
+    assert np.deg2rad(179.7) <= pivot.position() <= np.deg2rad(180.3)
+
+    # Control the joint in velocity direct
+    assert pivot.set_control_mode(mode=scenario_core.JointControlMode_velocity_follower_dart)
+
+    # Set the velocity reference to 3.14 rad / s
+    assert pivot.set_velocity_target(velocity=np.pi)
+
+    # The target should be reached after just one run
+    assert gazebo.run()
+    assert pivot.velocity() == pytest.approx(np.pi)
+
+    # Simulate for a while
+    [gazebo.run() for _ in range(1_500)]
+
+    # Check again
+    assert pivot.velocity() == pytest.approx(np.pi)
+
+    # Change direction abruptly
+    assert pivot.set_velocity_target(velocity=-np.pi)
+    assert gazebo.run()
+    assert pivot.velocity() == pytest.approx(-np.pi)
+
+    # Go in idle and make it swing
+    assert pivot.set_control_mode(mode=scenario_core.JointControlMode_idle)
+    [gazebo.run() for _ in range(5_000)]
+
+    # It should rest in its stable equilibrium point
+    assert 2*np.pi + np.deg2rad(179.7) <= pivot.position() <= 2*np.pi + np.deg2rad(180.3)


### PR DESCRIPTION
This control mode is DART-only but for the moment it is useful supporting it officially. It allows controlling models in simulation without the need to tune any PID. Joints controlled in `VELOCITY_DIRECT` follow velocity trajectories precisely. The physics engine is responsible to compute the right force to apply in order to follow the velocity references.

Note that this is not a realistic control mode. However, in many cases, it can provide a quick way to control models before starting the effort of tuning PID gains.