### PR TITLE
Simplify passing the physics parameters to the `Server`

### DIFF
--- a/cpp/scenario/gazebo/src/GazeboSimulator.cpp
+++ b/cpp/scenario/gazebo/src/GazeboSimulator.cpp
@@ -40,6 +40,7 @@
 #include <ignition/gazebo/ServerConfig.hh>
 #include <ignition/gazebo/components/Name.hh>
 #include <ignition/gazebo/components/Pose.hh>
+#include <ignition/gazebo/components/Physics.hh>
 #include <ignition/gazebo/components/PhysicsCmd.hh>
 #include <ignition/gazebo/components/World.hh>
 #include <ignition/transport/Node.hh>
@@ -134,12 +135,34 @@ GazeboSimulator::~GazeboSimulator()
 
 double GazeboSimulator::stepSize() const
 {
-    return pImpl->gazebo.physics.maxStepSize;
+    if (!this->initialized()) {
+        return pImpl->gazebo.physics.maxStepSize;
+    }
+
+    // Get the first world
+    const auto world = this->getWorld(this->worldNames().front());
+
+    // Get the active physics parameters
+    const auto& physics = utils::getExistingComponentData< //
+        ignition::gazebo::components::Physics>(world->ecm(), world->entity());
+
+    return physics.MaxStepSize();
 }
 
 double GazeboSimulator::realTimeFactor() const
 {
-    return pImpl->gazebo.physics.rtf;
+    if (!this->initialized()) {
+        return pImpl->gazebo.physics.rtf;
+    }
+
+    // Get the first world
+    const auto world = this->getWorld(this->worldNames().front());
+
+    // Get the active physics parameters
+    const auto& physics = utils::getExistingComponentData< //
+        ignition::gazebo::components::Physics>(world->ecm(), world->entity());
+
+    return physics.RealTimeFactor();
 }
 
 size_t GazeboSimulator::stepsPerRun() const

--- a/cpp/scenario/gazebo/src/World.cpp
+++ b/cpp/scenario/gazebo/src/World.cpp
@@ -39,6 +39,7 @@
 #include <ignition/gazebo/components/Model.hh>
 #include <ignition/gazebo/components/Name.hh>
 #include <ignition/gazebo/components/ParentEntity.hh>
+#include <ignition/gazebo/components/Physics.hh>
 #include <ignition/gazebo/components/Pose.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/math/Vector3.hh>
@@ -226,6 +227,15 @@ bool World::createECMResources()
         utils::setComponentData<ignition::gazebo::components::SimulatedTime>(
             m_ecm, m_entity, std::chrono::steady_clock::duration::zero());
     }
+
+    // Print the active physics profile
+    const auto& physics = utils::getExistingComponentData< //
+        ignition::gazebo::components::Physics>(m_ecm, m_entity);
+    sDebug << "Initializing world '" << this->name()
+           << "' with physics parameters:" << std::endl
+           << "rtf=" << physics.RealTimeFactor() << std::endl
+           << "step=" << physics.MaxStepSize() << std::endl
+           << "type=" << physics.EngineType() << std::endl;
 
     return true;
 }


### PR DESCRIPTION
https://github.com/ignitionrobotics/ign-gazebo/pull/536 introduced the possibility of changing during runtime some of the physics parameters. So far, we had to pass through the `sdf::Root` of the inserted world to specify the rtf and the physics step used by the server (more precisely, by the `SimulationRunner`, as was recently discussed in https://github.com/robotology/gym-ignition/issues/296#issuecomment-797341202).

Using the new `Physics` and `PhysicsCmd` components allows simplifying our logic, and opens the possibility (not implemented in this PR) to change the parameters after the initialization of `GazeboSimulator`.