### PR TITLE
Allow specifying different pos and rot weights for POSE IK targets

### DIFF
--- a/python/gym_ignition/rbd/idyntree/inverse_kinematics_nlp.py
+++ b/python/gym_ignition/rbd/idyntree/inverse_kinematics_nlp.py
@@ -228,13 +228,17 @@ class InverseKinematicsNLP:
         self,
         frame_name: str,
         target_type: TargetType,
-        weight: Union[float, Tuple[float, float]] = 1.0,
+        weight: Union[float, Tuple[float, float]] = None,
         as_constraint: bool = False,
     ) -> None:
 
         # Check the type of the 'weight' argument
         float_target_types = {TargetType.ROTATION, TargetType.POSITION}
         weight_type = float if target_type in float_target_types else tuple
+
+        # Set the default weight if not specified
+        default_weight = 1.0 if target_type in float_target_types else (1.0, 1.0)
+        weight = weight if weight is not None else default_weight
 
         if not isinstance(weight, weight_type):
             raise ValueError(f"The weight must be {weight_type} for this target")

--- a/python/gym_ignition/rbd/idyntree/inverse_kinematics_nlp.py
+++ b/python/gym_ignition/rbd/idyntree/inverse_kinematics_nlp.py
@@ -236,6 +236,11 @@ class InverseKinematicsNLP:
         float_target_types = {TargetType.ROTATION, TargetType.POSITION}
         weight_type = float if target_type in float_target_types else tuple
 
+        # Backward compatibility: if the target type is POSE and the weight is a float,
+        # we apply the same weight to both target components
+        if target_type is TargetType.POSE and isinstance(weight, float):
+            weight = (weight, weight)
+
         # Set the default weight if not specified
         default_weight = 1.0 if target_type in float_target_types else (1.0, 1.0)
         weight = weight if weight is not None else default_weight


### PR DESCRIPTION
Before this PR, the IK was accepting and applying the same weight to both components of the pose, and the implementation does not allow to add to the same frame two different targets (position + rotation).

cc @fedeceola 