### PR TITLE
Run the Python tests in different processes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,7 @@ where = python
 testing =
     pytest
     pytest-xvfb
+    pytest-forked
     pytest-icdiff
 website =
     sphinx
@@ -87,7 +88,7 @@ all =
     %(website)s
 
 [tool:pytest]
-addopts = -rsxX -v --strict-markers
+addopts = -rsxX -v --strict-markers --forked
 testpaths = tests
 markers =
     scenario: Select the tests in the 'tests/test_scenario/' folder.


### PR DESCRIPTION
This should prevent flaky tests that might segfault to crash the all the test suite. It uses [`pytest-forked`](https://github.com/pytest-dev/pytest-forked) plugin.

Note that this plugin does not work in Windows, but we do not yet support this platform.
