### PR TITLE
Resolve Fuel resources when included in models and worlds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 cmake_minimum_required(VERSION 3.16)
-project(Scenario VERSION 1.0.1)
+project(Scenario VERSION 1.1.0)
 
 # Add custom functions / macros
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 cmake_minimum_required(VERSION 3.16)
-project(Scenario VERSION 1.0)
+project(Scenario VERSION 1.0.1)
 
 # Add custom functions / macros
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@
                 <a href="https://github.com/robotology/gym-ignition/actions">
                 <img src="https://github.com/robotology/gym-ignition/workflows/Docker%20Images/badge.svg" alt="Docker Images" />
                 </a>
-                <a href="https://www.codacy.com/app/diegoferigo/gym-ignition?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=diegoferigo/gym-ignition&amp;utm_campaign=Badge_Grade">
-                <img src="https://api.codacy.com/project/badge/Grade/899a7c8304e14ed9b2330eb309cdad15" alt="Codacy Badge" />
+                <a href="ttps://www.codacy.com/gh/robotology/gym-ignition/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=robotology/gym-ignition&amp;utm_campaign=Badge_Grade">
+                <img src="https://api.codacy.com/project/badge/Grade/5536b05f8be94483b64ee883e7170a39" alt="Codacy Badge" />
                 </a>
             </td>
         </tr>   

--- a/cmake/ImportTargetsDome.cmake
+++ b/cmake/ImportTargetsDome.cmake
@@ -71,3 +71,13 @@ alias_imported_target(
     NAMESPACE_DEST ignition-physics
     REQUIRED TRUE
     )
+
+    alias_imported_target(
+    PACKAGE_ORIG ignition-fuel_tools5
+    PACKAGE_DEST ignition-fuel_tools
+    TARGETS_ORIG ignition-fuel_tools5
+    TARGETS_DEST ignition-fuel_tools
+    NAMESPACE_ORIG ignition-fuel_tools5
+    NAMESPACE_DEST ignition-fuel_tools
+    REQUIRED TRUE
+    )

--- a/cpp/scenario/gazebo/CMakeLists.txt
+++ b/cpp/scenario/gazebo/CMakeLists.txt
@@ -99,7 +99,8 @@ target_link_libraries(ScenarioGazebo
     ${ignition-common.ignition-common}
     PRIVATE
     ScenarioCore::CoreUtils
-    ScenarioGazebo::ExtraComponents)
+    ScenarioGazebo::ExtraComponents
+    ${ignition-fuel_tools.ignition-fuel_tools})
 
 set_target_properties(ScenarioGazebo PROPERTIES
     PUBLIC_HEADER "${SCENARIO_GAZEBO_PUBLIC_HDRS}")
@@ -126,7 +127,8 @@ target_link_libraries(GazeboSimulator
     ScenarioCore::CoreUtils
     ScenarioGazebo::ScenarioGazebo
     ScenarioGazebo::ExtraComponents
-    ScenarioGazeboPlugins::ECMSingleton)
+    ScenarioGazeboPlugins::ECMSingleton
+    ${ignition-fuel_tools.ignition-fuel_tools})
 
 set_target_properties(GazeboSimulator PROPERTIES
     PUBLIC_HEADER include/scenario/gazebo/GazeboSimulator.h)

--- a/cpp/scenario/gazebo/src/GazeboSimulator.cpp
+++ b/cpp/scenario/gazebo/src/GazeboSimulator.cpp
@@ -136,6 +136,7 @@ public: // methods
 // ===============
 // GazeboSimulator
 // ===============
+
 GazeboSimulator::GazeboSimulator(const double stepSize,
                                  const double rtf,
                                  const size_t stepsPerRun)

--- a/cpp/scenario/gazebo/src/GazeboSimulator.cpp
+++ b/cpp/scenario/gazebo/src/GazeboSimulator.cpp
@@ -119,7 +119,7 @@ public: // attributes
 
 public: // methods
     Impl()
-        : fuelClient{new ignition::fuel_tools::FuelClient()}
+        : fuelClient{std::make_shared<ignition::fuel_tools::FuelClient>()}
     {}
 
     bool insertSDFWorld(const sdf::World& world);

--- a/cpp/scenario/gazebo/src/GazeboSimulator.cpp
+++ b/cpp/scenario/gazebo/src/GazeboSimulator.cpp
@@ -150,7 +150,7 @@ GazeboSimulator::GazeboSimulator(const double stepSize,
     pImpl->gazebo.physics.maxStepSize = stepSize;
 
     // Configure Fuel Callback
-    sdf::setFindCallback([this](const std::string uri) -> std::string {
+    sdf::setFindCallback([this](const std::string &uri) -> std::string {
         auto path = fetchResourceWithClient(uri, *pImpl.get()->fuelClient.get());
         return path;
     });

--- a/cpp/scenario/gazebo/src/GazeboSimulator.cpp
+++ b/cpp/scenario/gazebo/src/GazeboSimulator.cpp
@@ -109,19 +109,7 @@ public: // attributes
     using GazeboWorldPtr = std::shared_ptr<scenario::gazebo::World>;
     std::unordered_map<WorldName, GazeboWorldPtr> worlds;
 
-    // Attributes related to Fuel Support
-    // Note to devs: sdformat10 uses a global parser config. Starting with
-    // stformat11, this practice is depreciated in favour of creating a local
-    // parser config that is fed into all functions reading sdf
-    // (sdf::readFile(...), etc.) with Ignition Edifice and beyond, this will
-    // need an to be amended with the local sdf config.
-    std::shared_ptr<ignition::fuel_tools::FuelClient> fuelClient;
-
 public: // methods
-    Impl()
-        : fuelClient{std::make_shared<ignition::fuel_tools::FuelClient>()}
-    {}
-
     bool insertSDFWorld(const sdf::World& world);
     std::shared_ptr<ignition::gazebo::Server> getServer();
 
@@ -150,9 +138,10 @@ GazeboSimulator::GazeboSimulator(const double stepSize,
     pImpl->gazebo.physics.maxStepSize = stepSize;
 
     // Configure Fuel Callback
-    sdf::setFindCallback([this](const std::string& uri) -> std::string {
-        const auto path = ignition::fuel_tools::fetchResourceWithClient(
-            uri, *pImpl->fuelClient);
+    sdf::setFindCallback([](const std::string& uri) -> std::string {
+        auto fuelClient = ignition::fuel_tools::FuelClient();
+        const auto path =
+            ignition::fuel_tools::fetchResourceWithClient(uri, fuelClient);
         return path;
     });
 }

--- a/cpp/scenario/gazebo/src/GazeboSimulator.cpp
+++ b/cpp/scenario/gazebo/src/GazeboSimulator.cpp
@@ -56,7 +56,7 @@
 #include <unordered_map>
 
 using namespace scenario::gazebo;
-using ignition::fuel_tools::ClientConfig;
+using ignition::fuel_tools::FuelClient;
 
 namespace scenario::gazebo::detail {
     struct PhysicsData;

--- a/cpp/scenario/gazebo/src/GazeboSimulator.cpp
+++ b/cpp/scenario/gazebo/src/GazeboSimulator.cpp
@@ -55,7 +55,6 @@
 #include <unordered_map>
 
 using namespace scenario::gazebo;
-using ignition::fuel_tools::FuelClient;
 
 namespace scenario::gazebo::detail {
     struct PhysicsData;
@@ -116,11 +115,11 @@ public: // attributes
     // parser config that is fed into all functions reading sdf
     // (sdf::readFile(...), etc.) with Ignition Edifice and beyond, this will
     // need an to be amended with the local sdf config.
-    std::shared_ptr<FuelClient> fuelClient;
+    std::shared_ptr<ignition::fuel_tools::FuelClient> fuelClient;
 
 public: // methods
     Impl()
-        : fuelClient{new FuelClient()}
+        : fuelClient{new ignition::fuel_tools::FuelClient()}
     {}
 
     bool insertSDFWorld(const sdf::World& world);

--- a/tests/assets/worlds/fuel_support.sdf
+++ b/tests/assets/worlds/fuel_support.sdf
@@ -1,0 +1,30 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <world name="default">
+    <include>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Ground Plane</uri>
+    </include>
+    <include>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Sun</uri>
+    </include>
+    <model name="box">
+      <pose>0 0 0.5 0 0 0</pose>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+    </model>
+  </world>
+</sdf>

--- a/tests/test_scenario/test_ignition_fuel.py
+++ b/tests/test_scenario/test_ignition_fuel.py
@@ -3,6 +3,7 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 import pytest
+
 pytestmark = pytest.mark.scenario
 
 from ..common import utils
@@ -10,14 +11,15 @@ from scenario import core
 from scenario import gazebo as scenario
 from ..common.utils import gazebo_fixture as gazebo
 
+from pathlib import Path
+
 # Set the verbosity
 scenario.set_verbosity(scenario.Verbosity_debug)
 
 
-@pytest.mark.parametrize("gazebo",
-                         [(0.001, 1.0, 1)],
-                         indirect=True,
-                         ids=utils.id_gazebo_fn)
+@pytest.mark.parametrize(
+    "gazebo", [(0.001, 1.0, 1)], indirect=True, ids=utils.id_gazebo_fn
+)
 def test_download_model_from_fuel(gazebo: scenario.GazeboSimulator):
 
     assert gazebo.initialize()
@@ -28,7 +30,8 @@ def test_download_model_from_fuel(gazebo: scenario.GazeboSimulator):
     # Download a model from Fuel (testing a name with spaces)
     model_name = "Electrical Box"
     model_sdf = scenario.get_model_file_from_fuel(
-        f"https://fuel.ignitionrobotics.org/openrobotics/models/{model_name}", False)
+        f"https://fuel.ignitionrobotics.org/openrobotics/models/{model_name}", False
+    )
     assert model_sdf
 
     assert world.insert_model(model_sdf, core.Pose_identity())
@@ -41,3 +44,18 @@ def test_download_model_from_fuel(gazebo: scenario.GazeboSimulator):
     assert other_model_name in world.model_names()
 
     assert gazebo.run()
+
+
+@pytest.mark.parametrize(
+    "gazebo", [(0.001, 1.0, 1)], indirect=True, ids=utils.id_gazebo_fn
+)
+def test_fuel_world(gazebo):
+    # (setup) load a world that includes a fuel model
+    worlds_folder = Path(__file__) / ".." / ".." / "assets" / "worlds"
+    world_file = worlds_folder / "fuel_support.sdf"
+    assert gazebo.insert_world_from_sdf(str(world_file.resolve()))
+    assert gazebo.initialize()
+    assert gazebo.run(paused=True)
+
+    # the actual test
+    assert "ground_plane" in gazebo.get_world().model_names()


### PR DESCRIPTION
Closes: #296
Closes: #174
Closes: #168

After digging into it, all that was needed is to specify a callback. I chose to implement it slightly differently than #174

Instead of adding fuel support to the GazeboWrapper, I added it directly to the (lower level?) `GazeboSimulator`. Loading fuel models requires a `FuelClient` which became an attribute of `GazeboSimulator` to avoid constantly re-instantiating it (I mimic this behavior from ign-gazebo).

I didn't find any C++ unit tests to add a test for downloading fuel models, so I didn't add one. I found some python tests, so I can add a test there if desired.

I experimented with it locally. It expands the include tags correctly, but I am getting other resource not found errors, so I am now investigating where they come from and if they are related to the download or to the world being misspecified.