### PR TITLE
Align vendored Physics system

### DIFF
--- a/cpp/scenario/plugins/Physics/Physics.cpp
+++ b/cpp/scenario/plugins/Physics/Physics.cpp
@@ -63,6 +63,7 @@
 #include <ignition/gazebo/components/Pose.hh>
 #include <ignition/gazebo/components/PoseCmd.hh>
 #include <ignition/gazebo/components/SelfCollide.hh>
+#include <ignition/gazebo/components/SlipComplianceCmd.hh>
 #include <ignition/gazebo/components/Static.hh>
 #include <ignition/gazebo/components/ThreadPitch.hh>
 #include <ignition/gazebo/components/World.hh>
@@ -73,31 +74,10 @@
 #include <ignition/msgs/contact.pb.h>
 #include <ignition/msgs/contacts.pb.h>
 #include <ignition/msgs/entity.pb.h>
-#include <ignition/physics/BoxShape.hh>
-#include <ignition/physics/CylinderShape.hh>
-#include <ignition/physics/FeatureList.hh>
-#include <ignition/physics/FeaturePolicy.hh>
-#include <ignition/physics/FindFeatures.hh>
-#include <ignition/physics/FixedJoint.hh>
-#include <ignition/physics/ForwardStep.hh>
-#include <ignition/physics/FrameSemantics.hh>
-#include <ignition/physics/FreeGroup.hh>
-#include <ignition/physics/GetBoundingBox.hh>
-#include <ignition/physics/GetContacts.hh>
-#include <ignition/physics/Joint.hh>
-#include <ignition/physics/Link.hh>
 #include <ignition/physics/RelativeQuantity.hh>
-#include <ignition/physics/RemoveEntities.hh>
 #include <ignition/physics/RequestEngine.hh>
-#include <ignition/physics/Shape.hh>
-#include <ignition/physics/SphereShape.hh>
 #include <ignition/physics/config.hh>
 #include <ignition/physics/mesh/MeshShape.hh>
-#include <ignition/physics/sdf/ConstructCollision.hh>
-#include <ignition/physics/sdf/ConstructJoint.hh>
-#include <ignition/physics/sdf/ConstructLink.hh>
-#include <ignition/physics/sdf/ConstructModel.hh>
-#include <ignition/physics/sdf/ConstructWorld.hh>
 #include <ignition/plugin/Loader.hh>
 #include <ignition/plugin/PluginPtr.hh>
 #include <ignition/plugin/Register.hh>
@@ -109,9 +89,12 @@
 #include <sdf/Surface.hh>
 #include <sdf/World.hh>
 
+#include <algorithm>
 #include <deque>
 #include <iostream>
+#include <string>
 #include <unordered_map>
+#include <vector>
 
 using namespace ignition;
 using namespace scenario::plugins::gazebo;
@@ -200,6 +183,16 @@ public:
     LinkFrameDataAtOffset(const LinkPtrType& _link,
                           const math::Pose3d& _pose) const;
 
+    /// \brief Get transform from one ancestor entity to a descendant entity
+    /// that are in the same model.
+    /// \param[in] _from An ancestor of the _to entity.
+    /// \param[in] _to A descendant of the _from entity.
+    /// \return Pose transform between the two entities
+    ignition::math::Pose3d
+    RelativePose(const Entity& _from,
+                 const Entity& _to,
+                 const EntityComponentManager& _ecm) const;
+
     /// \brief A map between world entity ids in the ECM to World Entities in
     /// ign-physics.
     std::unordered_map<Entity, WorldPtrType> entityWorldMap;
@@ -252,6 +245,28 @@ public:
 
     /// \brief Environment variable which holds paths to look for engine plugins
     std::string pluginPathEnv = "IGN_GAZEBO_PHYSICS_ENGINE_PATH";
+
+    //////////////////////////////////////////////////
+    // Slip Compliance
+
+    /// \brief Feature list to process `FrictionPyramidSlipCompliance`
+    /// components.
+    using FrictionPyramidSlipComplianceFeatureList = physics::FeatureList<
+        MinimumFeatureList,
+        ignition::physics::GetShapeFrictionPyramidSlipCompliance,
+        ignition::physics::SetShapeFrictionPyramidSlipCompliance>;
+
+    /// \brief Shape type with slip compliance features.
+    using ShapeSlipParamPtrType =
+        physics::ShapePtr<physics::FeaturePolicy3d,
+                          FrictionPyramidSlipComplianceFeatureList>;
+
+    /// \brief A map between shape entity ids in the ECM to Shape Entities in
+    /// ign-physics
+    /// All shapes on this map are also in `entityCollisionMap`. The difference
+    /// is that here they've been casted for
+    /// `FrictionPyramidSlipComplianceFeatureList`.
+    std::unordered_map<Entity, ShapeSlipParamPtrType> entityShapeSlipParamMap;
 
     //////////////////////////////////////////////////
     // Joints
@@ -481,6 +496,36 @@ public:
     /// that here they've been casted for `MeshFeatureList`.
     std::unordered_map<Entity, LinkMeshPtrType> entityLinkMeshMap;
 
+    //////////////////////////////////////////////////
+    // Nested Models
+
+    /// \brief Feature list to construct nested models
+    using NestedModelFeatureList = ignition::physics::FeatureList<
+        MinimumFeatureList,
+        ignition::physics::sdf::ConstructSdfNestedModel>;
+
+    /// \brief Model type with nested model feature.
+    using ModelNestedModelPtrType =
+        physics::ModelPtr<physics::FeaturePolicy3d, NestedModelFeatureList>;
+
+    /// \brief World type with nested model feature.
+    using WorldNestedModelPtrType =
+        physics::WorldPtr<physics::FeaturePolicy3d, NestedModelFeatureList>;
+
+    /// \brief A map between model entity ids in the ECM to Model Entities in
+    /// ign-physics, with Nested Model feature.
+    /// All models on this map are also in `entityModelMap`. The difference is
+    /// that here they've been casted for `ConstructedSdfNestedModel`.
+    std::unordered_map<Entity, ModelNestedModelPtrType>
+        entityModelNestedModelMap;
+
+    /// \brief A map between model entity ids in the ECM to World Entities in
+    /// ign-physics, with Nested Model feature.
+    /// All models on this map are also in `entityWorldMap`. The difference is
+    /// that here they've been casted for `ConstructedSdfNestedModel`.
+    std::unordered_map<Entity, WorldNestedModelPtrType>
+        entityWorldNestedModelMap;
+
     /// \brief Boolean value that is true only the first call of Configure and
     /// PreUpdate.
     bool firstRun = true;
@@ -677,17 +722,7 @@ void Physics::Impl::CreatePhysicsEntities(const EntityComponentManager& _ecm)
 
         // TODO(anyone) Don't load models unless they have collisions
 
-        // Check if parent world exists
-        // TODO(louise): Support nested models, see
-        // https://github.com/ignitionrobotics/ign-physics/issues/10
-        if (this->entityWorldMap.find(_parent->Data())
-            == this->entityWorldMap.end()) {
-            ignwarn << "Model's parent entity [" << _parent->Data()
-                    << "] not found on world map." << std::endl;
-            return true;
-        }
-        auto worldPtrPhys = this->entityWorldMap.at(_parent->Data());
-
+        // Check if parent world / model exists
         sdf::Model model;
         model.SetName(_name->Data());
         model.SetRawPose(_pose->Data());
@@ -702,8 +737,86 @@ void Physics::Impl::CreatePhysicsEntities(const EntityComponentManager& _ecm)
             model.SetSelfCollide(selfCollideComp->Data());
         }
 
-        auto modelPtrPhys = worldPtrPhys->ConstructModel(model);
-        this->entityModelMap.insert(std::make_pair(_entity, modelPtrPhys));
+        // check if parent is a world
+        auto worldIt = this->entityWorldMap.find(_parent->Data());
+        if (worldIt != this->entityWorldMap.end()) {
+            auto worldPtrPhys = worldIt->second;
+
+            // Use the ConstructNestedModel feature for nested models
+            if (model.ModelCount() > 0) {
+                auto nestedModelFeature =
+                    entityCast(_parent->Data(),
+                               worldPtrPhys,
+                               this->entityWorldNestedModelMap);
+                if (!nestedModelFeature) {
+                    static bool informed{false};
+                    if (!informed) {
+                        igndbg
+                            << "Attempting to construct nested models, but the "
+                            << "phyiscs engine doesn't support feature "
+                            << "[ConstructSdfNestedModelFeature]. "
+                            << "Nested model will be ignored." << std::endl;
+                        informed = true;
+                    }
+                    return true;
+                }
+                auto modelPtrPhys =
+                    nestedModelFeature->ConstructNestedModel(model);
+                this->entityModelMap.insert(
+                    std::make_pair(_entity, modelPtrPhys));
+            }
+            else {
+                auto modelPtrPhys = worldPtrPhys->ConstructModel(model);
+                this->entityModelMap.insert(
+                    std::make_pair(_entity, modelPtrPhys));
+            }
+        }
+        // check if parent is a model (nested model)
+        else {
+            auto parentIt = this->entityModelMap.find(_parent->Data());
+            if (parentIt != this->entityModelMap.end()) {
+                auto parentPtrPhys = parentIt->second;
+
+                auto nestedModelFeature =
+                    entityCast(_parent->Data(),
+                               parentPtrPhys,
+                               this->entityModelNestedModelMap);
+                if (!nestedModelFeature) {
+                    static bool informed{false};
+                    if (!informed) {
+                        igndbg
+                            << "Attempting to construct nested models, but the "
+                            << "physics engine doesn't support feature "
+                            << "[ConstructSdfNestedModelFeature]. "
+                            << "Nested model will be ignored." << std::endl;
+                        informed = true;
+                    }
+                    return true;
+                }
+
+                // override static property only if parent is static.
+                auto parentStaticComp =
+                    _ecm.Component<components::Static>(_parent->Data());
+                if (parentStaticComp && parentStaticComp->Data())
+                    model.SetStatic(true);
+
+                auto modelPtrPhys =
+                    nestedModelFeature->ConstructNestedModel(model);
+                if (modelPtrPhys) {
+                    this->entityModelMap.insert(
+                        std::make_pair(_entity, modelPtrPhys));
+                }
+                else {
+                    ignerr << "Model: '" << _name->Data() << "' not loaded. "
+                           << "Failed to create nested model." << std::endl;
+                }
+            }
+            else {
+                ignwarn << "Model's parent entity [" << _parent->Data()
+                        << "] not found on world / model map." << std::endl;
+                return true;
+            }
+        }
 
         return true;
     };
@@ -1115,7 +1228,7 @@ void Physics::Impl::RemovePhysicsEntities(const EntityComponentManager& _ecm)
     // removed so, here, we only remove the entities from the gazebo
     // entity->physics entity map.
     _ecm.EachRemoved<components::Model>([&](const Entity& _entity,
-                                            const components::Model *
+                                            const components::Model*
                                             /* _model */) -> bool {
         // Remove model if found
         auto modelIt = this->entityModelMap.find(_entity);
@@ -1427,6 +1540,13 @@ void Physics::Impl::UpdatePhysics(const ignition::gazebo::UpdateInfo& _info,
             if (modelIt == this->entityModelMap.end())
                 return true;
 
+            // world pose cmd currently not supported for nested models
+            if (_entity != topLevelModel(_entity, _ecm)) {
+                ignerr << "Unable to set world pose for nested models."
+                       << std::endl;
+                return true;
+            }
+
             // The canonical link as specified by sdformat is different from
             // the canonical link of the FreeGroup object
 
@@ -1442,11 +1562,14 @@ void Physics::Impl::UpdatePhysics(const ignition::gazebo::UpdateInfo& _info,
             if (linkEntityIt == this->linkEntityMap.end())
                 return true;
 
-            auto canonicalPoseComp =
-                _ecm.Component<components::Pose>(linkEntityIt->second);
+            // set world pose of canonical link in freegroup
+            // canonical link might be in a nested model so use RelativePose to
+            // get its pose relative to this model
+            math::Pose3d linkPose =
+                this->RelativePose(_entity, linkEntityIt->second, _ecm);
 
-            freeGroup->SetWorldPose(math::eigen3::convert(
-                _poseCmd->Data() * canonicalPoseComp->Data()));
+            freeGroup->SetWorldPose(
+                math::eigen3::convert(_poseCmd->Data() * linkPose));
 
             // Process pose commands for static models here, as one-time
             // changes
@@ -1466,6 +1589,39 @@ void Physics::Impl::UpdatePhysics(const ignition::gazebo::UpdateInfo& _info,
             return true;
         });
 
+    // Slip compliance on Collisions
+    _ecm.Each<components::SlipComplianceCmd>(
+        [&](const Entity& _entity,
+            const components::SlipComplianceCmd* _slipCmdComp) {
+            auto shapeIt = this->entityCollisionMap.find(_entity);
+            if (shapeIt == this->entityCollisionMap.end()) {
+                ignwarn << "Failed to find shape [" << _entity << "]."
+                        << std::endl;
+                return true;
+            }
+
+            auto slipComplianceShape = entityCast(
+                _entity, shapeIt->second, this->entityShapeSlipParamMap);
+
+            if (!slipComplianceShape) {
+                ignwarn << "Can't process Wheel Slip component, physics engine "
+                        << "missing SetShapeFrictionPyramidSlipCompliance"
+                        << std::endl;
+
+                // Break Each call since no SlipCompliances can be processed
+                return false;
+            }
+
+            if (_slipCmdComp->Data().size() == 2) {
+                slipComplianceShape->SetPrimarySlipCompliance(
+                    _slipCmdComp->Data()[0]);
+                slipComplianceShape->SetSecondarySlipCompliance(
+                    _slipCmdComp->Data()[1]);
+            }
+
+            return true;
+        });
+
     // Update model angular velocity
     _ecm.Each<components::Model, components::AngularVelocityCmd>(
         [&](const Entity& _entity,
@@ -1474,6 +1630,13 @@ void Physics::Impl::UpdatePhysics(const ignition::gazebo::UpdateInfo& _info,
             auto modelIt = this->entityModelMap.find(_entity);
             if (modelIt == this->entityModelMap.end())
                 return true;
+
+            // angular vel cmd currently not supported for nested models
+            if (_entity != topLevelModel(_entity, _ecm)) {
+                ignerr << "Unable to set angular velocity for nested models."
+                       << std::endl;
+                return true;
+            }
 
             auto freeGroup = modelIt->second->FindFreeGroup();
             if (!freeGroup)
@@ -1487,6 +1650,14 @@ void Physics::Impl::UpdatePhysics(const ignition::gazebo::UpdateInfo& _info,
             auto worldAngularVelFeature = entityCast(
                 _entity, freeGroup, this->entityWorldVelocityCommandMap);
             if (!worldAngularVelFeature) {
+                static bool informed{false};
+                if (!informed) {
+                    igndbg
+                        << "Attempting to set model angular velocity, but the "
+                        << "physics engine doesn't support velocity commands. "
+                        << "Velocity won't be set." << std::endl;
+                    informed = true;
+                }
                 return true;
             }
 
@@ -1505,6 +1676,13 @@ void Physics::Impl::UpdatePhysics(const ignition::gazebo::UpdateInfo& _info,
             if (modelIt == this->entityModelMap.end())
                 return true;
 
+            // linear vel cmd currently not supported for nested models
+            if (_entity != topLevelModel(_entity, _ecm)) {
+                ignerr << "Unable to set linear velocity for nested models."
+                       << std::endl;
+                return true;
+            }
+
             auto freeGroup = modelIt->second->FindFreeGroup();
             if (!freeGroup)
                 return true;
@@ -1517,6 +1695,14 @@ void Physics::Impl::UpdatePhysics(const ignition::gazebo::UpdateInfo& _info,
             auto worldLinearVelFeature = entityCast(
                 _entity, freeGroup, this->entityWorldVelocityCommandMap);
             if (!worldLinearVelFeature) {
+                static bool informed{false};
+                if (!informed) {
+                    igndbg
+                        << "Attempting to set model linear velocity, but the "
+                        << "physics engine doesn't support velocity commands. "
+                        << "Velocity won't be set." << std::endl;
+                    informed = true;
+                }
                 return true;
             }
 
@@ -1648,6 +1834,40 @@ void Physics::Impl::Step(const std::chrono::steady_clock::duration& _dt)
     }
 }
 
+ignition::math::Pose3d
+Physics::Impl::RelativePose(const Entity& _from,
+                            const Entity& _to,
+                            const EntityComponentManager& _ecm) const
+{
+    math::Pose3d transform;
+
+    if (_from == _to)
+        return transform;
+
+    auto currentEntity = _to;
+    auto parentComp = _ecm.Component<components::ParentEntity>(_to);
+    while (parentComp) {
+        auto parentEntity = parentComp->Data();
+
+        // get the entity pose
+        auto entityPoseComp = _ecm.Component<components::Pose>(currentEntity);
+
+        // update transform
+        transform = entityPoseComp->Data() * transform;
+
+        if (parentEntity == _from)
+            break;
+
+        // set current entity to parent
+        currentEntity = parentEntity;
+
+        // get entity's parent
+        parentComp = _ecm.Component<components::ParentEntity>(parentEntity);
+    }
+
+    return transform;
+}
+
 void Physics::Impl::UpdateSim(const ignition::gazebo::UpdateInfo& _info,
                               EntityComponentManager& _ecm)
 {
@@ -1668,44 +1888,58 @@ void Physics::Impl::UpdateSim(const ignition::gazebo::UpdateInfo& _info,
 
         auto linkIt = this->entityLinkMap.find(_entity);
         if (linkIt != this->entityLinkMap.end()) {
+            // get top level model of this link
+            auto topLevelModelEnt = topLevelModel(_parent->Data(), _ecm);
+
             auto canonicalLink =
                 _ecm.Component<components::CanonicalLink>(_entity);
-
-            // get the pose component of the parent model
-            const components::Pose* parentPose =
-                _ecm.Component<components::Pose>(_parent->Data());
 
             auto frameData = linkIt->second->FrameDataRelativeToWorld();
             const auto& worldPose = frameData.pose;
 
-            // if the parentPose is a nullptr, something is wrong with ECS
-            // creation
-            if (!parentPose) {
-                ignerr << "The pose component of " << _parent->Data()
-                       << " could not be found. This should never happen!\n";
-                return true;
-            }
             if (canonicalLink) {
-                // This is the canonical link, update the model
-                // The Pose component, _pose, of this link is the initial
-                // transform of the link w.r.t its model. This component
-                // never changes because it's "fixed" to the model. Instead,
-                // we change the model's pose here. The physics engine gives
-                // us the pose of this link relative to world so to set the
-                // model's pose, we have to post-multiply it by the inverse
-                // of the initial transform of the link w.r.t to its model.
-                auto mutableParentPose =
-                    _ecm.Component<components::Pose>(_parent->Data());
-                *(mutableParentPose) = components::Pose(
-                    _pose->Data().Inverse() + math::eigen3::convert(worldPose));
-                _ecm.SetChanged(_parent->Data(),
+                // This is the canonical link, update the top level model.
+                // The pose of this link w.r.t its top level model never
+                // changes because it's "fixed" to the model. Instead, we
+                // change the top level model's pose here. The physics
+                // engine gives us the pose of this link relative to world
+                // so to set the top level model's pose, we have to
+                // post-multiply it by the inverse of the transform of the
+                // link w.r.t to its top level model.
+                math::Pose3d linkPoseFromTopLevelModel;
+                linkPoseFromTopLevelModel =
+                    this->RelativePose(topLevelModelEnt, _entity, _ecm);
+
+                // update top level model's pose
+                auto mutableModelPose =
+                    _ecm.Component<components::Pose>(topLevelModelEnt);
+                *(mutableModelPose) =
+                    components::Pose(math::eigen3::convert(worldPose)
+                                     * linkPoseFromTopLevelModel.Inverse());
+
+                _ecm.SetChanged(topLevelModelEnt,
                                 components::Pose::typeId,
                                 ComponentState::PeriodicChange);
             }
             else {
-                // Compute the relative pose of this link from the model
+                // Compute the relative pose of this link from the top level
+                // model first get the world pose of the top level model
+                auto worldComp =
+                    _ecm.Component<components::ParentEntity>(topLevelModelEnt);
+                // if the worldComp is a nullptr, something is wrong with ECS
+                if (!worldComp) {
+                    ignerr
+                        << "The parent component of " << topLevelModelEnt
+                        << " could not be found. This should never happen!\n";
+                    return true;
+                }
+                math::Pose3d parentWorldPose = this->RelativePose(
+                    worldComp->Data(), _parent->Data(), _ecm);
+
+                // Unlike canonical links, pose of regular links can move
+                // relative. to the parent. Same for links inside nested models.
                 *_pose = components::Pose(math::eigen3::convert(worldPose)
-                                          + parentPose->Data().Inverse());
+                                          + parentWorldPose.Inverse());
                 _ecm.SetChanged(_entity,
                                 components::Pose::typeId,
                                 ComponentState::PeriodicChange);
@@ -1843,9 +2077,6 @@ void Physics::Impl::UpdateSim(const ignition::gazebo::UpdateInfo& _info,
                 _ecm.SetChanged(
                     _entity, components::AngularAcceleration::typeId, state);
             }
-        }
-        else {
-            ignwarn << "Unknown link with id " << _entity << " found\n";
         }
         return true;
     });
@@ -2032,6 +2263,12 @@ void Physics::Impl::UpdateSim(const ignition::gazebo::UpdateInfo& _info,
     _ecm.Each<components::JointVelocityCmd>(
         [&](const Entity&, components::JointVelocityCmd* _vel) -> bool {
             std::fill(_vel->Data().begin(), _vel->Data().end(), 0.0);
+            return true;
+        });
+
+    _ecm.Each<components::SlipComplianceCmd>(
+        [&](const Entity&, components::SlipComplianceCmd* _slip) -> bool {
+            std::fill(_slip->Data().begin(), _slip->Data().end(), 0.0);
             return true;
         });
 

--- a/cpp/scenario/plugins/Physics/Physics.h
+++ b/cpp/scenario/plugins/Physics/Physics.h
@@ -18,13 +18,36 @@
 #ifndef SCENARIO_PLUGINS_GAZEBO_PHYSICS
 #define SCENARIO_PLUGINS_GAZEBO_PHYSICS
 
-#include <ignition/gazebo/System.hh>
-#include <ignition/physics/FeatureList.hh>
-#include <ignition/physics/RequestFeatures.hh>
-
 #include <memory>
 #include <unordered_map>
 #include <utility>
+
+#include <ignition/gazebo/System.hh>
+#include <ignition/physics/FeatureList.hh>
+#include <ignition/physics/FindFeatures.hh>
+#include <ignition/physics/RequestFeatures.hh>
+
+// Features need to be defined ahead of entityCast
+#include <ignition/physics/BoxShape.hh>
+#include <ignition/physics/CylinderShape.hh>
+#include <ignition/physics/FixedJoint.hh>
+#include <ignition/physics/ForwardStep.hh>
+#include <ignition/physics/FrameSemantics.hh>
+#include <ignition/physics/FreeGroup.hh>
+#include <ignition/physics/GetBoundingBox.hh>
+#include <ignition/physics/GetContacts.hh>
+#include <ignition/physics/Joint.hh>
+#include <ignition/physics/Link.hh>
+#include <ignition/physics/RemoveEntities.hh>
+#include <ignition/physics/Shape.hh>
+#include <ignition/physics/SphereShape.hh>
+#include <ignition/physics/mesh/MeshShape.hh>
+#include <ignition/physics/sdf/ConstructCollision.hh>
+#include <ignition/physics/sdf/ConstructJoint.hh>
+#include <ignition/physics/sdf/ConstructLink.hh>
+#include <ignition/physics/sdf/ConstructModel.hh>
+#include <ignition/physics/sdf/ConstructNestedModel.hh>
+#include <ignition/physics/sdf/ConstructWorld.hh>
 
 namespace scenario::plugins::gazebo {
     class Physics;


### PR DESCRIPTION
Follows up #258. This time it alignes the system up to https://github.com/ignitionrobotics/ign-gazebo/commit/4341bb2b29ebd810c17d1e7edf5c931d5273b95e (see full history of ign-gazebo4 [here](https://github.com/ignitionrobotics/ign-gazebo/commits/ign-gazebo4/src/systems/physics)).

[Full diff](https://github.com/ignitionrobotics/ign-gazebo/compare/85cc042aa663b1efa2188d5c1133e2ced833e1c4..4341bb2b29ebd810c17d1e7edf5c931d5273b95e) wrt #258 (filter for only `Physics.cc` and `Physics.hh`).