### PR TITLE
DOC: add link to website at the top of the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 <b><a href="https://github.com/robotology/gym-ignition#setup">Setup</a></b>
 •
 <b><a href="https://github.com/robotology/gym-ignition#citation">Citation</a></b>
-</p>
 •
 <b><a href="https://robotology.github.io/gym-ignition/master/index.html">Website</a></b>
 </p>

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 •
 <b><a href="https://github.com/robotology/gym-ignition#citation">Citation</a></b>
 </p>
+•
+<b><a href="https://robotology.github.io/gym-ignition/master/index.html">Website</a></b>
+</p>
 
 <div align="center">
 <p><br/></p>


### PR DESCRIPTION
Mostly a QoL change. There is already a link to the website in the readme, but I thought adding a second one somewhere prominent won't hurt and will likely improve navigation.

Note: this PR targets the master branch. It seems that master and devel have diverged and require a manual merge (retargeting this branch onto devel causes a merge conflict).