### PR TITLE
Use the versioned name of the DART physics plugin

### DIFF
--- a/scenario/src/gazebo/CMakeLists.txt
+++ b/scenario/src/gazebo/CMakeLists.txt
@@ -99,6 +99,7 @@ target_link_libraries(ScenarioGazebo
     PRIVATE
     ScenarioCore::CoreUtils
     ScenarioGazebo::ExtraComponents
+    ${ignition-physics.ignition-physics}
     ${ignition-fuel_tools.ignition-fuel_tools})
 
 set_target_properties(ScenarioGazebo PROPERTIES

--- a/scenario/src/gazebo/src/World.cpp
+++ b/scenario/src/gazebo/src/World.cpp
@@ -45,6 +45,7 @@
 #include <ignition/gazebo/components/Pose.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/math/Vector3.hh>
+#include <ignition/physics/config.hh>
 #include <sdf/Element.hh>
 #include <sdf/Model.hh>
 #include <sdf/Root.hh>
@@ -245,7 +246,9 @@ bool World::setPhysicsEngine(const PhysicsEngine engine)
     const std::string pluginLib = [&engine]() -> std::string {
         switch (engine) {
             case PhysicsEngine::Dart:
-                return "ignition-physics-dartsim-plugin";
+                return "ignition-physics"
+                       + std::to_string(IGNITION_PHYSICS_MAJOR_VERSION)
+                       + "-dartsim-plugin";
         }
         return "";
     }();


### PR DESCRIPTION
In some setups, [we recommend](https://github.com/robotology/gym-ignition/blob/311b08ef16/docs/sphinx/installation/system_configuration.rst) users to export the `IGN_GAZEBO_PHYSICS_ENGINE_PATH` environment variable.

Working on a downstream project which CI installs Ignition Gazebo from the PPA, I found out that I have to manually set this env variable because otherwise the plugin is not found, generating this error:

```
[Err] [Physics.cc:597] Failed to find plugin [ignition-physics-dartsim-plugin]. Have you checked the IGN_GAZEBO_PHYSICS_ENGINE_PATH environment variable?
```

Now, investigating a bit on this setup, I realized that there are two locations where the dart plugin in installed:

1. `/usr/lib/x86_64-linux-gnu`
2. `/usr/lib/x86_64-linux-gnu/ign-physics-4/engine-plugins/`

And this is the relevant content of the two folders:

```
$ ls -alh /usr/lib/x86_64-linux-gnu
[...]
lrwxrwxrwx   1 root root    40 May  3 16:08 libignition-physics4-dartsim-plugin.so -> libignition-physics4-dartsim-plugin.so.4
lrwxrwxrwx   1 root root    44 May  3 16:08 libignition-physics4-dartsim-plugin.so.4 -> libignition-physics4-dartsim-plugin.so.4.1.0
-rw-r--r--   1 root root  1.9M May  3 16:08 libignition-physics4-dartsim-plugin.so.4.1.0
[...]
```

```
ls -alh /usr/lib/x86_64-linux-gnu/ign-physics-4/engine-plugins
lrwxrwxrwx 1 root root   38 May  3 16:08 libignition-physics-dartsim-plugin.so -> libignition-physics4-dartsim-plugin.so
lrwxrwxrwx 1 root root   40 May  3 16:08 libignition-physics4-dartsim-plugin.so -> libignition-physics4-dartsim-plugin.so.4
lrwxrwxrwx 1 root root   44 May  3 16:08 libignition-physics4-dartsim-plugin.so.4 -> libignition-physics4-dartsim-plugin.so.4.1.0
-rw-r--r-- 1 root root 1.9M May  3 16:08 libignition-physics4-dartsim-plugin.so.4.1.0
```

It can be noticed that in the first case, the unversioned `libignition-physics-dartsim-plugin.so` symlink is not there. This makes sense since multiple `ign-physics` versions could be installed side-by-side and they all share the `/usr/lib/x86_64-linux-gnu` folder.

Though, when we load the plugin, we use this unversioned name of the shared library:

https://github.com/robotology/gym-ignition/blob/fcf705e246c697f7bd5728ca3e018837c9800421/scenario/src/gazebo/src/World.cpp#L244-L251

I suspect that the `/usr/lib/x86_64-linux-gnu/ign-physics-<version>/engine-plugins/` is not always added in the search path by default, therefore there are cases where the loading could fail. This would not happen if we use the versioned name.

This PR updates our logic to always use the versioned name of the library.