### PR TITLE
[`devel`]→[`master`] Preparation of v1.3.2

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -140,6 +140,7 @@ jobs:
         python:
           - 3.8
           - 3.9
+          - "3.10"
     steps:
 
       - name: '🔍 Inspect Environment'

--- a/python/gym_ignition/rbd/idyntree/numpy.py
+++ b/python/gym_ignition/rbd/idyntree/numpy.py
@@ -129,7 +129,7 @@ class ToNumPy(abc.ABC):
             return position.toNumPy(), rotation.toNumPy()
 
         else:
-            H = np.zeros(shape=[4, 4])
+            H = np.eye(4)
             H[0:3, 3] = position.toNumPy()
             H[0:3, 0:3] = rotation.toNumPy()
 

--- a/scenario/setup.cfg
+++ b/scenario/setup.cfg
@@ -44,6 +44,7 @@ classifiers =
     Programming Language :: C++
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: Implementation :: CPython
     License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)

--- a/scenario/src/gazebo/include/scenario/gazebo/World.h
+++ b/scenario/src/gazebo/include/scenario/gazebo/World.h
@@ -50,6 +50,10 @@ namespace scenario::gazebo {
         /// The physics engine included in the Dynamic Animation and Robotics
         /// Toolkit.
         Dart,
+
+        /// The Trivial Physics Engine, a kinematics-only physics engine
+        /// developed by Open Robotics.
+        TPE,
     };
 } // namespace scenario::gazebo
 

--- a/scenario/src/gazebo/include/scenario/gazebo/utils.h
+++ b/scenario/src/gazebo/include/scenario/gazebo/utils.h
@@ -111,28 +111,27 @@ namespace scenario::gazebo::utils {
     std::string getSdfString(const std::string& fileName);
 
     /**
-     * Get the name of a model from a SDF file.
+     * Get the name of a model from a SDF file or SDF string.
      *
-     * @note sdformat supports only one model per SDF file.
+     * @note sdformat supports only one model per SDF.
      *
-     * @param fileName An SDF file. It could be either an absolute path
-     *        to the file or the file name if the parent folder is part
-     *        of the ``IGN_GAZEBO_RESOURCE_PATH`` environment variable.
-     * @return The name of the model if the file was found and is valid,
-     *         an empty string otherwise.
+     * @param fileName An SDF file or string. It could be an absolute path to
+     * the file, the file name if the parent folder is part of the
+     * ``IGN_GAZEBO_RESOURCE_PATH`` environment variable, or a SDF string.
+     * @return The name of the model if the SDF is valid, an empty string
+     * otherwise.
      */
     std::string getModelNameFromSdf(const std::string& fileName);
 
     /**
-     * Get the name of a world from a SDF file.
+     * Get the name of a world from a SDF file or SDF string.
      *
-     * @param fileName An SDF file. It could be either an absolute path
-     *        to the file or the file name if the parent folder is part
-     *        of the ``IGN_GAZEBO_RESOURCE_PATH`` environment variable.
-     * @param worldIndex The index of the world in the SDF file. By
-     *        default it finds the first world.
-     * @return The name of the world if the file was found and is valid,
-     *         an empty string otherwise.
+     * @param fileName An SDF file or string. It could be an absolute path to
+     * the file, the file name if the parent folder is part of the
+     * ``IGN_GAZEBO_RESOURCE_PATH`` environment variable, or a SDF string.
+     * @return The name of the world if the SDF is valid, an empty string
+     * otherwise.
+     *
      */
     std::string getWorldNameFromSdf(const std::string& fileName,
                                     const size_t worldIndex = 0);

--- a/scenario/src/gazebo/src/World.cpp
+++ b/scenario/src/gazebo/src/World.cpp
@@ -257,6 +257,10 @@ bool World::setPhysicsEngine(const PhysicsEngine engine)
                 return "ignition-physics"
                        + std::to_string(IGNITION_PHYSICS_MAJOR_VERSION)
                        + "-dartsim-plugin";
+            case PhysicsEngine::TPE:
+                return "ignition-physics"
+                       + std::to_string(IGNITION_PHYSICS_MAJOR_VERSION)
+                       + "-tpe-plugin";
         }
         return "";
     }();

--- a/scenario/src/gazebo/src/utils.cpp
+++ b/scenario/src/gazebo/src/utils.cpp
@@ -88,19 +88,20 @@ std::string utils::getSdfString(const std::string& fileName)
 {
     // NOTE: We could use std::filesystem for the following, but compilers
     //       support is still rough even with C++17 enabled :/
-    std::string sdfFileAbsPath;
+    std::string sdfFileAbsPath = fileName;
 
-    if (!ignition::common::isFile(fileName)) {
+    std::shared_ptr<sdf::Root> root;
+
+    if (ignition::common::isFile(fileName)) {
         sdfFileAbsPath = findSdfFile(fileName);
+        root = getSdfRootFromFile(fileName);
     }
-
-    if (sdfFileAbsPath.empty()) {
-        return {};
+    else {
+        root = getSdfRootFromString(sdfFileAbsPath);
     }
-
-    auto root = getSdfRootFromString(sdfFileAbsPath);
 
     if (!root) {
+        sError << "Failed to get SDF string" << std::endl;
         return {};
     }
 
@@ -109,24 +110,30 @@ std::string utils::getSdfString(const std::string& fileName)
 
 std::string utils::getModelNameFromSdf(const std::string& fileName)
 {
-    std::string absFileName = findSdfFile(fileName);
+    // NOTE: We could use std::filesystem for the following, but compilers
+    //       support is still rough even with C++17 enabled :/
+    std::string sdfFileAbsPath = fileName;
 
-    if (absFileName.empty()) {
-        sError << "Failed to find file " << fileName << std::endl;
-        return {};
+    std::shared_ptr<sdf::Root> root;
+
+    if (ignition::common::isFile(fileName)) {
+        sdfFileAbsPath = findSdfFile(fileName);
+        root = getSdfRootFromFile(fileName);
     }
-
-    const auto root = utils::getSdfRootFromFile(absFileName);
+    else {
+        root = getSdfRootFromString(sdfFileAbsPath);
+    }
 
     if (!root) {
+        sError << "Failed to get model name from SDF" << std::endl;
         return {};
     }
 
-    if (const auto model = root->Model()) {
+    if (const auto& model = root->Model()) {
         return model->Name();
     }
 
-    sError << "No model found in file " << fileName << std::endl;
+    sError << "No model found in SDF" << std::endl;
     return {};
 }
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ package_dir =
     =python
 python_requires = >=3.8
 install_requires =
-    scenario ~= 1.3.1.pre
+    scenario >= 1.3.2.dev
     gym >= 0.13.1
     numpy
     scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ classifiers =
     Intended Audience :: Science/Research
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: Implementation :: CPython
     License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)


### PR DESCRIPTION
Needed for https://github.com/conda-forge/staged-recipes/pull/16582.

- [x] Resolve conflicts merging `master` into `devel`, if needed.
- [ ] Merge `devel` into `master`, making sure that everything works as expected.
- [ ] Bump the ScenarIO version in the top-level `CMakeLists.txt`.
- [ ] Make sure that `scenario.__init__.py` defines the correct specifier set for the Ignition distribution.
- [ ] Check if any dependency under our control has to be bumped, or if any dependency version has to be updated in `setup.py`, `setup.cfg`, and `pyproject.toml`.
- [ ] Create a new GitHub pre-release with a new tag `v*.rc0`[^1] and make sure that is properly deployed to PyPI. This is necessary for the next step.
- [ ] Bump the `scenario` specifier set in the `setup.cfg` of gym-ignition in `master` (e.g. `~= 1.3.1.rc` for the `1.3.1` release). It makes all `gym_ignition` packages compatible only with `scenario` packages that share the same minor version.
- [ ] Create a new GitHub release with a new tag `v*`[^1].
- [ ] Make sure that the release was successfully uploaded in PyPI in both `sdist` and `wheel` formats.
- [ ] Bump the `scenario` specifier set in the `setup.cfg` of gym-ignition in `devel` by increasing the least significant number (e.g. `>= 1.3.2.dev` for the `1.3.1` release, or  `>= 1.3.1post1.dev` for the `1.3.1.post0` release). It makes nightly releases incompatible with stable versions, making sure that calling `pip install --pre gym_ignition` pulls the pre-release also of `scenario`. 
- [ ] Merge `master` into `devel`. This merge must contain the commit associated to the release tag in order to reset the automatic numbering of the pre-release packages of the nightly branch. If a post-release has to be published to fix minor errors, `master` has to be merged again into `devel`.

[^1]: Note that the version without the `v` prefix must comply with [PEP440](https://www.python.org/dev/peps/pep-0440/) in [this regexp](https://regexr.com/5gr9h).