### PR TITLE
Address sdformat11 deprecations

### DIFF
--- a/cpp/scenario/gazebo/include/scenario/gazebo/helpers.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/helpers.h
@@ -149,9 +149,7 @@ namespace scenario::gazebo::utils {
     sdf::World renameSDFWorld(const sdf::World& world,
                               const std::string& newWorldName);
 
-    bool renameSDFModel(sdf::Root& sdfRoot,
-                        const std::string& newModelName,
-                        const size_t modelIndex = 0);
+    bool renameSDFModel(sdf::Root& sdfRoot, const std::string& newModelName);
 
     bool updateSDFPhysics(sdf::Root& sdfRoot,
                           const double maxStepSize,

--- a/cpp/scenario/gazebo/include/scenario/gazebo/utils.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/utils.h
@@ -112,15 +112,15 @@ namespace scenario::gazebo::utils {
     /**
      * Get the name of a model from a SDF file.
      *
+     * @note sdformat supports only one model per SDF file.
+     *
      * @param fileName An SDF file. It could be either an absolute path
      *        to the file or the file name if the parent folder is part
      *        of the ``IGN_GAZEBO_RESOURCE_PATH`` environment variable.
-     * @param modelIndex The index of the model in the SDF file. By
-     *        default it finds the first model.
-     * @return The name of the model.
+     * @return The name of the model if the file was found and is valid,
+     *         an empty string otherwise.
      */
-    std::string getModelNameFromSdf(const std::string& fileName,
-                                    const size_t modelIndex = 0);
+    std::string getModelNameFromSdf(const std::string& fileName);
 
     /**
      * Get the name of a world from a SDF file.
@@ -130,7 +130,8 @@ namespace scenario::gazebo::utils {
      *        of the ``IGN_GAZEBO_RESOURCE_PATH`` environment variable.
      * @param worldIndex The index of the world in the SDF file. By
      *        default it finds the first world.
-     * @return The name of the world.
+     * @return The name of the world if the file was found and is valid,
+     *         an empty string otherwise.
      */
     std::string getWorldNameFromSdf(const std::string& fileName,
                                     const size_t worldIndex = 0);

--- a/cpp/scenario/gazebo/src/utils.cpp
+++ b/cpp/scenario/gazebo/src/utils.cpp
@@ -106,8 +106,7 @@ std::string utils::getSdfString(const std::string& fileName)
     return root->Element()->ToString("");
 }
 
-std::string utils::getModelNameFromSdf(const std::string& fileName,
-                                       const size_t modelIndex)
+std::string utils::getModelNameFromSdf(const std::string& fileName)
 {
     std::string absFileName = findSdfFile(fileName);
 
@@ -116,25 +115,18 @@ std::string utils::getModelNameFromSdf(const std::string& fileName,
         return {};
     }
 
-    auto root = utils::getSdfRootFromFile(absFileName);
+    const auto root = utils::getSdfRootFromFile(absFileName);
 
     if (!root) {
         return {};
     }
 
-    if (root->ModelCount() == 0) {
-        sError << "Didn't find any model in file " << fileName << std::endl;
-        return {};
+    if (const auto model = root->Model()) {
+        return model->Name();
     }
 
-    if (modelIndex >= root->ModelCount()) {
-        sError << "Model with index " << modelIndex
-               << " not found. The model has only " << root->ModelCount()
-               << " model(s)" << std::endl;
-        return {};
-    }
-
-    return root->ModelByIndex(modelIndex)->Name();
+    sError << "No model found in file " << fileName << std::endl;
+    return {};
 }
 
 std::string utils::getWorldNameFromSdf(const std::string& fileName,

--- a/tests/test_scenario/test_world.py
+++ b/tests/test_scenario/test_world.py
@@ -89,7 +89,7 @@ def test_world_api(gazebo: scenario.GazeboSimulator):
     assert world.insert_model(cube_urdf)
     assert len(world.model_names()) == 1
 
-    default_model_name = scenario.get_model_name_from_sdf(cube_urdf, 0)
+    default_model_name = scenario.get_model_name_from_sdf(cube_urdf)
     assert default_model_name in world.model_names()
     cube1 = world.get_model(default_model_name)
     # TODO: assert cube1


### PR DESCRIPTION
Updates the code to sdformat11, and particularly complies with https://github.com/osrf/sdformat/pull/444.

---

This PR depends on #307 for Edifice support, and #318 for disabling Dome in CI.