### PR TITLE
Check for a compatible Ignition distribution in the system when importing the `scenario` Python package

### DIFF
--- a/scenario/setup.cfg
+++ b/scenario/setup.cfg
@@ -51,3 +51,5 @@ classifiers =
 [options]
 zip_safe = False
 python_requires = >=3.8
+install_requires =
+    packaging


### PR DESCRIPTION
Often happens that users don't read thoroughly the support policy and install the wrong Ignition distribution. When this happens, importing `scenario` fails with arcane error on shared libraries not found.

This PR implements a new feature that should provide a more explanatory error message to the users in this case. It covers both cases in which the `ign` command does not exists in PATH (i.e. either Ignition is not installed or the environment is not properly configured) and if `ign gazebo --versions` returns a failing exit code (to be future proof in case the command line changes in next versions). 

From the python side, we exploit the [`packaging`](https://github.com/pypa/packaging) package.