### PR TITLE
Fix leftover after removing `ScenarioGazeboPlugins` CMake component

### DIFF
--- a/scenario/src/gazebo/CMakeLists.txt
+++ b/scenario/src/gazebo/CMakeLists.txt
@@ -171,7 +171,7 @@ install_basic_package_files(ScenarioGazebo
     VERSION ${PROJECT_VERSION}
     COMPATIBILITY AnyNewerVersion
     EXPORT ScenarioGazeboExport
-    DEPENDENCIES ScenarioCore ScenarioGazeboPlugins ${ignition-gazebo} ${ignition-common}
+    DEPENDENCIES ScenarioCore ${ignition-gazebo} ${ignition-common}
     NAMESPACE ScenarioGazebo::
     NO_CHECK_REQUIRED_COMPONENTS_MACRO
     INSTALL_DESTINATION


### PR DESCRIPTION
Leftover of #379. CI didn't catch it because the error occurred downstream when a project tried to import the targets.