### PR TITLE
Update specifier set of supported Ignition distribution

### DIFF
--- a/scenario/bindings/__init__.py
+++ b/scenario/bindings/__init__.py
@@ -23,7 +23,7 @@ def supported_versions_specifier_set() -> packaging.specifiers.SpecifierSet:
     # 6.Y.Z.preK
     # 6.Y.Z.postK
     #
-    return packaging.specifiers.SpecifierSet("~=6.0.0.dev")
+    return packaging.specifiers.SpecifierSet(">=6.0.0.pre,<7.0.0.dev")
 
 
 class InstallMode(Enum):


### PR DESCRIPTION
Follows up (yet again) #408. The previous `SpecifierSet` was only including `6.0.Z` but we want `6.Y.Z`. There's no way of doing it with `~=` while also supporting `alpha|beta|rc|pre|post`, therefore I switched to the long form.