### PR TITLE
Disable contact detection by default

### DIFF
--- a/cpp/scenario/gazebo/src/Link.cpp
+++ b/cpp/scenario/gazebo/src/Link.cpp
@@ -165,7 +165,7 @@ bool Link::createECMResources()
     m_ecm->CreateComponent(m_entity, components::LinearAcceleration());
     m_ecm->CreateComponent(m_entity, components::AngularAcceleration());
 
-    if (!this->enableContactDetection(true)) {
+    if (!this->enableContactDetection(false)) {
         sError << "Failed to enable contact detection" << std::endl;
         return false;
     }

--- a/docs/sphinx/getting_started/manipulation.rst
+++ b/docs/sphinx/getting_started/manipulation.rst
@@ -256,6 +256,12 @@ It shows the following functionalities:
     # Insert the Panda manipulator
     panda = gym_ignition_environments.models.panda.Panda(
         world=world, position=[-0.1, 0, 1.0])
+
+    # Enable contacts only for the finger links
+    panda.get_link("panda_leftfinger").to_gazebo().enable_contact_detection(True)
+    panda.get_link("panda_rightfinger").to_gazebo().enable_contact_detection(True)
+
+    # Process model insertion in the simulation
     gazebo.run(paused=True)
 
     # Monkey patch the class with finger helpers
@@ -427,4 +433,3 @@ It shows the following functionalities:
     # It is always a good practice to close the simulator.
     # In this case it is not required since above there is an infinite loop.
     # gazebo.close()
-

--- a/examples/panda_pick_and_place.py
+++ b/examples/panda_pick_and_place.py
@@ -221,6 +221,12 @@ gazebo.run(paused=True)
 # Insert the Panda manipulator
 panda = gym_ignition_environments.models.panda.Panda(
     world=world, position=[-0.1, 0, 1.0])
+
+# Enable contacts only for the finger links
+panda.get_link("panda_leftfinger").to_gazebo().enable_contact_detection(True)
+panda.get_link("panda_rightfinger").to_gazebo().enable_contact_detection(True)
+
+# Process model insertion in the simulation
 gazebo.run(paused=True)
 
 # Monkey patch the class with finger helpers

--- a/tests/test_scenario/test_contacts.py
+++ b/tests/test_scenario/test_contacts.py
@@ -84,6 +84,8 @@ def test_cube_contact(gazebo: scenario.GazeboSimulator,
     cube = world.get_model("cube")
 
     # Enable contact detection
+    assert not cube.contacts_enabled()
+    assert cube.enable_contacts(enable=True)
     assert cube.contacts_enabled()
 
     # The cube was inserted floating in the air with a 5cm gap wrt to ground.
@@ -153,7 +155,13 @@ def test_cube_multiple_contacts(gazebo: scenario.GazeboSimulator,
     cube2 = world.get_model("cube2")
 
     # Enable contact detection
+    assert not cube1.contacts_enabled()
+    assert cube1.enable_contacts(enable=True)
     assert cube1.contacts_enabled()
+
+    # Enable contact detection
+    assert not cube2.contacts_enabled()
+    assert cube2.enable_contacts(enable=True)
     assert cube2.contacts_enabled()
 
     # The cubes were inserted floating in the air with a 1mm gap wrt to ground.
@@ -180,6 +188,8 @@ def test_cube_multiple_contacts(gazebo: scenario.GazeboSimulator,
     assert len(world.model_names()) == 4
 
     cube3 = world.get_model("cube3")
+    assert not cube3.contacts_enabled()
+    assert cube3.enable_contacts(enable=True)
     assert cube3.contacts_enabled()
 
     gazebo.run(paused=True)


### PR DESCRIPTION
As discussed in #314, I was thinking that contact detection was disabled by default. This PR disables them.

The recommended way to use contact is enabling their detection either on a link level, or model-wise (less efficient).

https://github.com/robotology/gym-ignition/blob/bba62416e97fe5788019e32cae66355bcb9fe70a/cpp/scenario/core/include/scenario/core/Link.h#L153-L159

https://github.com/robotology/gym-ignition/blob/bba62416e97fe5788019e32cae66355bcb9fe70a/cpp/scenario/core/include/scenario/core/Model.h#L200-L207