### PR TITLE
Disable `test_multi_world_simulation`

### DIFF
--- a/tests/test_scenario/test_multi_world.py
+++ b/tests/test_scenario/test_multi_world.py
@@ -113,99 +113,99 @@ def _test_insert_world_multiple_calls(gazebo: scenario_gazebo.GazeboSimulator):
     assert world1.id() != world2.id()
 
 
-# This test is flaky
-@pytest.mark.xfail(strict=False)
-@pytest.mark.parametrize("gazebo, solver",
-                         [((0.001, 2.0, 1), "pgs"),
-                          ((0.001, 2.0, 1), "dantzig")],
-                         indirect=["gazebo"],
-                         ids=utils.id_gazebo_fn)
-def test_multi_world_simulation(gazebo: scenario_gazebo.GazeboSimulator,
-                                solver: str):
-
-    # Empty DART world with bullet as collision detector.
-    # It should prevent ODE crashes in a multi-world setting due to its static variables.
-    world_sdf_string = f"""
-    <?xml version="1.0" ?>
-    <sdf version="1.7">
-        <world name="default">
-            <physics default="true" type="dart">
-                <dart>
-                    <collision_detector>bullet</collision_detector>
-                    <solver>
-                        <solver_type>{solver}</solver_type>
-                    </solver>
-                </dart>
-            </physics>
-            <light type="directional" name="sun">
-                <cast_shadows>true</cast_shadows>
-                <pose>0 0 10 0 0 0</pose>
-                <diffuse>1 1 1 1</diffuse>
-                <specular>0.5 0.5 0.5 1</specular>
-                <attenuation>
-                    <range>1000</range>
-                    <constant>0.9</constant>
-                    <linear>0.01</linear>
-                    <quadratic>0.001</quadratic>
-                </attenuation>
-                <direction>-0.5 0.1 -0.9</direction>
-            </light>
-        </world>
-    </sdf>
-    """
-
-    # Create a tmp file from the SDF string
-    world_sdf_file = misc.string_to_file(string=world_sdf_string)
-
-    # Load two different worlds
-    assert gazebo.insert_world_from_sdf(world_sdf_file, "dart1")
-    assert gazebo.insert_world_from_sdf(world_sdf_file, "dart2")
-
-    # Initialize the simulator
-    assert gazebo.initialize()
-
-    # gazebo.gui()
-    # import time
-    # time.sleep(1)
-    # gazebo.run(paused=True)
-
-    sphere_urdf_string = utils.SphereURDF(restitution=0.8).urdf()
-    sphere_urdf = misc.string_to_file(sphere_urdf_string)
-    ground_plane_urdf = gym_ignition_models.get_model_file(robot_name="ground_plane")
-
-    # Pose of the sphere
-    sphere_pose = scenario_core.Pose([0, 0, 0.5], [1, 0, 0, 0])
-
-    # Populate the first DART world
-    world1 = gazebo.get_world("dart1")
-    world1.set_physics_engine(scenario_gazebo.PhysicsEngine_dart)
-    world1.insert_model(ground_plane_urdf)
-    world1.insert_model(sphere_urdf, sphere_pose)
-    sphere1 = world1.get_model(model_name="sphere_model")
-
-    # Populate the second DART world
-    world2 = gazebo.get_world("dart2")
-    world2.set_physics_engine(scenario_gazebo.PhysicsEngine_dart)
-    world2.insert_model(ground_plane_urdf)
-    world2.insert_model(sphere_urdf, sphere_pose)
-    sphere2 = world2.get_model(model_name="sphere_model")
-
-    # Integration time
-    dt = gazebo.step_size() * gazebo.steps_per_run()
-
-    # Enable contacts
-    sphere1.enable_contacts(True)
-    sphere2.enable_contacts(True)
-
-    for _ in np.arange(start=0.0, stop=5.0, step=dt):
-
-        # Run the simulator
-        assert gazebo.run()
-
-        # Check that both worlds evolve similarly
-        assert sphere1.base_position() == \
-               pytest.approx(sphere2.base_position(), abs=0.001)
-        assert sphere1.base_world_linear_velocity() == \
-               pytest.approx(sphere2.base_world_linear_velocity(), abs=0.001)
-        assert sphere1.base_world_angular_velocity() == \
-               pytest.approx(sphere2.base_world_angular_velocity())
+# # This test is flaky
+# @pytest.mark.xfail(strict=False)
+# @pytest.mark.parametrize("gazebo, solver",
+#                          [((0.001, 2.0, 1), "pgs"),
+#                           ((0.001, 2.0, 1), "dantzig")],
+#                          indirect=["gazebo"],
+#                          ids=utils.id_gazebo_fn)
+# def test_multi_world_simulation(gazebo: scenario_gazebo.GazeboSimulator,
+#                                 solver: str):
+#
+#     # Empty DART world with bullet as collision detector.
+#     # It should prevent ODE crashes in a multi-world setting due to its static variables.
+#     world_sdf_string = f"""
+#     <?xml version="1.0" ?>
+#     <sdf version="1.7">
+#         <world name="default">
+#             <physics default="true" type="dart">
+#                 <dart>
+#                     <collision_detector>bullet</collision_detector>
+#                     <solver>
+#                         <solver_type>{solver}</solver_type>
+#                     </solver>
+#                 </dart>
+#             </physics>
+#             <light type="directional" name="sun">
+#                 <cast_shadows>true</cast_shadows>
+#                 <pose>0 0 10 0 0 0</pose>
+#                 <diffuse>1 1 1 1</diffuse>
+#                 <specular>0.5 0.5 0.5 1</specular>
+#                 <attenuation>
+#                     <range>1000</range>
+#                     <constant>0.9</constant>
+#                     <linear>0.01</linear>
+#                     <quadratic>0.001</quadratic>
+#                 </attenuation>
+#                 <direction>-0.5 0.1 -0.9</direction>
+#             </light>
+#         </world>
+#     </sdf>
+#     """
+#
+#     # Create a tmp file from the SDF string
+#     world_sdf_file = misc.string_to_file(string=world_sdf_string)
+#
+#     # Load two different worlds
+#     assert gazebo.insert_world_from_sdf(world_sdf_file, "dart1")
+#     assert gazebo.insert_world_from_sdf(world_sdf_file, "dart2")
+#
+#     # Initialize the simulator
+#     assert gazebo.initialize()
+#
+#     # gazebo.gui()
+#     # import time
+#     # time.sleep(1)
+#     # gazebo.run(paused=True)
+#
+#     sphere_urdf_string = utils.SphereURDF(restitution=0.8).urdf()
+#     sphere_urdf = misc.string_to_file(sphere_urdf_string)
+#     ground_plane_urdf = gym_ignition_models.get_model_file(robot_name="ground_plane")
+#
+#     # Pose of the sphere
+#     sphere_pose = scenario_core.Pose([0, 0, 0.5], [1, 0, 0, 0])
+#
+#     # Populate the first DART world
+#     world1 = gazebo.get_world("dart1")
+#     world1.set_physics_engine(scenario_gazebo.PhysicsEngine_dart)
+#     world1.insert_model(ground_plane_urdf)
+#     world1.insert_model(sphere_urdf, sphere_pose)
+#     sphere1 = world1.get_model(model_name="sphere_model")
+#
+#     # Populate the second DART world
+#     world2 = gazebo.get_world("dart2")
+#     world2.set_physics_engine(scenario_gazebo.PhysicsEngine_dart)
+#     world2.insert_model(ground_plane_urdf)
+#     world2.insert_model(sphere_urdf, sphere_pose)
+#     sphere2 = world2.get_model(model_name="sphere_model")
+#
+#     # Integration time
+#     dt = gazebo.step_size() * gazebo.steps_per_run()
+#
+#     # Enable contacts
+#     sphere1.enable_contacts(True)
+#     sphere2.enable_contacts(True)
+#
+#     for _ in np.arange(start=0.0, stop=5.0, step=dt):
+#
+#         # Run the simulator
+#         assert gazebo.run()
+#
+#         # Check that both worlds evolve similarly
+#         assert sphere1.base_position() == \
+#                pytest.approx(sphere2.base_position(), abs=0.001)
+#         assert sphere1.base_world_linear_velocity() == \
+#                pytest.approx(sphere2.base_world_linear_velocity(), abs=0.001)
+#         assert sphere1.base_world_angular_velocity() == \
+#                pytest.approx(sphere2.base_world_angular_velocity())


### PR DESCRIPTION
Since #370 seems not enough to fix flaky tests that could segfault, this PR temporarily disable the only problematic test introduced in #368.