### PR TITLE
Application of external wrenches: new `empty` method and new Python test

### DIFF
--- a/scenario/src/gazebo/include/scenario/gazebo/helpers.h
+++ b/scenario/src/gazebo/include/scenario/gazebo/helpers.h
@@ -318,17 +318,17 @@ namespace scenario::gazebo::utils {
                                  curSimTime)
         {}
 
-        inline ignition::msgs::Vector3d force() const
+        const ignition::msgs::Vector3d& force() const
         {
             return m_wrench.force();
         }
 
-        inline ignition::msgs::Vector3d torque() const
+        const ignition::msgs::Vector3d& torque() const
         {
             return m_wrench.torque();
         }
 
-        inline std::chrono::steady_clock::duration expiration()
+        const std::chrono::steady_clock::duration& expiration()
         {
             return m_expiration;
         }
@@ -348,6 +348,8 @@ namespace scenario::gazebo::utils {
     {
     public:
         LinkWrenchCmd() = default;
+
+        bool empty() const { return m_wrenches.empty(); }
 
         inline void addWorldWrench(const WrenchWithDuration& wrench)
         {
@@ -375,14 +377,19 @@ namespace scenario::gazebo::utils {
             return totalWrench;
         }
 
-        inline void cleanExpired(const std::chrono::steady_clock::duration& now)
+        void cleanExpired(const std::chrono::steady_clock::duration& now)
         {
-            auto end = std::remove_if(
-                m_wrenches.begin(),
-                m_wrenches.end(),
-                [&](const WrenchWithDuration& w) { return w.expired(now); });
+            if (m_wrenches.empty())
+                return;
 
-            m_wrenches.erase(end, m_wrenches.end());
+            // Remove the expired wrenches
+            m_wrenches.erase( //
+                std::remove_if(m_wrenches.begin(),
+                               m_wrenches.end(),
+                               [&](const WrenchWithDuration& w) {
+                                   return w.expired(now);
+                               }),
+                m_wrenches.end());
         }
 
     private:

--- a/tests/test_scenario/test_external_wrench.py
+++ b/tests/test_scenario/test_external_wrench.py
@@ -1,0 +1,56 @@
+# Copyright (C) 2021 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+import pytest
+
+pytestmark = pytest.mark.scenario
+
+from typing import Tuple
+
+import numpy as np
+
+from scenario import core
+from scenario import gazebo as scenario
+
+from ..common import utils
+from ..common.utils import default_world_fixture as default_world
+
+# Set the verbosity
+scenario.set_verbosity(scenario.Verbosity_debug)
+
+
+@pytest.mark.parametrize("default_world", [(1.0 / 1_000, 1.0, 1)], indirect=True)
+def test_fixed_base(default_world: Tuple[scenario.GazeboSimulator, scenario.World]):
+
+    # Get the simulator and the world
+    gazebo, world = default_world
+
+    # Insert a sphere
+    pose = core.Pose([0, 0.0, 1.0], [1.0, 0, 0, 0])
+    assert world.insert_model_from_string(
+        utils.SphereURDF(mass=10.0).urdf(), pose, "sphere"
+    )
+    assert "sphere" in world.model_names()
+
+    # Get the sphere
+    sphere = world.get_model("sphere")
+    link = sphere.get_link("sphere").to_gazebo()
+
+    # Get the initial z position
+    initial_height = link.position()[2]
+
+    # Apply a vertical force that counterbalances gravity
+    assert link.apply_world_force(
+        force=-np.array(world.gravity()) * sphere.total_mass(), duration=0.5
+    )
+
+    # Run the simulation for a while
+    for _ in range(500):
+        gazebo.run()
+        assert link.position()[2] == pytest.approx(initial_height)
+
+    # Run the simulation for a while
+    for _ in range(500):
+        gazebo.run()
+        assert link.position()[2] < initial_height


### PR DESCRIPTION
- Adds new test for checking if wrenches are applied for the right time interval.
- Adds a new `LinkWrenchCmd::empty` to check if there are wrenches to apply. This will be used by the Physics system in a new PR to prevent applying a zero wrench each time.