### PR TITLE
Automatic configuration of a sane default verbosity

### DIFF
--- a/python/gym_ignition/__init__.py
+++ b/python/gym_ignition/__init__.py
@@ -12,3 +12,25 @@ import os
 from gym_ignition.utils import resource_finder
 if "IGN_GAZEBO_RESOURCE_PATH" in os.environ:
     resource_finder.add_path_from_env_var("IGN_GAZEBO_RESOURCE_PATH")
+
+
+def initialize_verbosity() -> None:
+
+    import gym
+    import scenario
+    import gym_ignition.utils.logger
+
+    if scenario.detect_install_mode() is scenario.InstallMode.Developer:
+        gym_ignition.utils.logger.set_level(level=gym.logger.INFO,
+                                            scenario_level=gym.logger.WARN)
+
+    elif scenario.detect_install_mode() is scenario.InstallMode.User:
+        gym_ignition.utils.logger.set_level(level=gym.logger.WARN,
+                                            scenario_level=gym.logger.WARN)
+
+    else:
+        raise ValueError(scenario.detect_install_mode())
+
+
+# Configure default verbosity
+initialize_verbosity()

--- a/python/gym_ignition/randomizers/gazebo_env_randomizer.py
+++ b/python/gym_ignition/randomizers/gazebo_env_randomizer.py
@@ -52,6 +52,9 @@ class GazeboEnvRandomizer(gym.Wrapper,
                  randomizers.physics.dart.DART(),
                  **kwargs):
 
+        # Print the extra kwargs
+        gym.logger.debug(f"GazeboEnvRandomizer: {dict(kwargs=kwargs)}")
+
         # Store the options
         self._env_option = env
         self._kwargs = dict(**kwargs, physics_engine=physics_randomizer.get_engine())
@@ -128,15 +131,11 @@ class GazeboEnvRandomizer(gym.Wrapper,
     def _create_from_callable(make_env: MakeEnvCallable,
                               **kwargs) -> gym.Env:
 
-        with logger.gym_verbosity(level=gym.logger.WARN):
-            env = make_env(**kwargs)
-
+        env = make_env(**kwargs)
         return env
 
     @staticmethod
     def _create_from_id(env_id: str, **kwargs) -> gym.Env:
 
-        with logger.gym_verbosity(level=gym.logger.WARN):
-            env = gym.make(env_id, **kwargs)
-
+        env = gym.make(env_id, **kwargs)
         return env

--- a/python/gym_ignition/runtimes/gazebo_runtime.py
+++ b/python/gym_ignition/runtimes/gazebo_runtime.py
@@ -41,6 +41,12 @@ class GazeboRuntime(runtime.Runtime):
                  world: str = None,
                  **kwargs):
 
+        if gym.logger.MIN_LEVEL <= gym.logger.DEBUG:
+            import inspect
+            frame = inspect.currentframe()
+            args, _, _, values = inspect.getargvalues(frame)
+            gym.logger.debug(f"{dict({arg: values[arg] for arg in args})}")
+
         # Gazebo attributes
         self._gazebo = None
         self._physics_rate = physics_rate

--- a/python/gym_ignition/utils/logger.py
+++ b/python/gym_ignition/utils/logger.py
@@ -36,7 +36,7 @@ def warn(msg: str, *args) -> None:
 warnings.formatwarning = custom_formatwarning
 
 
-def set_level(level: int) -> None:
+def set_level(level: int, scenario_level: int = None) -> None:
     """
     Set the verbosity level of both :py:mod:`gym` and :py:mod:`gym_ignition`.
 
@@ -50,6 +50,7 @@ def set_level(level: int) -> None:
 
     Args:
         level: The desired verbosity level.
+        scenario_level: The desired ScenarIO verbosity level (defaults to ``level``).
     """
 
     # Set the gym verbosity
@@ -60,14 +61,17 @@ def set_level(level: int) -> None:
     except ImportError:
         return
 
+    if scenario_level is None:
+        scenario_level = level
+
     # Set the ScenarI/O verbosity
-    if logger.MIN_LEVEL <= logger.DEBUG:
+    if scenario_level <= logger.DEBUG:
         scenario.set_verbosity(scenario.Verbosity_debug)
-    elif logger.MIN_LEVEL <= logger.INFO:
+    elif scenario_level <= logger.INFO:
         scenario.set_verbosity(scenario.Verbosity_info)
-    elif logger.MIN_LEVEL <= logger.WARN:
+    elif scenario_level <= logger.WARN:
         scenario.set_verbosity(scenario.Verbosity_warning)
-    elif logger.MIN_LEVEL <= logger.ERROR:
+    elif scenario_level <= logger.ERROR:
         scenario.set_verbosity(scenario.Verbosity_error)
     else:
         scenario.set_verbosity(scenario.Verbosity_suppress_all)


### PR DESCRIPTION
- Allow setting the C++ and Python verbosity independently
- Set a different default verbosity depending on the installation mode (User or Developer)
- Supress stderr of the GUI to prevent printing the annoying stacktrace printed all the time when the GUI closes