### PR TITLE
Enable automatic generation of release changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+changelog:
+  exclude:
+    labels:
+      - pr::changelog::ignore
+    authors: [ ]
+  categories:
+    - title: Bug fixing and new features
+      labels:
+        - pr::changelog::bugfix
+        - pr::changelog::release
+        - pr::changelog::feature
+    - title: Documentation, CI/CD, tests
+      labels:
+        - pr::changelog::docs
+        - pr::changelog::cicd
+        - pr::changelog::tests
+    - title: Other changes
+      labels:
+        - pr::changelog::other
+    - title: No category
+      labels: [ "*" ]


### PR DESCRIPTION
This PR adds the configuration file to support the automatic generation of the release changelog described in:

https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

Closes #61