### PR TITLE
Enforce compliance of clang-format style

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,34 @@
+name: Code Style
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+
+  clang-format:
+
+    name: "clang-format"
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: "🔀 Checkout repository"
+        uses: actions/checkout@v2
+
+      - name: "⬇️️ Install dependencies"
+        run: sudo apt-get install -y --no-install-recommends colordiff
+
+      - name: "📝 Format C++"
+        uses: diegoferigo/gh-action-clang-format@v0.1
+        id: format
+        with:
+          style: file
+          pattern: |
+            *.h
+            *.cpp
+
+      - name: "🔍️ Inspect style diff"
+        if: failure()
+        run: printf "${{ steps.format.outputs.diff }}" | colordiff


### PR DESCRIPTION
This PR introduces a new workflow that uses [diegoferigo/gh-action-clang-format](https://github.com/diegoferigo/gh-action-clang-format) to enforce on opened PRs the C++ style defined in the file [`.clang-format`](https://github.com/robotology/gym-ignition/blob/master/.clang-format) stored in the repository root.

Note: the workflow filters only `*.cpp` and `*.h` files, therefore the vendored resources from upstream (that use `*.hh` and `*.cc`) are not affected.

I plan on the long term to do something similar also for Python using [black](https://github.com/psf/black/).