### PR TITLE
Fix include directories in SWIG bindings

### DIFF
--- a/scenario/bindings/gazebo/CMakeLists.txt
+++ b/scenario/bindings/gazebo/CMakeLists.txt
@@ -17,9 +17,9 @@ swig_add_library(${scenario_swig_name}
 
 target_link_libraries(${scenario_swig_name}
     PUBLIC
-    ECMSingleton
     ScenarioGazebo::ScenarioGazebo
     ScenarioGazebo::GazeboSimulator
+    ECMSingleton
     Python3::Python)
 add_library(ScenarioSwig::Gazebo ALIAS gazebo)
 


### PR DESCRIPTION
For some reason, the first `-I` compiler option passed to compile the bindings is a system folder, and if the CMake project is installed, the installed headers are included in the bindings. This is not a big problem in most cases, but it could create problems when the public headers change while developing because SWIG would generate the bindings with the installed ones instead of the new in-source updated headers.

This minor change of dependent targets seems solving the ordering of the options passed to the compiler, but I suspect that there is another small error somewhere else that originates the problem.