### PR TITLE
Fix segfault with protobuf, torch, gym (atari), and ScenarIO

### DIFF
--- a/bindings/__init__.py
+++ b/bindings/__init__.py
@@ -74,6 +74,18 @@ def preload_tensorflow_shared_libraries() -> None:
         ctypes.CDLL(str(lib))
 
 
+def pre_import_gym() -> None:
+
+    # Check if gym is installed
+    import importlib.util
+    spec = importlib.util.find_spec("gym")
+
+    if spec is None:
+        return
+
+    import gym
+
+
 def import_gazebo() -> None:
 
     # Check the the module was never loaded by someone else
@@ -84,6 +96,11 @@ def import_gazebo() -> None:
     # If tensorflow is imported after scenario.bindings.gazebo, the application segfaults.
     if os.environ.get("SCENARIO_DISABLE_TENSORFLOW_PRELOAD") != "1":
         preload_tensorflow_shared_libraries()
+
+    # Import gym before scenario.bindings.gazebo. Similarly to tensorflow, also gym
+    # includes a module that imports protobuf, producing a similar segfault.
+    if os.environ.get("SCENARIO_DISABLE_GYM_PREIMPORT") != "1":
+        pre_import_gym()
 
     # Import SWIG bindings
     # See https://github.com/robotology/gym-ignition/issues/7


### PR DESCRIPTION
Similar to the infamous problems we have with tensorflow / protobuf, also a system with torch could segfault similarly :cold_sweat:

> [libprotobuf FATAL google/protobuf/stubs/common.cc:87] This program was compiled against version 3.5.1 of the Protocol Buffer runtime library, which is not compatible with the installed version (3.15.6).  Contact the program author for an update.  If you compiled the program yourself, make sure that your headers are from the same version of Protocol Buffers as your link-time library.  (Version verification failed in "../modules/dnn/misc/caffe/opencv-caffe.pb.cc".)
terminate called after throwing an instance of 'google::protobuf::FatalException'
  what():  This program was compiled against version 3.5.1 of the Protocol Buffer runtime library, which is not compatible with the installed version (3.15.6).  Contact the program author for an update.  If you compiled the program yourself, make sure that your headers are from the same version of Protocol Buffers as your link-time library.  (Version verification failed in "../modules/dnn/misc/caffe/opencv-caffe.pb.cc".)

<details>
<summary>stack trace</summary>

```
Current thread 0x00007f7921033740 (most recent call first):
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 1101 in create_module
  File "<frozen importlib._bootstrap>", line 556 in module_from_spec
  File "<frozen importlib._bootstrap>", line 657 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 975 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 991 in _find_and_load
  File "/conda/lib/python3.8/site-packages/gym/wrappers/atari_preprocessing.py", line 7 in <module>
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 783 in exec_module
  File "<frozen importlib._bootstrap>", line 671 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 975 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 991 in _find_and_load
  File "/conda/lib/python3.8/site-packages/gym/wrappers/__init__.py", line 5 in <module>
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 783 in exec_module
  File "<frozen importlib._bootstrap>", line 671 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 975 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 991 in _find_and_load
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1042 in _handle_fromlist
  File "/conda/lib/python3.8/site-packages/gym/__init__.py", line 14 in <module>
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 783 in exec_module
  File "<frozen importlib._bootstrap>", line 671 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 975 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 991 in _find_and_load
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 961 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 991 in _find_and_load
  File "/home/dferigo/git/gym-ignition/python/gym_ignition/utils/typing.py", line 5 in <module>
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 783 in exec_module
  File "<frozen importlib._bootstrap>", line 671 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 975 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 991 in _find_and_load
  File "/home/dferigo/git/gym-ignition/python/gym_ignition/utils/__init__.py", line 7 in <module>
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 783 in exec_module
  File "<frozen importlib._bootstrap>", line 671 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 975 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 991 in _find_and_load
  File "/home/dferigo/git/gym-ignition/python/gym_ignition/__init__.py", line 12 in <module>
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 783 in exec_module
  File "<frozen importlib._bootstrap>", line 671 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 975 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 991 in _find_and_load
  File "/home/dferigo/git/gym-ignition/examples/panda_pick_and_place.py", line 5 in <module>
```

</details>

This time, the culprit is `gym/wrappers/atari_preprocessing.py`. I found out that, as done for tensorflow, pre-importing `gym` fixes the problem.