### PR TITLE
Allow inserting worlds from file containing models

### DIFF
--- a/scenario/src/core/include/scenario/core/World.h
+++ b/scenario/src/core/include/scenario/core/World.h
@@ -72,6 +72,16 @@ public:
      * @return The model if it is part of the world, ``nullptr`` otherwise.
      */
     virtual ModelPtr getModel(const std::string& modelName) const = 0;
+
+    /**
+     * Get the models of the world.
+     *
+     * @param modelNames Optional vector of considered models. By default,
+     * ``World::modelNames`` is used.
+     * @return A vector of pointers to the model objects.
+     */
+    virtual std::vector<ModelPtr> models( //
+        const std::vector<std::string>& modelNames = {}) const = 0;
 };
 
 #endif // SCENARIO_CORE_WORLD_H

--- a/scenario/src/gazebo/include/scenario/gazebo/World.h
+++ b/scenario/src/gazebo/include/scenario/gazebo/World.h
@@ -202,6 +202,9 @@ public:
     scenario::core::ModelPtr
     getModel(const std::string& modelName) const override;
 
+    std::vector<core::ModelPtr> models( //
+        const std::vector<std::string>& modelNames = {}) const override;
+
 private:
     class Impl;
     std::unique_ptr<Impl> pImpl;

--- a/scenario/src/gazebo/src/World.cpp
+++ b/scenario/src/gazebo/src/World.cpp
@@ -376,6 +376,21 @@ scenario::core::ModelPtr World::getModel(const std::string& modelName) const
     return pImpl->models[modelName];
 }
 
+std::vector<scenario::core::ModelPtr>
+World::models(const std::vector<std::string>& modelNames) const
+{
+    const std::vector<std::string>& modelSerialization =
+        modelNames.empty() ? this->modelNames() : modelNames;
+
+    std::vector<core::ModelPtr> models;
+
+    for (const auto& modelName : modelSerialization) {
+        models.push_back(this->getModel(modelName));
+    }
+
+    return models;
+}
+
 bool World::insertModel(const std::string& modelFile,
                         const core::Pose& pose,
                         const std::string& overrideModelName)

--- a/scenario/src/gazebo/src/World.cpp
+++ b/scenario/src/gazebo/src/World.cpp
@@ -229,6 +229,15 @@ bool World::createECMResources()
            << "step=" << physics.MaxStepSize() << std::endl
            << "type=" << physics.EngineType() << std::endl;
 
+    // Create required model resources
+    sMessage << "Models:" << std::endl;
+    for (const auto& model : this->models()) {
+        if (!std::static_pointer_cast<Model>(model)->createECMResources()) {
+            sError << "Failed to initialize ECM model resources" << std::endl;
+            return false;
+        }
+    }
+
     return true;
 }
 


### PR DESCRIPTION
Before this PR, models were exposed to the user but not properly initialized. Closes #385.

- Adds a new ScenarIO API `World::models`
- Implements this new method for Gazebo ScenarIO
- Fix the creation of models resources