### PR TITLE
Force loading tensorflow shared libraries to prevent segfault

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -130,7 +130,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y --no-install-recommends \
-            python3-numpy libxml2-dev coinor-libipopt-dev libeigen3-dev libassimp-dev swig
+            libxml2-dev coinor-libipopt-dev libeigen3-dev libassimp-dev swig
 
       # =============
       # Build project

--- a/bindings/__init__.py
+++ b/bindings/__init__.py
@@ -82,7 +82,8 @@ def import_gazebo() -> None:
 
     # Preload the shared libraries of tensorflow if the package is installed.
     # If tensorflow is imported after scenario.bindings.gazebo, the application segfaults.
-    preload_tensorflow_shared_libraries()
+    if os.environ.get("SCENARIO_DISABLE_TENSORFLOW_PRELOAD") != "1":
+        preload_tensorflow_shared_libraries()
 
     # Import SWIG bindings
     # See https://github.com/robotology/gym-ignition/issues/7

--- a/bindings/__init__.py
+++ b/bindings/__init__.py
@@ -42,11 +42,47 @@ def setup_gazebo_environment() -> None:
     os.environ["IGN_GAZEBO_SYSTEM_PLUGIN_PATH"] = ign_gazebo_system_plugin_path
 
 
+def preload_tensorflow_shared_libraries() -> None:
+
+    # Check if tensorflow is installed
+    import importlib.util
+    spec = importlib.util.find_spec("tensorflow")
+
+    if spec is None:
+        return
+
+    # Get the tensorflow __init__ location
+    import pathlib
+    init = pathlib.Path(spec.origin)
+
+    # Get the tensorflow top-level folder
+    tensorflow_dir = init.parent
+    assert tensorflow_dir.is_dir()
+
+    # Get the tensorflow/python folder
+    tensorflow_python_dir = tensorflow_dir / "python"
+    assert tensorflow_python_dir.is_dir()
+
+    # Load the main shared library
+    for lib in tensorflow_dir.glob("*tensorflow*.so*"):
+        import ctypes
+        ctypes.CDLL(str(lib))
+
+    # Load all the shared libraries inside tensorflow/python
+    for lib in tensorflow_python_dir.glob("_*.so"):
+        import ctypes
+        ctypes.CDLL(str(lib))
+
+
 def import_gazebo() -> None:
 
     # Check the the module was never loaded by someone else
     if "scenario.bindings._gazebo" in sys.modules:
         raise ImportError("Failed to load ScenarI/O Gazebo with custom dlopen flags")
+
+    # Preload the shared libraries of tensorflow if the package is installed.
+    # If tensorflow is imported after scenario.bindings.gazebo, the application segfaults.
+    preload_tensorflow_shared_libraries()
 
     # Import SWIG bindings
     # See https://github.com/robotology/gym-ignition/issues/7

--- a/python/gym_ignition/rbd/idyntree/inverse_kinematics_nlp.py
+++ b/python/gym_ignition/rbd/idyntree/inverse_kinematics_nlp.py
@@ -187,8 +187,7 @@ class InverseKinematicsNLP:
 
         q = rbd.idyntree.numpy.FromNumPy.to_idyntree_dyn_vector(array=joint_configuration)
 
-        if not self._ik.setCurrentRobotConfiguration(baseConfiguration=H,
-                                                     jointConfiguration=q):
+        if not self._ik.setCurrentRobotConfiguration(H, q):
             raise RuntimeError("Failed to set the current robot configuration")
 
         if not self._floating_base:


### PR DESCRIPTION
The segfault is a know problem and it is already documented in the FAQs:

https://github.com/robotology/gym-ignition/blob/321df6a2f93da829682ead2f428022ec1c4ef416/docs/sphinx/info/faq.rst#L4-L18

This PR is an attempt to prevent the occurrence, similar to https://github.com/apache/arrow/pull/2210. Additional information can be found in https://github.com/robotology/gym-ignition/issues/279#issuecomment-774730540.

Note that loading only the shared libraries is much faster than loading the entire `tensorflow` package.