### PR TITLE
Allow loading link and joint plugins

### DIFF
--- a/bindings/gazebo/gazebo.i
+++ b/bindings/gazebo/gazebo.i
@@ -65,9 +65,6 @@ namespace scenario::gazebo::utils {
 %rename("") GazeboSimulator;
 %rename("") JointControlMode;
 
-// Public helpers
-%include "scenario/gazebo/utils.h"
-
 // Other templates for ScenarI/O APIs
 %shared_ptr(scenario::gazebo::Joint)
 %shared_ptr(scenario::gazebo::Link)
@@ -96,6 +93,9 @@ namespace scenario::gazebo::utils {
 
 // Interface of Gazebo entities
 %include "scenario/gazebo/GazeboEntity.h"
+
+// Public helpers
+%include "scenario/gazebo/utils.h"
 
 // ScenarI/O headers
 %include "scenario/gazebo/Joint.h"

--- a/cpp/scenario/gazebo/include/scenario/gazebo/Joint.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/Joint.h
@@ -68,6 +68,18 @@ public:
     // ============
 
     /**
+     * Insert a Ignition Gazebo plugin to the joint.
+     *
+     * @param libName The library name of the plugin.
+     * @param className The class name (or alias) of the plugin.
+     * @param context Optional XML plugin context.
+     * @return True for success, false otherwise.
+     */
+    bool insertJointPlugin(const std::string& libName,
+                           const std::string& className,
+                           const std::string& context = {});
+
+    /**
      * Reset the position of a joint DOF.
      *
      * @param position The desired position.

--- a/cpp/scenario/gazebo/include/scenario/gazebo/Link.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/Link.h
@@ -65,6 +65,22 @@ public:
 
     bool createECMResources() override;
 
+    // ===========
+    // Gazebo Link
+    // ===========
+
+    /**
+     * Insert a Ignition Gazebo plugin to the link.
+     *
+     * @param libName The library name of the plugin.
+     * @param className The class name (or alias) of the plugin.
+     * @param context Optional XML plugin context.
+     * @return True for success, false otherwise.
+     */
+    bool insertLinkPlugin(const std::string& libName,
+                          const std::string& className,
+                          const std::string& context = {});
+
     // =========
     // Link Core
     // =========

--- a/cpp/scenario/gazebo/include/scenario/gazebo/utils.h
+++ b/cpp/scenario/gazebo/include/scenario/gazebo/utils.h
@@ -27,6 +27,7 @@
 #ifndef SCENARIO_GAZEBO_UTILS_H
 #define SCENARIO_GAZEBO_UTILS_H
 
+#include "scenario/gazebo/GazeboEntity.h"
 #include <memory>
 #include <string>
 #include <vector>
@@ -239,6 +240,25 @@ namespace scenario::gazebo::utils {
     std::vector<double> denormalize(const std::vector<double>& input,
                                     const std::vector<double>& low,
                                     const std::vector<double>& high);
+
+    /**
+     * Insert a plugin to any Gazebo entity.
+     *
+     * @note This function will not return true if the plugin is successful.
+     * This function just triggers an event that notifies the server to load a
+     * plugin, and it does not receive any return value that could be used to
+     * assess the outcome.
+     *
+     * @param gazeboEntity The Gazebo entity (world, model, joint, ...).
+     * @param libName The name of the plugin library.
+     * @param className The name of the class implementing the plugin.
+     * @param context The optional plugin SDF context.
+     * @return True if the entity is valid, false otherwise.
+     */
+    bool insertPluginToGazeboEntity(const GazeboEntity& gazeboEntity,
+                                    const std::string& libName,
+                                    const std::string& className,
+                                    const std::string& context = "");
 } // namespace scenario::gazebo::utils
 
 #endif // SCENARIO_GAZEBO_UTILS_H

--- a/cpp/scenario/gazebo/src/Joint.cpp
+++ b/cpp/scenario/gazebo/src/Joint.cpp
@@ -40,6 +40,7 @@
 #include "scenario/gazebo/components/Timestamp.h"
 #include "scenario/gazebo/exceptions.h"
 #include "scenario/gazebo/helpers.h"
+#include "scenario/gazebo/utils.h"
 
 #include <ignition/gazebo/components/JointAxis.hh>
 #include <ignition/gazebo/components/JointForce.hh>
@@ -127,6 +128,14 @@ bool Joint::createECMResources()
         m_entity, components::JointControlMode(core::JointControlMode::Idle));
 
     return true;
+}
+
+bool Joint::insertJointPlugin(const std::string& libName,
+                              const std::string& className,
+                              const std::string& context)
+{
+    return utils::insertPluginToGazeboEntity(
+        *this, libName, className, context);
 }
 
 bool Joint::resetPosition(const double position, size_t dof)

--- a/cpp/scenario/gazebo/src/Link.cpp
+++ b/cpp/scenario/gazebo/src/Link.cpp
@@ -32,6 +32,7 @@
 #include "scenario/gazebo/components/SimulatedTime.h"
 #include "scenario/gazebo/exceptions.h"
 #include "scenario/gazebo/helpers.h"
+#include "scenario/gazebo/utils.h"
 
 #include <ignition/gazebo/Link.hh>
 #include <ignition/gazebo/components/AngularAcceleration.hh>
@@ -171,6 +172,14 @@ bool Link::createECMResources()
     }
 
     return true;
+}
+
+bool Link::insertLinkPlugin(const std::string& libName,
+                            const std::string& className,
+                            const std::string& context)
+{
+    return utils::insertPluginToGazeboEntity(
+        *this, libName, className, context);
 }
 
 bool Link::valid() const

--- a/cpp/scenario/gazebo/src/Model.cpp
+++ b/cpp/scenario/gazebo/src/Model.cpp
@@ -36,6 +36,7 @@
 #include "scenario/gazebo/components/Timestamp.h"
 #include "scenario/gazebo/exceptions.h"
 #include "scenario/gazebo/helpers.h"
+#include "scenario/gazebo/utils.h"
 
 #include <ignition/common/Event.hh>
 #include <ignition/gazebo/Events.hh>
@@ -192,40 +193,8 @@ bool Model::insertModelPlugin(const std::string& libName,
                               const std::string& className,
                               const std::string& context)
 {
-    // Create a new <plugin name="" filename=""> element without context
-    sdf::ElementPtr pluginElement =
-        utils::getPluginSDFElement(libName, className);
-
-    // Insert the context into the plugin element
-    if (!context.empty()) {
-
-        std::shared_ptr<sdf::Root> contextRoot =
-            utils::getSdfRootFromString(context);
-
-        if (!contextRoot) {
-            return false;
-        }
-
-        // Get the first element of the context
-        // (stripping out the <sdf> container)
-        auto contextNextElement = contextRoot->Element()->GetFirstElement();
-
-        // Insert the plugin context elements
-        while (contextNextElement) {
-            pluginElement->InsertElement(contextNextElement);
-            contextNextElement = contextNextElement->GetNextElement();
-        }
-    }
-
-    // The plugin element must be wrapped in another element, otherwise
-    // who receives it does not get the additional context
-    const auto wrapped = sdf::SDF::WrapInRoot(pluginElement);
-
-    // Trigger the plugin loading
-    m_eventManager->Emit<ignition::gazebo::events::LoadPlugins>(m_entity,
-                                                                wrapped);
-
-    return true;
+    return utils::insertPluginToGazeboEntity(
+        *this, libName, className, context);
 }
 
 bool Model::resetJointPositions(const std::vector<double>& positions,

--- a/cpp/scenario/gazebo/src/World.cpp
+++ b/cpp/scenario/gazebo/src/World.cpp
@@ -31,6 +31,7 @@
 #include "scenario/gazebo/components/Timestamp.h"
 #include "scenario/gazebo/exceptions.h"
 #include "scenario/gazebo/helpers.h"
+#include "scenario/gazebo/utils.h"
 
 #include <ignition/common/Event.hh>
 #include <ignition/gazebo/Events.hh>
@@ -234,40 +235,8 @@ bool World::insertWorldPlugin(const std::string& libName,
                               const std::string& className,
                               const std::string& context)
 {
-    // Create a new <plugin name="" filename=""> element without context
-    sdf::ElementPtr pluginElement =
-        utils::getPluginSDFElement(libName, className);
-
-    // Insert the context into the plugin element
-    if (!context.empty()) {
-
-        // Try to get the sdf::Root (it will alredy print an error if it fails)
-        auto contextRoot = utils::getSdfRootFromString(context);
-
-        if (!contextRoot) {
-            return false;
-        }
-
-        // Get the first element of the context
-        // (stripping out the <sdf> container)
-        auto contextNextElement = contextRoot->Element()->GetFirstElement();
-
-        // Insert the plugin context elements
-        while (contextNextElement) {
-            pluginElement->InsertElement(contextNextElement);
-            contextNextElement = contextNextElement->GetNextElement();
-        }
-    }
-
-    // The plugin element must be wrapped in another element, otherwise
-    // who receives it does not get the additional context
-    const auto wrapped = sdf::SDF::WrapInRoot(pluginElement);
-
-    // Trigger the plugin loading
-    m_eventManager->Emit<ignition::gazebo::events::LoadPlugins>(m_entity,
-                                                                wrapped);
-
-    return true;
+    return utils::insertPluginToGazeboEntity(
+        *this, libName, className, context);
 }
 
 bool World::setPhysicsEngine(const PhysicsEngine engine)


### PR DESCRIPTION
- New public function `insertPluginToGazeboEntity`
- New method `Link::insertLinkPlugin`
- New method `Joint::insertJointPlugin`
- Methods `World::insertWorldtPlugin` and `Model::insertModelPlugin` now use `insertPluginToGazeboEntity`