### PR TITLE
Make Joint::jointGeneralizedForceTarget return data from the right component

### DIFF
--- a/cpp/scenario/gazebo/src/Joint.cpp
+++ b/cpp/scenario/gazebo/src/Joint.cpp
@@ -1105,7 +1105,7 @@ std::vector<double> Joint::jointAccelerationTarget() const
 std::vector<double> Joint::jointGeneralizedForceTarget() const
 {
     const std::vector<double>& target = utils::getExistingComponentData< //
-        ignition::gazebo::components::JointForce>(m_ecm, m_entity);
+        ignition::gazebo::components::JointForceCmd>(m_ecm, m_entity);
 
     if (target.size() != this->dofs()) {
         throw exceptions::DOFMismatch(

--- a/tests/test_scenario/test_model.py
+++ b/tests/test_scenario/test_model.py
@@ -240,12 +240,9 @@ def test_model_references(gazebo: scenario.GazeboSimulator):
     assert model.joint_acceleration_targets() == pytest.approx([-0, 3.14])
     assert model.joint_acceleration_targets(["pivot"]) == pytest.approx([3.14])
 
-    # TODO
-    # assert not model.set_joint_generalized_force_targets([20.1, -13])
-    # assert model.set_joint_control_mode()(bindings.JointControlMode_force)
-    # assert model.set_joint_generalized_force_targets([20.1, -13])
-    # assert model.joint_generalized_force_targets() == pytest.approx([20.1, -13])
-    # assert model.joint_generalized_force_targets(["pivot"]) == pytest.approx([-13])
+    assert model.set_joint_generalized_force_targets([20.1, -13])
+    assert model.joint_generalized_force_targets() == pytest.approx([20.1, -13])
+    assert model.joint_generalized_force_targets(["pivot"]) == pytest.approx([-13])
 
     assert model.set_base_pose_target((0, 0, 5), (0, 0, 0, 1.0))
     assert model.set_base_orientation_target((0, 0, 1.0, 0))


### PR DESCRIPTION
Before #259, and particularly 5bf1b4b, we were handling differently what was stored in the `JointForce` component. Now, the force is filled by what the ign-physics plugin provides. Before, we were storing the command. In presence of friction or when the joint limit is reached, the command and the real joint force do not match.

This PR makes `gazebo::Joint::jointGeneralizedForceTarget` return the `JointForceCmd` instead. The trade off here is that this component is cleared after the first application, therefore getting the target is valid only before the next `GazeboSimulator::run()` call.

Until now, there have always been a mismatch about how the force target was handled wrt to the position, velocity, etc. This PR reduces the gap. It does not fill it entirely because the other targets will persist even after the run. However, this behaviour matches what happens in reality, since the force command is only applied once. Instead, when a joint controller is enabled, the position, velocity, etc. targets remain valid.