### PR TITLE
Add Panda and iCub models to gym_ignition_environments

### DIFF
--- a/docs/sphinx/apidoc/gym-ignition-environments/gym_ignition_environments.models.rst
+++ b/docs/sphinx/apidoc/gym-ignition-environments/gym_ignition_environments.models.rst
@@ -15,6 +15,22 @@ gym\_ignition\_environments.models.cartpole
    :undoc-members:
    :show-inheritance:
 
+gym\_ignition\_environments.models.icub
+---------------------------------------
+
+.. automodule:: gym_ignition_environments.models.icub
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+gym\_ignition\_environments.models.panda
+----------------------------------------
+
+.. automodule:: gym_ignition_environments.models.panda
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 gym\_ignition\_environments.models.pendulum
 -------------------------------------------
 

--- a/python/gym_ignition_environments/models/__init__.py
+++ b/python/gym_ignition_environments/models/__init__.py
@@ -2,5 +2,6 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
+from . import icub
 from . import cartpole
 from . import pendulum

--- a/python/gym_ignition_environments/models/__init__.py
+++ b/python/gym_ignition_environments/models/__init__.py
@@ -3,5 +3,6 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 from . import icub
+from . import panda
 from . import cartpole
 from . import pendulum

--- a/python/gym_ignition_environments/models/icub.py
+++ b/python/gym_ignition_environments/models/icub.py
@@ -1,0 +1,119 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import abc
+from typing import List
+from gym_ignition import scenario
+from scenario import core as scenario_core
+from gym_ignition.utils.scenario import get_unique_model_name
+
+
+class ICubGazeboABC(scenario.model_wrapper.ModelWrapper,
+                    abc.ABC):
+
+    DOFS = 32
+    NUM_LINKS = 39
+    NUM_JOINTS = 32
+
+    initial_positions = {
+        # Left leg
+        'l_knee': -1.05,
+        'l_ankle_pitch': -0.57, 'l_ankle_roll': -0.024,
+        'l_hip_pitch': 0.48, 'l_hip_roll': 0.023, 'l_hip_yaw': -0.005,
+        # Left arm
+        'l_elbow': 0.54,
+        'l_wrist_pitch': 0.0, 'l_wrist_prosup': 0.0, 'l_wrist_yaw': 0.0,
+        'l_shoulder_pitch': -0.159, 'l_shoulder_roll': 0.435, 'l_shoulder_yaw': 0.183,
+        # Head
+        'neck_pitch': 0.0, 'neck_roll': 0.0, 'neck_yaw': 0.0,
+        # Right leg
+        'r_knee': -1.05,
+        'r_ankle_pitch': -0.57, 'r_ankle_roll': -0.024,
+        'r_hip_pitch': 0.48, 'r_hip_roll': 0.023, 'r_hip_yaw': -0.005,
+        # Right arm
+        'r_elbow': 0.54,
+        'r_wrist_pitch': 0.0, 'r_wrist_prosup': 0.0, 'r_wrist_yaw': 0.0,
+        'r_shoulder_pitch': -0.159, 'r_shoulder_roll': 0.435, 'r_shoulder_yaw': 0.183,
+        # Torso
+        'torso_pitch': 0.1, 'torso_roll': 0.0, 'torso_yaw': 0.0,
+    }
+
+    def __init__(self,
+                 world: scenario_core.World,
+                 position: List[float],
+                 orientation: List[float],
+                 model_file: str = None):
+
+        # Get a unique model name
+        model_name = get_unique_model_name(world, "icub")
+
+        # Initial pose
+        initial_pose = scenario_core.Pose(position, orientation)
+
+        # Get the model file (URDF or SDF) and allow to override it
+        if model_file is None:
+            model_file = self.get_model_file()
+
+        # Insert the model
+        ok_model = world.to_gazebo().insert_model(model_file,
+                                                  initial_pose,
+                                                  model_name)
+
+        if not ok_model:
+            raise RuntimeError("Failed to insert model")
+
+        # Get the model
+        model = world.get_model(model_name)
+
+        # Initialize base class
+        super().__init__(model=model)
+
+        # Store the initial positions
+        q0 = list(self.initial_positions.values())
+        joint_names = list(self.initial_positions.keys())
+        assert self.dofs() == len(q0) == len(joint_names)
+
+        ok_q0 = self.to_gazebo().reset_joint_positions(q0, joint_names)
+        assert ok_q0, "Failed to set initial position"
+
+
+class ICubGazebo(ICubGazeboABC,
+                 scenario.model_with_file.ModelWithFile):
+
+    def __init__(self,
+                 world: scenario_core.World,
+                 position: List[float] = (0., 0., 0.572),
+                 orientation: List[float] = (0, 0, 0, 1.0),
+                 model_file: str = None):
+
+        super().__init__(world=world,
+                         position=position,
+                         orientation=orientation,
+                         model_file=model_file)
+
+    @classmethod
+    def get_model_file(cls) -> str:
+
+        import gym_ignition_models
+        return gym_ignition_models.get_model_file("iCubGazeboV2_5")
+
+
+class ICubGazeboSimpleCollisions(ICubGazeboABC):
+
+    def __init__(self,
+                 world: scenario_core.World,
+                 position: List[float] = (0., 0., 0.572),
+                 orientation: List[float] = (0, 0, 0, 1.0),
+                 model_file: str = None):
+
+        super().__init__(world=world,
+                         position=position,
+                         orientation=orientation,
+                         model_file=model_file)
+
+    @classmethod
+    def get_model_file(cls) -> str:
+
+        import gym_ignition_models
+        return gym_ignition_models.get_model_file("iCubGazeboSimpleCollisionsV2_5")

--- a/python/gym_ignition_environments/models/panda.py
+++ b/python/gym_ignition_environments/models/panda.py
@@ -1,0 +1,75 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+from typing import List
+from scenario import core as scenario
+from gym_ignition.utils.scenario import get_unique_model_name
+from gym_ignition.scenario import model_wrapper, model_with_file
+
+
+class Panda(model_wrapper.ModelWrapper,
+            model_with_file.ModelWithFile):
+
+    def __init__(self,
+                 world: scenario.World,
+                 position: List[float] = (0.0, 0.0, 0.0),
+                 orientation: List[float] = (1.0, 0, 0, 0),
+                 model_file: str = None):
+
+        # Get a unique model name
+        model_name = get_unique_model_name(world, "panda")
+
+        # Initial pose
+        initial_pose = scenario.Pose(position, orientation)
+
+        # Get the default model description (URDF or SDF) allowing to pass a custom model
+        if model_file is None:
+            model_file = Panda.get_model_file()
+
+        # Insert the model
+        ok_model = world.to_gazebo().insert_model(model_file,
+                                                  initial_pose,
+                                                  model_name)
+
+        if not ok_model:
+            raise RuntimeError("Failed to insert model")
+
+        # Get the model
+        model = world.get_model(model_name)
+
+        # From:
+        # https://github.com/mkrizmancic/franka_gazebo/blob/master/config/default.yaml
+        pid_gains_1000hz = {
+            'panda_joint1': scenario.PID(50,    0,  20),
+            'panda_joint2': scenario.PID(10000, 0, 500),
+            'panda_joint3': scenario.PID(100,   0,  10),
+            'panda_joint4': scenario.PID(1000,  0,  50),
+            'panda_joint5': scenario.PID(100,   0,  10),
+            'panda_joint6': scenario.PID(100,   0,  10),
+            'panda_joint7': scenario.PID(10,  0.5, 0.1),
+            'panda_finger_joint1': scenario.PID(100, 0, 50),
+            'panda_finger_joint2': scenario.PID(100, 0, 50),
+        }
+
+        # Check that all joints have gains
+        if not set(model.joint_names()) == set(pid_gains_1000hz.keys()):
+            raise ValueError("The number of PIDs does not match the number of joints")
+
+        # Set the PID gains
+        for joint_name, pid in pid_gains_1000hz.items():
+
+            if not model.get_joint(joint_name).set_pid(pid=pid):
+                raise RuntimeError(f"Failed to set the PID of joint '{joint_name}'")
+
+        # Set the default PID update period
+        assert model.set_controller_period(1000.0)
+
+        # Initialize base class
+        super().__init__(model=model)
+
+    @classmethod
+    def get_model_file(cls) -> str:
+
+        import gym_ignition_models
+        return gym_ignition_models.get_model_file("panda")


### PR DESCRIPTION
While we do not have any environment with these two robots, having their helpers classes simplifies writing tests and examples.

Related PRs:

- https://github.com/robotology/gym-ignition-models/pull/2
- https://github.com/robotology/gym-ignition-models/pull/1
- https://github.com/robotology/gym-ignition-models/pull/15 
- https://github.com/robotology/gym-ignition-models/pull/20

cc @paolo-viceconte 