### PR TITLE
Improve how links with no collision elements are handled in contact detection

### DIFF
--- a/cpp/scenario/core/include/scenario/core/Link.h
+++ b/cpp/scenario/core/include/scenario/core/Link.h
@@ -161,7 +161,8 @@ public:
     /**
      * Check if the link has active contacts.
      *
-     * @return True if the link has at least one contact, false otherwise.
+     * @return True if the link has at least one contact and contacts are
+     * enabled, false otherwise.
      */
     virtual bool inContact() const = 0;
 

--- a/cpp/scenario/gazebo/src/Model.cpp
+++ b/cpp/scenario/gazebo/src/Model.cpp
@@ -656,6 +656,8 @@ std::vector<double> Model::historyOfAppliedJointForces(
 bool Model::contactsEnabled() const
 {
     for (auto& link : this->links()) {
+        // Note: links with no collision elements return true even though no
+        //       contacts can be detected.
         if (!link->contactsEnabled()) {
             return false;
         }
@@ -670,6 +672,8 @@ bool Model::enableContacts(const bool enable)
     bool ok = true;
 
     for (auto& link : this->links()) {
+        // Note: links with no collision elements return true even though no
+        //       contacts can be detected.
         ok = ok && link->enableContactDetection(enable);
     }
 


### PR DESCRIPTION
~Before this PR, if a `scenario:gazebo::Link` had no collisions, the method `Link::contactsEnabled` was returning true.~

Refer to discussion below https://github.com/robotology/gym-ignition/pull/334#issuecomment-828524354.