### PR TITLE
Bump Ignition distribution to Edifice

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     build:
       args:
         from: diegoferigo/gym-ignition:base
-        ignition_codename: dome
+        ignition_codename: edifice
         CMAKE_BUILD_TYPE: Debug
       context: .
       dockerfile: cicd-devel.Dockerfile
@@ -50,7 +50,7 @@ services:
     build:
       args:
         from: diegoferigo/gym-ignition:base
-        ignition_codename: dome
+        ignition_codename: edifice
         CMAKE_BUILD_TYPE: Release
       context: .
       dockerfile: cicd-devel.Dockerfile

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -20,6 +20,7 @@ jobs:
           - User
           - Developer
         ignition:
+          - edifice
           - dome
           # - citadel
 
@@ -163,13 +164,13 @@ jobs:
 
       # User installation
       - name: '[User] Create wheel'
-        if: matrix.type == 'User' && matrix.ignition == 'dome'
+        if: matrix.type == 'User' && matrix.ignition == 'edifice'
         shell: bash -i -e {0}
         run: pip3 wheel -w dist/ .
       # Note: calling "pip wheel" with "--global-option" forces dependencies to be build from their sdist.
       #       Since it's very slow, we create the wheel from setup.py without isolation.
       - name: '[User] Create wheel'
-        if: matrix.type == 'User' && matrix.ignition != 'dome'
+        if: matrix.type == 'User' && matrix.ignition != 'edifice'
         shell: bash -i -e {0}
         run: |
           pip3 install \
@@ -265,8 +266,8 @@ jobs:
       - name: Publish package to PyPI
         if: |
           github.repository == 'robotology/gym-ignition' && matrix.type == 'User' &&
-          ((github.event_name == 'release' && github.event.action == 'published' && matrix.ignition == 'dome') ||
-           (github.event_name == 'push' && matrix.ignition == 'dome' && github.ref == 'refs/heads/devel'))
+          ((github.event_name == 'release' && github.event.action == 'published' && matrix.ignition == 'edifice') ||
+           (github.event_name == 'push' && matrix.ignition == 'edifice' && github.ref == 'refs/heads/devel'))
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -193,11 +193,13 @@ jobs:
       # ============
 
       - name: '[ScenarI/O] Python Tests'
+        shell: bash -i -e {0}
         run: |
           cd tests
           pytest -m "scenario"
 
       - name: '[ScenarI/O] Python Tests with Valgrind'
+        shell: bash -i -e {0}
         if: failure()
         run: |
           apt-get install -y --no-install-recommends valgrind
@@ -206,11 +208,13 @@ jobs:
           valgrind --log-file=/tmp/valgrind.log pytest -s -m "scenario" || colour-valgrind -t /tmp/valgrind.log
 
       - name: '[gym_ignition] Python Tests'
+        shell: bash -i -e {0}
         run: |
           cd tests
           pytest -m "gym_ignition"
 
       - name: '[gym_ignition] Python Tests with Valgrind'
+        shell: bash -i -e {0}
         if: failure()
         run: |
           pip3 install colour-valgrind

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -110,7 +110,8 @@ jobs:
           cd /workspace/src
           wget -O - ${TAGS_YAML} | vcs import
           SYSTEM_VERSION=$(lsb_release -cs)
-          apt-get -y install $(sort -u $(find . -iname 'packages-'$SYSTEM_VERSION'.apt' -o -iname 'packages.apt') | tr '\n' ' ')
+          #apt-get -y install $(sort -u $(find . -iname 'packages-'$SYSTEM_VERSION'.apt' -o -iname 'packages.apt') | tr '\n' ' ')
+          apt-get -y install $(sort -u $(find . -iname 'packages-'$(lsb_release -cs)'.apt' -o -iname 'packages.apt') | grep -v -E "^libignition|^libsdformat")
           cd /workspace
           colcon graph
           colcon build \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ add_install_rpath_support(
 if(NOT IGNITION_DISTRIBUTION)
 
     include(FindIgnitionDistribution)
-    set(SUPPORTED_IGNITION_DISTRIBUTIONS "Dome" "Citadel")
+    set(SUPPORTED_IGNITION_DISTRIBUTIONS "Edifice" "Dome" "Citadel")
 
     foreach(distribution IN LISTS SUPPORTED_IGNITION_DISTRIBUTIONS)
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ our simulations, visit the _Motivations_ section of the [website](https://roboto
 
 ## Setup
 
-1. Install the latest Ignition suite following the [official instructions](https://ignitionrobotics.org/docs/dome).
+1. Install the Ignition suite following the [official instructions](https://ignitionrobotics.org/docs/edifice).
 1. Execute `pip install gym-ignition`, preferably in a virtual environment.
 
 **Note**: `gym-ignition` currently only supports the latest version of the ignition suite. For more information on supported versions please refer to the [Support Policy](https://robotology.github.io/gym-ignition/master/installation/support_policy.html).

--- a/cmake/FindIgnitionDistribution.cmake
+++ b/cmake/FindIgnitionDistribution.cmake
@@ -7,6 +7,7 @@
 # In the future we could pull and parse the tags.yaml file.
 set(IGNITION-GAZEBO_CITADEL_VER 3)
 set(IGNITION-GAZEBO_DOME_VER 4)
+set(IGNITION-GAZEBO_EDIFICE_VER 5)
 
 macro(find_ignition_distribution)
 

--- a/cmake/ImportTargetsEdifice.cmake
+++ b/cmake/ImportTargetsEdifice.cmake
@@ -1,0 +1,73 @@
+include(AliasImportedTarget)
+
+# https://ignitionrobotics.org/docs/edifice/install#edifice-libraries
+
+alias_imported_target(
+    PACKAGE_ORIG sdformat11
+    PACKAGE_DEST sdformat
+    TARGETS_ORIG sdformat11
+    TARGETS_DEST sdformat
+    NAMESPACE_ORIG sdformat11
+    NAMESPACE_DEST sdformat
+    REQUIRED TRUE
+    )
+
+alias_imported_target(
+    PACKAGE_ORIG ignition-gazebo5
+    PACKAGE_DEST ignition-gazebo
+    TARGETS_ORIG ignition-gazebo5 core
+    TARGETS_DEST ignition-gazebo  core
+    NAMESPACE_ORIG ignition-gazebo5
+    NAMESPACE_DEST ignition-gazebo
+    REQUIRED TRUE
+    )
+
+alias_imported_target(
+    PACKAGE_ORIG ignition-common4
+    PACKAGE_DEST ignition-common
+    TARGETS_ORIG ignition-common4
+    TARGETS_DEST ignition-common
+    NAMESPACE_ORIG ignition-common4
+    NAMESPACE_DEST ignition-common
+    REQUIRED TRUE
+    )
+
+alias_imported_target(
+    PACKAGE_ORIG ignition-sensors5-all
+    PACKAGE_DEST ignition-sensors-all
+    TARGETS_ORIG ignition-sensors5-all
+    TARGETS_DEST ignition-sensors-all
+    NAMESPACE_ORIG ignition-sensors5
+    NAMESPACE_DEST ignition-sensors
+    REQUIRED TRUE
+    )
+
+alias_imported_target(
+    PACKAGE_ORIG ignition-rendering5
+    PACKAGE_DEST ignition-rendering
+    TARGETS_ORIG ignition-rendering5
+    TARGETS_DEST ignition-rendering
+    NAMESPACE_ORIG ignition-rendering5
+    NAMESPACE_DEST ignition-rendering
+    REQUIRED TRUE
+    )
+
+alias_imported_target(
+    PACKAGE_ORIG ignition-gazebo5-rendering
+    PACKAGE_DEST ignition-gazebo-rendering
+    TARGETS_ORIG ignition-gazebo5-rendering
+    TARGETS_DEST ignition-gazebo-rendering
+    NAMESPACE_ORIG ignition-gazebo5
+    NAMESPACE_DEST ignition-gazebo
+    REQUIRED TRUE
+    )
+
+alias_imported_target(
+    PACKAGE_ORIG ignition-physics4
+    PACKAGE_DEST ignition-physics
+    TARGETS_ORIG ignition-physics4
+    TARGETS_DEST ignition-physics
+    NAMESPACE_ORIG ignition-physics4
+    NAMESPACE_DEST ignition-physics
+    REQUIRED TRUE
+    )

--- a/docs/sphinx/info/faq.rst
+++ b/docs/sphinx/info/faq.rst
@@ -24,7 +24,7 @@ On GNU/Linux distributions that ship an old OpenGL version, the GUI could fail t
 error like *Unable to create the rendering window*.
 The reason is that Ignition Gazebo has `ogre-next <https://github.com/OGRECave/ogre-next>`_
 (also known as ogre2) as default rendering engine, and it requires OpenGL greater than 3.3.
-You can find more details `here <https://github.com/ignitionrobotics/blob/master/docs/dome/install_ubuntu_src.md#unable-to-create-the-rendering-window>`_.
+You can find more details `here <https://github.com/ignitionrobotics/docs/blob/master/edifice/troubleshooting.md#unable-to-create-the-rendering-window>`_.
 
 The workaround we recommend is modifying the file ``~/.ignition/gazebo/gui.config`` as follows:
 

--- a/docs/sphinx/installation/support_policy.rst
+++ b/docs/sphinx/installation/support_policy.rst
@@ -12,15 +12,16 @@ We do not yet provide direct support to other operating systems.
 
 The table below recaps the project requirements of the :ref:`Stable <installation_stable>` and :ref:`Nightly <installation_nightly>` channels:
 
-+-------------+-----------------+--------+------------------+----------+------------+---------+
-| Channel     |       C++       | Python |     Ignition     |  Ubuntu  | macOS [*]_ | Windows |
-+=============+=================+========+==================+==========+============+=========+
-| **Stable**  | >= gcc8, clang6 | >= 3.8 | `Dome`_ (binary) | >= 20.04 |     No     |    No   |
-+-------------+-----------------+--------+------------------+----------+------------+---------+
-| **Nightly** | >= gcc8, clang6 | >= 3.8 | `Dome`_ (source) | >= 20.04 |     No     |    No   |
-+-------------+-----------------+--------+------------------+----------+------------+---------+
++-------------+-----------------+--------+---------------------+----------+------------+---------+
+| Channel     |       C++       | Python |      Ignition       |  Ubuntu  | macOS [*]_ | Windows |
++=============+=================+========+=====================+==========+============+=========+
+| **Stable**  | >= gcc8, clang6 | >= 3.8 | `Dome`_ (binary)    | >= 20.04 |     No     |    No   |
++-------------+-----------------+--------+---------------------+----------+------------+---------+
+| **Nightly** | >= gcc8, clang6 | >= 3.8 | `Edifice`_ (source) | >= 20.04 |     No     |    No   |
++-------------+-----------------+--------+---------------------+----------+------------+---------+
 
 .. _`Dome`: https://ignitionrobotics.org/docs/dome/install
+.. _`Edifice`: https://ignitionrobotics.org/docs/edifice/install
 
 .. [*] Ignition officially supports macOS and also ``gym-ignition`` could be installed on this platform.
        However, we do not currently test this configuration and we cannot guarantee support.


### PR DESCRIPTION
- [Ignition Edifice Release](https://community.gazebosim.org/t/ignition-edifice-release/893)
- [Roadmap](https://ignitionrobotics.org/docs/all/roadmap#edifice)
- [Community meeting: Edifice (March 2021)](https://community.gazebosim.org/t/community-meeting-edifice-march-2021/851)
- [Edifice Demos! Ignition Community Meeting (March 2021)](https://www.youtube.com/watch?v=aKpUSXgZXYM)
- [Feature comparison](https://ignitionrobotics.org/docs/edifice/comparison)

---

- [x] Update CMake logic
- [x] Update CI to:
  - [x] Build and test gym-ignition against Edifice
  - [x] Build and upload wheels by default against Edifice 
  - [x] Build docker images with Edifice 
- [x] Check that all documentation is updated
- [x] Check that building the wheel locally succeeds by passing custom Dome flag to pip / setup.py (even if not supported officially)

<!--
## Physics System alignment

Follows up #284. This time it aligns the system up to https://github.com/ignitionrobotics/ign-gazebo/commit/a84ec51c2fddcc09eeb0ed26b31f8de669c1ce56#diff-313a35c6783313d7722e6b2e2dac1708f069daee5c8518c3bb56426266966038 (see full history of ign-gazebo4 [here](https://github.com/ignitionrobotics/ign-gazebo/commits/ign-gazebo4/src/systems/physics)).

[Full diff](https://github.com/ignitionrobotics/ign-gazebo/compare/4341bb2b29ebd810c17d1e7edf5c931d5273b95e..a84ec51c2fddcc09eeb0ed26b31f8de669c1ce56) wrt #284 (filter for only `Physics.cc` and `Physics.hh`).
-->