### PR TITLE
Fix type hinting of binded methods returning `std::vector`s

### DIFF
--- a/scenario/bindings/core/core.i
+++ b/scenario/bindings/core/core.i
@@ -51,18 +51,18 @@
 %template(VectorOfContactPoints) std::vector<scenario::core::ContactPoint>;
 
 // Doxygen typemaps
-%typemap(doctype) std::array<double, 3> "Iterable[float, float, float]";
-%typemap(doctype) std::array<double, 4> "Iterable[float, float, float, float]";
-%typemap(doctype) std::array<double, 6> "Iterable[float, float, float, float, float, float]";
-%typemap(doctype) std::vector<double> "Iterable[float]";
-%typemap(doctype) std::vector<std::string> "Iterable[string]";
+%typemap(doctype) std::array<double, 3> "Tuple[float, float, float]";
+%typemap(doctype) std::array<double, 4> "Tuple[float, float, float, float]";
+%typemap(doctype) std::array<double, 6> "Tuple[float, float, float, float, float, float]";
+%typemap(doctype) std::vector<double> "Tuple[float]";
+%typemap(doctype) std::vector<std::string> "Tuple[string]";
 %typemap(doctype) std::vector<scenario::core::LinkPtr> "Tuple[Link]";
 %typemap(doctype) std::vector<scenario::core::JointPtr> "Tuple[Joint]";
 %typemap(doctype) std::vector<scenario::core::Contact> "Tuple[Contact]";
 %typemap(doctype) std::vector<scenario::core::ContactPoint> "Tuple[ContactPoint]";
 
 %pythonbegin %{
-from typing import Iterable, Tuple
+from typing import Tuple
 %}
 
 // NOTE: Keep all template instantiations above.


### PR DESCRIPTION
All `std::vector`s are mapped to Python's tuples by SWIG. The `Iterable` typing does not have the `[]` operator, and accessing a single element creates a warning in some IDEs, like PyCharm. This PR updates the type hinting.

![Screenshot_20210522_112313](https://user-images.githubusercontent.com/469199/119221523-1f00de00-baf0-11eb-9308-3493909c1842.png)
