### PR TITLE
Fix call to `setComTarget` in InverseKinematicsNLP

### DIFF
--- a/python/gym_ignition/rbd/idyntree/inverse_kinematics_nlp.py
+++ b/python/gym_ignition/rbd/idyntree/inverse_kinematics_nlp.py
@@ -279,7 +279,7 @@ class InverseKinematicsNLP:
                        constraint_tolerance: float = 1E-8) -> None:
 
         # Add the target
-        self._ik.setCOMTarget(desiredPosition=idt.Position_Zero(), weight=weight)
+        self._ik.setCOMTarget(idt.Position_Zero(), weight)
 
         # Configure it either as target or constraint
         self._ik.setCOMAsConstraint(asConstraint=as_constraint)
@@ -374,8 +374,7 @@ class InverseKinematicsNLP:
         p = rbd.idyntree.numpy.FromNumPy.to_idyntree_position(position=position)
 
         # Update the target inside IK
-        self._ik.setCOMTarget(desiredPosition=p,
-                              weight=self._targets_data["com"].weight)
+        self._ik.setCOMTarget(p, self._targets_data["com"].weight)
 
         # Update the target data
         self._targets_data["com"] = TargetData(type=TargetType.POSITION,

--- a/tests/test_scenario/test_ignition_fuel.py
+++ b/tests/test_scenario/test_ignition_fuel.py
@@ -17,6 +17,8 @@ from pathlib import Path
 scenario.set_verbosity(scenario.Verbosity_debug)
 
 
+# See https://github.com/robotology/gym-ignition/pull/339#issuecomment-828300490
+@pytest.mark.xfail(strict=False)
 @pytest.mark.parametrize(
     "gazebo", [(0.001, 1.0, 1)], indirect=True, ids=utils.id_gazebo_fn
 )
@@ -49,7 +51,7 @@ def test_download_model_from_fuel(gazebo: scenario.GazeboSimulator):
 @pytest.mark.parametrize(
     "gazebo", [(0.001, 1.0, 1)], indirect=True, ids=utils.id_gazebo_fn
 )
-def test_fuel_world(gazebo):
+def test_fuel_world(gazebo: scenario.GazeboSimulator):
     # (setup) load a world that includes a fuel model
     worlds_folder = Path(__file__) / ".." / ".." / "assets" / "worlds"
     world_file = worlds_folder / "fuel_support.sdf"


### PR DESCRIPTION
The`kwargs` have been removed from the upstream bindings.