### PR TITLE
Introduce support for Trivial Physics Engine

### DIFF
--- a/scenario/src/gazebo/include/scenario/gazebo/World.h
+++ b/scenario/src/gazebo/include/scenario/gazebo/World.h
@@ -50,6 +50,10 @@ namespace scenario::gazebo {
         /// The physics engine included in the Dynamic Animation and Robotics
         /// Toolkit.
         Dart,
+
+        /// The Trivial Physics Engine, a kinematics-only physics engine
+        /// developed by Open Robotics.
+        TPE,
     };
 } // namespace scenario::gazebo
 

--- a/scenario/src/gazebo/src/World.cpp
+++ b/scenario/src/gazebo/src/World.cpp
@@ -257,6 +257,10 @@ bool World::setPhysicsEngine(const PhysicsEngine engine)
                 return "ignition-physics"
                        + std::to_string(IGNITION_PHYSICS_MAJOR_VERSION)
                        + "-dartsim-plugin";
+            case PhysicsEngine::TPE:
+                return "ignition-physics"
+                       + std::to_string(IGNITION_PHYSICS_MAJOR_VERSION)
+                       + "-tpe-plugin";
         }
         return "";
     }();


### PR DESCRIPTION
Refer to [ Announcing new physics engine TPE (Trivial Physics Engine)](https://community.gazebosim.org/t/announcing-new-physics-engine-tpe-trivial-physics-engine/629) and [ignitionrobotics/ign-physics/tpe](https://github.com/ignitionrobotics/ign-physics/tree/main/tpe) for more details.

Right now we cannot do much with this kinematic engine, but it could be useful in the future for kinematic-only visualization.