### PR TITLE
improve insertWorldFromSDF docs

### DIFF
--- a/cpp/scenario/gazebo/include/scenario/gazebo/GazeboSimulator.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/GazeboSimulator.h
@@ -146,6 +146,9 @@ public:
      * inserted. The default empty world does not have the ground plane nor
      * any physics. Both can be added by operating on the ``World`` object.
      *
+     * @note This function can only be used while the simulator object is
+     * uninitialized.
+     *
      * @param worldFile The path to the SDF world file.
      * @param worldName Optionally override the name of the world defined in the
      * SDF world file.

--- a/cpp/scenario/gazebo/src/GazeboSimulator.cpp
+++ b/cpp/scenario/gazebo/src/GazeboSimulator.cpp
@@ -384,7 +384,7 @@ bool GazeboSimulator::insertWorldFromSDF(const std::string& worldFile,
                                          const std::string& worldName)
 {
     if (this->initialized()) {
-        sMessage << "Worlds must be inserted before the initialization"
+        sError << "Worlds must be inserted before the initialization"
                  << std::endl;
         return false;
     }


### PR DESCRIPTION
As per #296 this PR improves the documentation of `insertWorldFromSDF` by (1) escalating the message of calling the function on an initialized simulator from `sMessage` to `sError` and (2) adding a note to the documentation that it can only be called on an initialized simulator.