### PR TITLE
Update Ignition installation link to Fortress in README

### DIFF
--- a/scenario/README.md
+++ b/scenario/README.md
@@ -62,7 +62,7 @@ Visit our [Support Policy](https://robotology.github.io/gym-ignition/master/inst
 to check the distribution currently supported.
 
 Then, install the supported Ignition suite following the 
-[official instructions](https://ignitionrobotics.org/docs/edifice).
+[official instructions](https://ignitionrobotics.org/docs/fortress).
 
 ### Python
 


### PR DESCRIPTION
Hello
Now i switch link to installation instructions for Fortress ignition according to v1.3.0
I dont know so well, but if gym-ignition now supports both `Edifice and `Fortress` ignition versions Edifice-link should be added too.